### PR TITLE
Don't mention things that weren't found

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -1438,6 +1438,9 @@ function vipgoci_github_pr_review_submit(
 					$commit_issue_stat_key =>
 						$commit_issue_stat_value
 			) {
+				if ( $commit_issue_stat_value === 0 ) {
+					continue;
+				}
 				$github_postfields['body'] .=
 					vipgoci_github_labels(
 						$commit_issue_stat_key


### PR DESCRIPTION
Nobody needs to know that zero warnings were found if 5 errors were spotted and vice versa

should make things a little more concise

e.g. this is good:

<img width="318" alt="screen shot 2018-09-13 at 02 29 26" src="https://user-images.githubusercontent.com/58855/45461800-df598580-b6fc-11e8-8504-cab1c579ad58.png">

But if 0 warnings are found, it shouldn't mention warnings