### PR TITLE
Adding ability to exclude PHPCS sniffs

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -1279,6 +1279,111 @@ function vipgoci_github_results_filter_comments_to_max(
 }
 
 /*
+ * Filter away issues that we should ignore from the set
+ * of results, according to --review-comments-ignore argument.
+ * The issues to be ignored are specified as an array of
+ * string-messages, all in lower-case.
+ */
+
+function vipgoci_results_filter_ignorable(
+	$options,
+	&$results
+) {
+	$comments_removed = array();
+
+	vipgoci_log(
+		'Removing comments to be ignored from results before submission',
+		array(
+			'messages-ignore' =>
+				$options['review-comments-ignore'],
+		)
+	);
+
+
+	foreach(
+		$results['issues'] as
+			$pr_number => $pr_issues_comments
+	) {
+		foreach(
+			$pr_issues_comments as
+				$pr_issue_key =>
+				$pr_issue
+		) {
+			if ( in_array(
+				strtolower(
+					$pr_issue['issue']['message']
+				),
+				$options['review-comments-ignore'],
+				true
+			) ) {
+				/*
+				 * Found a message to ignore,
+				 * remove it from the results-array.
+				 */
+				unset(
+					$results[
+						'issues'
+					][
+						$pr_number
+					][
+						$pr_issue_key
+					]
+				);
+
+				/*
+				 * Keep track of what we remove
+				 */
+				if ( ! isset(
+					$comments_removed[
+						$pr_number
+					]
+				) ) {
+					$comments_removed[
+						$pr_number
+					] = array();
+				}
+
+				$comments_removed[
+					$pr_number
+				] = $pr_issue;
+
+	
+				/*
+				 * Keep statistics up-to-date
+				 */
+				$results[
+					'stats'
+				][
+					$pr_issue['type']
+				][
+					$pr_number
+				][
+					strtolower(
+						$pr_issue['issue']['type']
+					)
+				]--;
+			}
+		}
+
+		/*
+		 * Re-create the array in
+		 * case of changes to keys,
+		 */
+
+		$results['issues'][ $pr_number ] = array_values(
+			$results['issues'][ $pr_number ]
+		);
+	}
+
+	vipgoci_log(
+		'Removed ignorable comments',
+		array(
+			'comments-removed' => $comments_removed
+		)
+	);
+}
+
+/*
  * Add pagebreak to a Markdown-style comment
  * string -- but only if a pagebreak is not
  * already the latest addition to the comment.
@@ -1326,3 +1431,5 @@ function vipgoci_markdown_comment_add_pagebreak(
 
 	$comment .= $pagebreak_style . "\n\r";
 }
+
+

--- a/misc.php
+++ b/misc.php
@@ -1244,7 +1244,7 @@ function vipgoci_github_results_filter_comments_to_max(
 
 				$comments_removed[
 					$pr_number
-				] = $pr_issue;
+				][] = $pr_issue;
 
 				$comments_to_remove--;
 			}
@@ -1345,7 +1345,7 @@ function vipgoci_results_filter_ignorable(
 
 				$comments_removed[
 					$pr_number
-				] = $pr_issue;
+				][] = $pr_issue;
 
 	
 				/*

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -9,6 +9,7 @@ function vipgoci_phpcs_do_scan(
 	$filename_tmp,
 	$phpcs_path,
 	$phpcs_standard,
+	$phpcs_sniffs_exclude,
 	$phpcs_severity
 ) {
 	/*
@@ -26,6 +27,18 @@ function vipgoci_phpcs_do_scan(
 		escapeshellarg( $phpcs_severity ),
 		escapeshellarg( 'json' )
 	);
+
+	/*
+	 * If we have sniffs to exclude, add them
+	 * to the command-line string.
+	 */
+
+	if ( ! empty( $phpcs_sniffs_exclude ) ) {
+		$cmd .= sprintf(
+			' --exclude=%s',
+			escapeshellarg( $phpcs_sniffs_exclude )
+		);
+	}
 
 	/*
 	 * Lastly, append the target filename
@@ -99,6 +112,7 @@ function vipgoci_phpcs_scan_single_file(
 		$temp_file_name,
 		$options['phpcs-path'],
 		$options['phpcs-standard'],
+		$options['phpcs-sniffs-exclude'],
 		$options['phpcs-severity']
 	);
 

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -362,6 +362,7 @@ function vipgoci_run() {
 			'phpcs-path:',
 			'phpcs-standard:',
 			'phpcs-severity:',
+			'phpcs-sniffs-exclude:',
 			'hashes-api-url:',
 			'hashes-oauth-token:',
 			'hashes-oauth-token-secret:',
@@ -426,6 +427,7 @@ function vipgoci_run() {
 			"\t" . '--phpcs-path=FILE              Full path to PHPCS script' . PHP_EOL .
 			"\t" . '--phpcs-standard=STRING        Specify which PHPCS standard to use' . PHP_EOL .
 			"\t" . '--phpcs-severity=NUMBER        Specify severity for PHPCS' . PHP_EOL .
+			"\t" . '--phpcs-sniffs-exclude=STRING  Specify which sniff to exclude from PHPCS scanning' . PHP_EOL .
 			"\t" . '--autoapprove=BOOL             Whether to auto-approve Pull-Requests' . PHP_EOL .
 			"\t" . '                               altering only files of certain types' . PHP_EOL .
 			"\t" . '--autoapprove-filetypes=STRING Specify what file-types can be auto-' . PHP_EOL .
@@ -515,6 +517,19 @@ function vipgoci_run() {
 		$options['phpcs-standard']
 	);
 
+	/*
+	 * Process --phpcs-sniffs-exclude -- expected to be
+	 * a string.
+	 */
+	if ( empty( $options['phpcs-sniffs-exclude'] ) ) {
+		$options['phpcs-sniffs-exclude'] = null;
+	}
+
+	else {
+		$options['phpcs-sniffs-exclude'] = trim(
+			$options['phpcs-sniffs-exclude']
+		);
+	}
 
 	/*
 	 * Process --phpcs-severity -- expected to be

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -124,12 +124,15 @@ function vipgoci_option_integer_handle(
  * makes sure forbidden values are not contained in it.
  * Does not return the result, but rather alters
  * $options directly.
+ *
+ * Allows for array-item separator to be specified.
  */
 function vipgoci_option_array_handle(
 	&$options,
 	$option_name,
 	$default_value = array(),
-	$forbidden_value = null
+	$forbidden_value = null,
+	$array_separator = ','
 ) {
 	if ( ! isset( $options[ $option_name ] ) ) {
 		$options[ $option_name ] = array();
@@ -137,7 +140,7 @@ function vipgoci_option_array_handle(
 
 	else {
 		$options[ $option_name ] = explode(
-			',',
+			$array_separator,
 			strtolower(
 				$options[ $option_name ]
 			)
@@ -354,6 +357,7 @@ function vipgoci_run() {
 			'token:',
 			'review-comments-max:',
 			'review-comments-total-max:',
+			'review-comments-ignore:',
 			'dismiss-stale-reviews:',
 			'branches-ignore:',
 			'output:',
@@ -417,6 +421,10 @@ function vipgoci_run() {
 			"\t" . '                                    a single Pull-Request by the program -- includes' . PHP_EOL .
 			"\t" . '                                    comments from previous executions. A value of ' . PHP_EOL .
 			"\t" . '                                    \'0\' indicates no limit.' . PHP_EOL .
+			"\t" . '--review-comments-ignore=STRING     Specify which result comments to ignore' . PHP_EOL .
+			"\t" . '                                    -- e.g. useful if one type of message is to be ignored' . PHP_EOL .
+			"\t" . '                                    rather than a whole PHPCS sniff. Should be a ' . PHP_EOL .
+			"\t" . '                                    whole string with items separated by \"|||\".' . PHP_EOL .
 			"\t" . '--dismiss-stale-reviews=BOOL   Dismiss any reviews associated with Pull-Requests ' . PHP_EOL .
 			"\t" . '                               that we process which have no active comments. ' . PHP_EOL .
 			"\t" . '                               The Pull-Requests we process are those associated ' . PHP_EOL .
@@ -528,6 +536,27 @@ function vipgoci_run() {
 	else {
 		$options['phpcs-sniffs-exclude'] = trim(
 			$options['phpcs-sniffs-exclude']
+		);
+	}
+
+	/*
+	 * Process --review-comments-ignore -- expected
+	 * to be an array (items separated by "|||"). 
+	 * Then transform all of the messages to lower-case.
+	 */
+
+	vipgoci_option_array_handle(
+		$options,
+		'review-comments-ignore',
+		array(),
+		array(),
+		'|||'
+	);
+
+	if ( ! empty( $options[ 'review-comments-ignore' ] ) ) {
+		$options['review-comments-ignore'] = array_map(
+			'strtolower',
+			$options['review-comments-ignore']
 		);
 	}
 
@@ -1168,6 +1197,18 @@ function vipgoci_run() {
 		$results,
 		true
 	);
+
+	/*
+	 * Remove ignorable comments from $results.
+	 */
+
+	if ( ! empty( $options['review-comments-ignore'] ) ) {
+		$file_issues_arr_master =
+			vipgoci_results_filter_ignorable(
+				$options,
+				$results
+			);
+	}
 
 	/*
 	 * Keep records of how many issues we found.


### PR DESCRIPTION
Adding ability to exclude sniffs on the commandline, using --phpcs-sniffs-exclude argument.