### PR TITLE
Adding test for cases when reference to test-name is included

### DIFF
--- a/tests/MiscGitHubCommentMatchTest.php
+++ b/tests/MiscGitHubCommentMatchTest.php
@@ -16,6 +16,9 @@ final class MiscGitHubCommentMatchTest extends TestCase {
 				),
 				json_decode(
 					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+				),
+				json_decode(
+					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error**: Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped (*WordPressVIPMinimum.JS.InnerHTML.innerHTML*).","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
 				)
 			),
 
@@ -49,6 +52,15 @@ final class MiscGitHubCommentMatchTest extends TestCase {
 			)
 		);
 
+		$this->assertTrue(
+			vipgoci_github_comment_match(
+				'bla-8.php',
+				3,
+				'Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped',
+				$prs_comments
+			)
+		);
+
 		$this->assertFalse(
 			vipgoci_github_comment_match(
 				'bla-8.php',
@@ -66,6 +78,16 @@ final class MiscGitHubCommentMatchTest extends TestCase {
 				$prs_comments	
 			)
 		);
+
+		$this->assertFalse(
+			vipgoci_github_comment_match(
+				'bla-8.php',
+				4,
+				'Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped',
+				$prs_comments
+			)
+		);
+
 
 		$this->assertFalse(
 			vipgoci_github_comment_match(


### PR DESCRIPTION
In newer versions of `vip-go-ci`, reference to the test-name is included in messages posted on GitHub. Here we test if this is successfully ignored when testing for a comment-match.