### PR TITLE
Moving expected/actual parameters into correct place with assert-functions

### DIFF
--- a/tests/0StatsCountersTest.php
+++ b/tests/0StatsCountersTest.php
@@ -19,10 +19,10 @@ final class StatsCountersTest extends TestCase {
 		);
 
 		$this->assertEquals(
+			array(),
 			vipgoci_counter_report(
 				VIPGOCI_COUNTERS_DUMP
-			),
-			array()
+			)
 		);
 	}
 
@@ -31,29 +31,29 @@ final class StatsCountersTest extends TestCase {
 	 */
 	function testCounterReport2() {
 		$this->assertEquals(
+			true,
 			vipgoci_counter_report(
 				VIPGOCI_COUNTERS_DO,
 				'mycounter2',
 				100
-			),
-			true
+			)
 		);
 
 		$this->assertEquals(
+			true,
 			vipgoci_counter_report(
 				VIPGOCI_COUNTERS_DO,
 				'mycounter2',
 				1
-			),
-			true
+			)
 		);
 
 		$this->assertEquals(
-			vipgoci_counter_report(
-				VIPGOCI_COUNTERS_DUMP
-			),
 			array(
 				'mycounter2' => 101,
+			),
+			vipgoci_counter_report(
+				VIPGOCI_COUNTERS_DUMP
 			)
 		);
 	}
@@ -93,10 +93,10 @@ final class StatsCountersTest extends TestCase {
 
 	
 		$this->assertEquals(
-			$report,
 			array(
 				'github_pr_unique_issue_issues' => 3,
-			)
+			),
+			$report
 		);	
 	}
 }

--- a/tests/9LintLintScanCommitTest.php
+++ b/tests/9LintLintScanCommitTest.php
@@ -140,7 +140,6 @@ final class LintLintScanCommitTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			$issues_submit,
 			array(
 				$pr_item->number => array(
 					array(
@@ -153,16 +152,17 @@ final class LintLintScanCommitTest extends TestCase {
 						)
 					)
 				)
-			)
+			),
+			$issues_submit
 		);
 
 		$this->assertEquals(
-			$issues_stat,
 			array(
 				$pr_item->number => array(
 					'error' => 1,
 				)
-			)
+			),
+			$issues_stat
 		);
 
 		unset( $this->options['commit'] );

--- a/tests/ApAutoApprovalTest.php
+++ b/tests/ApAutoApprovalTest.php
@@ -223,8 +223,8 @@ final class ApAutoApprovalTest extends TestCase {
 
 		foreach ( $prs_implicated as $pr_item ) {
 			$this->assertEquals(
-				$pr_item->number,
-				$this->options['pr-test-ap-auto-approval-1']
+				$this->options['pr-test-ap-auto-approval-1'],
+				$pr_item->number
 			);
 		}
 	}
@@ -296,8 +296,8 @@ final class ApAutoApprovalTest extends TestCase {
 
 		foreach ( $prs_implicated as $pr_item ) {
 			$this->assertEquals(
-				$pr_item->number,
-				$this->options['pr-test-ap-auto-approval-1']
+				$this->options['pr-test-ap-auto-approval-1'],
+				$pr_item->number
 			);
 
 			vipgoci_unittests_output_suppress();
@@ -397,14 +397,14 @@ final class ApAutoApprovalTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			count( $prs_implicated ),
-			1
+			1,
+			count( $prs_implicated )
 		);
 
 		foreach ( $prs_implicated as $pr_item ) {
 			$this->assertEquals(
-				$pr_item->number,
-				$this->options['pr-test-ap-auto-approval-1']
+				$this->options['pr-test-ap-auto-approval-1'],
+				$pr_item->number
 			);
 
 			vipgoci_unittests_output_suppress();
@@ -499,14 +499,14 @@ final class ApAutoApprovalTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			count( $prs_implicated ),
-			1
+			1,
+			count( $prs_implicated )
 		);
 
 		foreach ( $prs_implicated as $pr_item ) {
 			$this->assertEquals(
-				$pr_item->number,
-				$this->options['pr-test-ap-auto-approval-1']
+				$this->options['pr-test-ap-auto-approval-1'],
+				$pr_item->number
 			);
 
 			vipgoci_unittests_output_suppress();

--- a/tests/ApFileTypesTest.php
+++ b/tests/ApFileTypesTest.php
@@ -88,13 +88,13 @@ final class ApFileTypesTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			$auto_approved_files_arr,
 			array(
 				'auto-approvable-1.txt' => 'autoapprove-filetypes',
 				'auto-approvable-2.txt' => 'autoapprove-filetypes',
 				'auto-approvable-3.jpg' => 'autoapprove-filetypes',
 				'README.md'		=> 'autoapprove-filetypes',
-			)
+			),
+			$auto_approved_files_arr
 		);
 	}
 }

