### PR TITLE
Upgrade WPCS to 1.2.1

### DIFF
--- a/tools-init.sh
+++ b/tools-init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export PHP_CODESNIFFER_VER="3.3.2"
-export WP_CODING_STANDARDS_VER="1.2.0"
+export WP_CODING_STANDARDS_VER="1.2.1"
 export VIP_CODING_STANDARDS_VER="0.3.1"
 
 export TMP_LOCK_FILE="$HOME/.vip-go-ci-tools-init.lck"


### PR DESCRIPTION
WPCS 1.2.1 was released ([release notes](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/1.2.1)).