### PR TITLE
Fix a problem with warnings being posted repeatedly

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -618,7 +618,7 @@ function vipgoci_github_comment_match(
 		 * as "Warning: ..." -- remove all of that.
 		 */
 		$comment_made_body = str_replace(
-			array("**", "Warning", "Error", "Info", ":no_entry_sign:", ":exclamation:", ":information_source:"),
+			array("**", "Warning", "Error", "Info", ":no_entry_sign:", ":warning:", ":information_source:"),
 			array("", "", "", "", ""),
 			$comment_made->body
 		);


### PR DESCRIPTION
Changing :exclamation: to :warning: to get consistency with change made in fb14b2ebf01efb4cac4e3b81249a7980b1031dc2.

This fixes a problem with warnings being posted repeatedly in Pull-Requests.