--- a/tests/ApHashesApiScanCommitTest.php
+++ b/tests/ApHashesApiScanCommitTest.php
@@ -124,10 +124,10 @@ final class ApHashesApiScanCommitTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			$auto_approved_files_arr,
 			array(
 				'auto-approvable-6.php' => 'autoapprove-hashes-to-hashes',
-			)
+			),
+			$auto_approved_files_arr
 		);
 	}
 }

--- a/tests/ApSvgFilesTest.php
+++ b/tests/ApSvgFilesTest.php
@@ -126,11 +126,11 @@ final class ApSvgFilesTest extends TestCase {
 
 
 		$this->assertEquals(
-			$auto_approved_files_arr,
 			array(
 				'auto-approvable-1.svg' => 'ap-svg-files',
 				'auto-approvable-2.svg' => 'ap-svg-files',
-			)
+			),
+			$auto_approved_files_arr
 		);
 
 		unset( $this->options['svg-checks'] );
@@ -187,14 +187,14 @@ final class ApSvgFilesTest extends TestCase {
 
 
 		$this->assertEquals(
-			$auto_approved_files_arr,
 			array(
 				'auto-approvable-1.svg' => 'ap-svg-files',
 				'auto-approvable-2-renamed.svg' => 'ap-svg-files',
 				'auto-approvable3.svg' => 'ap-svg-files',
 				'auto-approvable4.svg' => 'ap-svg-files',
 				'auto-approvable-7.svg' => 'ap-svg-files',
-			)
+			),
+			$auto_approved_files_arr
 		);
 
 		unset( $this->options['svg-checks'] );

--- a/tests/GitHubApiCurlHeadersTest.php
+++ b/tests/GitHubApiCurlHeadersTest.php
@@ -47,13 +47,13 @@ final class GitHubApiCurlHeadersTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$actual_results,
 			array(
 				'content-type'	=> array( 'text/plain' ),
 				'date'		=> array( 'Mon, 04 Mar 2019 16:43:35 GMT' ),
 				'location'	=> array( 'https://www.ruv.is/' ),
 				'status'	=> array( 200, 'OK' ),
-			)
+			),
+			$actual_results
 		);
 	}
 }

--- a/tests/GitHubPrsCommitsListTest.php
+++ b/tests/GitHubPrsCommitsListTest.php
@@ -80,7 +80,6 @@ final class GitHubPrsCommitsListTest extends TestCase {
 			array(
 				$this->options['commit-test-repo-prs-commits-list-1']
 			),
-
 			$commits_list
 		);
 	}

--- a/tests/GitRepoRepoBlameForFileTest.php
+++ b/tests/GitRepoRepoBlameForFileTest.php
@@ -93,8 +93,8 @@ final class GitRepoRepoBlameForFileTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			json_encode( $ret ),
-			'[{"commit_id":"4869335189752462325aaef4838c9761d56195ce","file_name":"README.md","line_no":1},{"commit_id":"45b9e6479dfba4d54b584d53ace1814ce155d35e","file_name":"README.md","line_no":2}]'
+			'[{"commit_id":"4869335189752462325aaef4838c9761d56195ce","file_name":"README.md","line_no":1},{"commit_id":"45b9e6479dfba4d54b584d53ace1814ce155d35e","file_name":"README.md","line_no":2}]',
+			json_encode( $ret )
 		);
 	}
 }

--- a/tests/GitRepoRepoFetchCommittedFileTest.php
+++ b/tests/GitRepoRepoFetchCommittedFileTest.php
@@ -95,8 +95,8 @@ final class GitRepoRepoFetchCommittedFileTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			$ret,
-			'Test file contents. Some text.' . PHP_EOL
+			'Test file contents. Some text.' . PHP_EOL,
+			$ret
 		);
 	}
 }

--- a/tests/GitRepoRepoFetchTreeTest.php
+++ b/tests/GitRepoRepoFetchTreeTest.php
@@ -95,11 +95,11 @@ final class GitRepoRepoFetchTreeTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			$ret1,
 			array(
 				'README.md',
 				'file-1.txt',
-			)
+			),
+			$ret1
 		);
 	}
 
@@ -149,10 +149,10 @@ final class GitRepoRepoFetchTreeTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			$ret2,
 			array(
 				'file-1.txt',
-			)
+			),
+			$ret2
 		);
 	}
 }

--- a/tests/GitRepoRepoGetHeadTest.php
+++ b/tests/GitRepoRepoGetHeadTest.php
@@ -92,8 +92,8 @@ final class GitRepoRepoGetHeadTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			$ret,
-			$this->options['commit-test-repo-get-head-1']
+			$this->options['commit-test-repo-get-head-1'],
+			$ret
 		);
 	}
 }

--- a/tests/LintLintDoScanTest.php
+++ b/tests/LintLintDoScanTest.php
@@ -51,10 +51,10 @@ final class LintLintDoScanTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$ret,
 			array(
 				'No syntax errors detected in ' . $php_file_path
-			)
+			),
+			$ret
 		);
 	}
 
@@ -89,11 +89,11 @@ final class LintLintDoScanTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$ret,
 			array(
 				"PHP Parse error:  syntax error, unexpected end of file, expecting ',' or ';' in " . $php_file_path . " on line 3",
 				'Errors parsing ' . $php_file_path
-			)
+			),
+			$ret
 		);
 	}
 }

--- a/tests/LintLintGetIssuesTest.php
+++ b/tests/LintLintGetIssuesTest.php
@@ -57,9 +57,9 @@ final class LintLintGetIssuesTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$lint_issues_parsed,
 			array(
-			)
+			),
+			$lint_issues_parsed
 		);
 	}
 
@@ -100,7 +100,6 @@ final class LintLintGetIssuesTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$lint_issues_parsed,
 			array(
 				3 => array(
 					array(
@@ -108,7 +107,8 @@ final class LintLintGetIssuesTest extends TestCase {
 						'level'		=> 'ERROR',
 					)
 				)
-			)
+			),
+			$lint_issues_parsed
 		);
 	}
 }

--- a/tests/MiscFileExtensionTest.php
+++ b/tests/MiscFileExtensionTest.php
@@ -16,8 +16,8 @@ final class MiscFileExtensionTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$file_extension,
-			'exe'
+			'exe',
+			$file_extension
 		);
 	}
 
@@ -32,8 +32,8 @@ final class MiscFileExtensionTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$file_extension,
-			'exe'
+			'exe',
+			$file_extension
 		);
 	}
 
@@ -48,8 +48,8 @@ final class MiscFileExtensionTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$file_extension,
-			null
+			null,
+			$file_extension
 		);
 	}
 }

--- a/tests/MiscGitHubLabelsTest.php
+++ b/tests/MiscGitHubLabelsTest.php
@@ -10,10 +10,10 @@ final class MiscGitHubLabelsTest extends TestCase {
 	 */
 	public function testGitHubLabel1() {
 		$this->assertEquals(
+			':exclamation:',
 			vipgoci_github_labels(
 				'warning'
-			),
-			':exclamation:'
+			)
 		);
 	}
 }

--- a/tests/MiscResultsFilterIgnorableTest.php
+++ b/tests/MiscResultsFilterIgnorableTest.php
@@ -40,10 +40,10 @@ final class MiscResultsFilterIgnorableTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
+			$results_desired,
 			json_encode(
 				$results_altered
-			),
-			$results_desired
+			)
 		);
 	}
 }

--- a/tests/MiscScandirGitRepoTest.php
+++ b/tests/MiscScandirGitRepoTest.php
@@ -97,14 +97,14 @@ final class MiscScandirGitRepoTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			$ret,
 			array(
 				'README.md',
  				'myfile1.txt',	
 				'myfile2.txt',
 				'myfolder5/myotherfolder6/somefile2.txt',
 				'myfolder5/somefile1.txt'
-			)
+			),
+			$ret
 		);
 	}
 
@@ -151,10 +151,10 @@ final class MiscScandirGitRepoTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			$ret,
 			array(
 				'README.md'
-			)
+			),
+			$ret
 		);
 	}
 }

--- a/tests/MiscTempTest.php
+++ b/tests/MiscTempTest.php
@@ -20,8 +20,8 @@ final class MiscTempTest extends TestCase {
 		);
 
 		$this->assertNotEquals(
-			$temp_file_name,
-			false
+			false,
+			$temp_file_name
 		);
 
 		
@@ -35,8 +35,8 @@ final class MiscTempTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$temp_file_extension,
-			$file_name_extension
+			$file_name_extension,
+			$temp_file_extension
 		);
 
 		$this->assertEquals(
@@ -62,8 +62,8 @@ final class MiscTempTest extends TestCase {
 		);
 
 		$this->assertNotEquals(
-			$temp_file_name,
-			false
+			false,
+			$temp_file_name
 		);
 
 		
@@ -77,8 +77,8 @@ final class MiscTempTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$temp_file_extension,
-			$file_name_extension
+			$file_name_extension,
+			$temp_file_extension
 		);
 
 		$this->assertEquals(

--- a/tests/PhpcsScanDoScanTest.php
+++ b/tests/PhpcsScanDoScanTest.php
@@ -65,8 +65,8 @@ final class PhpcsScanDoScanTest extends TestCase {
 		unlink( $temp_file_path );
 
 		$this->assertEquals(
-			$phpcs_res,
-			'{"totals":{"errors":1,"warnings":1,"fixable":0},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":1,"warnings":1,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6},{"message":"`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.","source":"WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter","severity":5,"fixable":false,"type":"WARNING","line":4,"column":16}]}}}'
+			'{"totals":{"errors":1,"warnings":1,"fixable":0},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":1,"warnings":1,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6},{"message":"`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.","source":"WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter","severity":5,"fixable":false,"type":"WARNING","line":4,"column":16}]}}}',
+			$phpcs_res
 		);
 	}
 }

--- a/tests/PhpcsScanIssuesFilterDuplicate.php
+++ b/tests/PhpcsScanIssuesFilterDuplicate.php
@@ -47,7 +47,6 @@ final class PhpcsScanIssuesFilterDuplicate extends TestCase {
 		);
 
 		$this->assertEquals(
-			$issues_filtered,
 			array(
 				array(
 					'message' => 'json_encode() is discouraged. Use wp_json_encode() instead.',
@@ -59,7 +58,8 @@ final class PhpcsScanIssuesFilterDuplicate extends TestCase {
 					'column' => 6,
 					'level' => 'WARNING',
 				)
-			)
+			),
+			$issues_filtered
 		);
 	}
 
@@ -118,7 +118,6 @@ final class PhpcsScanIssuesFilterDuplicate extends TestCase {
 		);
 
 		$this->assertEquals(
-			$issues_filtered,
 			array(
 				array(
 					'message' => 'json_encode() is discouraged. Use wp_json_encode() instead.',
@@ -141,7 +140,8 @@ final class PhpcsScanIssuesFilterDuplicate extends TestCase {
 					'column' => 6,
 					'level' => 'WARNING',
 				),
-			)
+			),
+			$issues_filtered
 		);
 	}
 }

--- a/tests/PhpcsScanIssuesFilterIrrellevant.php
+++ b/tests/PhpcsScanIssuesFilterIrrellevant.php
@@ -39,7 +39,6 @@ final class PhpcsScanIssuesFilterIrrellevant extends TestCase {
 		);
 
 		$this->assertEquals(
-			$issues_filtered,
 			array(
 				array(
 					'message' => 'json_encode() is discouraged. Use wp_json_encode() instead.',
@@ -51,7 +50,8 @@ final class PhpcsScanIssuesFilterIrrellevant extends TestCase {
 					'column' => 6,
 					'level' => 'WARNING',
 				)
-			)
+			),
+			$issues_filtered
 		);
 	}
 }

--- a/tests/StatsRunTimeMeasureTest.php
+++ b/tests/StatsRunTimeMeasureTest.php
@@ -10,8 +10,8 @@ final class StatsRunTimeMeasureTest extends TestCase {
 	 */
 	function testRuntimeMeasure1() {
 		return $this->assertEquals(
-			vipgoci_runtime_measure( 'illegalaction', 'mytimer1' ),
-			false
+			false,
+			vipgoci_runtime_measure( 'illegalaction', 'mytimer1' )
 		);
 	}
 
@@ -20,8 +20,8 @@ final class StatsRunTimeMeasureTest extends TestCase {
 	 */
 	function testRuntimeMeasure2() {
 		return $this->assertEquals(
-			vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'mytimer2' ),
-			false
+			false,
+			vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'mytimer2' )
 		);
 	}
 
@@ -30,8 +30,8 @@ final class StatsRunTimeMeasureTest extends TestCase {
 	 */
 	function testRuntimeMeasure3() {
 		$this->assertEquals(
-			vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'mytimer3' ),
-			true
+			true,
+			vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'mytimer3' )
 		);
 
 		sleep( 2 );
@@ -56,8 +56,8 @@ final class StatsRunTimeMeasureTest extends TestCase {
 	 */
 	function testRuntimeMeasure4() {
 		$this->assertEquals(
-			vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'mytimer4' ),
-			true
+			true,
+			vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'mytimer4' )
 		);
 
 		sleep( 2 );

--- a/tests/SvgScanLookForSpecificTokensTest.php
+++ b/tests/SvgScanLookForSpecificTokensTest.php
@@ -60,8 +60,8 @@ final class SvgScanLookForSpecificTokensTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$results,
-			$results_expected
+			$results_expected,
+			$results
 		);
 	}
 }

--- a/tests/SvgScanScanSingleFileTest.php
+++ b/tests/SvgScanScanSingleFileTest.php
@@ -145,8 +145,8 @@ final class SvgScanScanSingleFileTest extends TestCase {
 		);
 	
 		$this->assertEquals(
-			$ret,
-			$expected_result
+			$expected_result,
+			$ret
 		);
 	}
 }

--- a/tests/SvgScanWithScannerTest.php
+++ b/tests/SvgScanWithScannerTest.php
@@ -73,8 +73,8 @@ final class SvgScanWithScannerTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$scanner_results,
-			$scanner_results_expected
+			$scanner_results_expected,
+			$scanner_results
 		);
 	}
 
@@ -130,8 +130,8 @@ final class SvgScanWithScannerTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$scanner_results,
-			$scanner_results_expected
+			$scanner_results_expected,
+			$scanner_results
 		);
 	}
 }

--- a/tests/VipgociExitStatusTest.php
+++ b/tests/VipgociExitStatusTest.php
@@ -22,8 +22,8 @@ final class VipgociExitStatusTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$exit_status,
-			0
+			0,
+			$exit_status
 		);
 	}
 
@@ -44,8 +44,8 @@ final class VipgociExitStatusTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$exit_status,
-			250
+			250,
+			$exit_status
 		);
 	}
 }

--- a/tests/VipgociOptionsArrayHandleTest.php
+++ b/tests/VipgociOptionsArrayHandleTest.php
@@ -21,10 +21,10 @@ final class VipgociOptionsArrayHandleTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$options['mytestoption'],
 			array(
 				'myvalue',
-			)
+			),
+			$options['mytestoption']
 		);
 	}
 
@@ -45,12 +45,12 @@ final class VipgociOptionsArrayHandleTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$options['mytestoption'],
 			array(
 				'myvalue1',
 				'myvalue2',
 				'myvalue3',
-			)
+			),
+			$options['mytestoption']
 		);
 	}
 }

--- a/tests/VipgociOptionsBoolHandleTest.php
+++ b/tests/VipgociOptionsBoolHandleTest.php
@@ -38,8 +38,8 @@ final class VipgociOptionsBoolHandleTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$options['mytestoption'],
-			false
+			false,
+			$options['mytestoption']
 		);
 	}
 
@@ -58,8 +58,8 @@ final class VipgociOptionsBoolHandleTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$options['mytestoption'],
-			true
+			true,
+			$options['mytestoption']
 		);
 	}
 }

--- a/tests/VipgociOptionsIntegerHandleTest.php
+++ b/tests/VipgociOptionsIntegerHandleTest.php
@@ -19,10 +19,10 @@ final class VipgociOptionsIntegerHandleTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			$options,
 			array(
 				'mytestoption'	=> 5
-			)
+			),
+			$options
 		);
 	}
 }


### PR DESCRIPTION
In some cases, the expected/actual parameters in calls to assert-functions have switched. This Pull-Request will fix this.