### PR TITLE
Allow to set or overwrite certain options via option file in repository

### DIFF
--- a/options.php
+++ b/options.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Read settings from a options file in the
+ * repository, but only allow certain options
+ * to be configured. 
+ */
+function vipgoci_read_repo_options_file(
+	&$options,
+	$repo_options_file_name,
+	$options_overwritable
+) {
+
+	vipgoci_log(
+		'Reading options from repository, overwriting ' .
+			'already set values if applicable',
+		array(
+			'repo_owner'		=> $options['repo-owner'],
+			'repo_name'		=> $options['repo-name'],
+			'commit'		=> $options['commit'],
+			'filename'		=> $filename,
+			'options_overwritable'	=> $options_overwritable,
+		)
+	);
+
+
+	/*
+	 * Try to read options-file from
+	 * repository, bail out of that fails.
+	 */
+
+	$repo_options_file_contents = vipgoci_gitrepo_fetch_committed_file(
+		$options['repo-owner'],
+		$options['repo-name'],
+		$options['token'],
+		$options['commit'],
+		$filename,
+		$options['local-git-repo']
+	);
+
+	if ( false === $repo_options_file_contents ) {
+		vipgoci_log(
+			'No options found, nothing further to do',
+			array(
+				'filename'		=> $filename,		
+			)
+		);
+
+		return false;
+	}
+
+	$repo_options_arr = json_decode(
+		$repo_options_file_contents,
+		true
+	);
+
+	if ( null === $repo_options_arr ) {
+		vipgoci_log(
+			'Options not parsable, nothing further to do',
+			array(
+				'filename'
+					=> $filename,
+
+				'repo_options_arr'
+					=> $repo_options_arr,
+
+				'repo_options_file_contents'
+					=> $repo_options_file_contents,
+			)
+		);
+
+
+		return false;
+	}
+
+
+	/*
+	 * Actually set/overwrite values. Keep account of what we set
+	 * and to what value, log it at the end.
+	 */
+	$options_read = array();
+
+	foreach( $options_overwritable as $option_overwritable_name ) {
+		if ( isset(
+			$repo_options_arr[
+				$option_overwritable_name
+			]
+		) ) {
+			$options[
+				$option_overwritable_name
+			]
+			=
+			$options_read[
+				$option_overwritable_name
+			]
+			=
+			$repo_options_arr[
+				$option_overwritable_name
+			];
+
+			// FIXME: Need to check if values are okay.
+		}		
+	}
+
+	vipgoci_log(
+		'Set or overwrote the following options',
+		$options_read
+	);
+}

--- a/options.php
+++ b/options.php
@@ -17,7 +17,7 @@ function vipgoci_options_read_repo_file(
 				'using data from repository settings file ' .
 				'as this is disabled via options',
 			array(
-				'phpcs-severity-repo-options-file'
+				'phpcs_severity_repo_options_file'
 					=> $options[ 'phpcs-severity-repo-options-file' ],
 			)
 		);

--- a/options.php
+++ b/options.php
@@ -98,7 +98,7 @@ function vipgoci_read_repo_options_file(
 				$option_overwritable_name
 			];
 
-			// FIXME: Need to check if values are okay.
+			// FIXME: Need to check if set values are valid.
 		}		
 	}
 

--- a/options.php
+++ b/options.php
@@ -11,6 +11,20 @@ function vipgoci_options_read_repo_file(
 	$options_overwritable
 ) {
 
+	if ( false === $options[ 'phpcs-severity-repo-options-file' ] ) {
+		vipgoci_log(
+			'Skipping possibly overwriting options ' .
+				'using data from repository settings file ' .
+				'as this is disabled via options',
+			array(
+				'phpcs-severity-repo-options-file'
+					=> $options[ 'phpcs-severity-repo-options-file' ],
+			)
+		);
+
+		return true;
+	}
+
 	vipgoci_log(
 		'Reading options from repository, overwriting ' .
 			'already set values if applicable',
@@ -163,4 +177,6 @@ function vipgoci_options_read_repo_file(
 		'Set or overwrote the following options',
 		$options_read
 	);
+
+	return true;
 }

--- a/options.php
+++ b/options.php
@@ -15,7 +15,7 @@ function vipgoci_options_read_repo_file(
 		vipgoci_log(
 			'Skipping possibly overwriting options ' .
 				'using data from repository settings file ' .
-				'as this is disabled via options',
+				'as this is disabled via command-line options',
 			array(
 				'phpcs_severity_repo_options_file'
 					=> $options[ 'phpcs-severity-repo-options-file' ],

--- a/options.php
+++ b/options.php
@@ -5,7 +5,7 @@
  * repository, but only allow certain options
  * to be configured. 
  */
-function vipgoci_read_repo_options_file(
+function vipgoci_options_read_repo_file(
 	&$options,
 	$repo_options_file_name,
 	$options_overwritable

--- a/options.php
+++ b/options.php
@@ -18,7 +18,7 @@ function vipgoci_options_read_repo_file(
 			'repo_owner'		=> $options['repo-owner'],
 			'repo_name'		=> $options['repo-name'],
 			'commit'		=> $options['commit'],
-			'filename'		=> $filename,
+			'filename'		=> $repo_options_file_name,
 			'options_overwritable'	=> $options_overwritable,
 		)
 	);
@@ -34,7 +34,7 @@ function vipgoci_options_read_repo_file(
 		$options['repo-name'],
 		$options['token'],
 		$options['commit'],
-		$filename,
+		$repo_options_file_name,
 		$options['local-git-repo']
 	);
 
@@ -42,7 +42,7 @@ function vipgoci_options_read_repo_file(
 		vipgoci_log(
 			'No options found, nothing further to do',
 			array(
-				'filename'		=> $filename,		
+				'filename'		=> $repo_options_file_name,		
 			)
 		);
 
@@ -59,7 +59,7 @@ function vipgoci_options_read_repo_file(
 			'Options not parsable, nothing further to do',
 			array(
 				'filename'
-					=> $filename,
+					=> $repo_options_file_name,
 
 				'repo_options_arr'
 					=> $repo_options_arr,

--- a/options.php
+++ b/options.php
@@ -42,7 +42,7 @@ function vipgoci_options_read_repo_file(
 		vipgoci_log(
 			'No options found, nothing further to do',
 			array(
-				'filename'		=> $repo_options_file_name,		
+				'filename' => $repo_options_file_name,		
 			)
 		);
 
@@ -80,26 +80,83 @@ function vipgoci_options_read_repo_file(
 	 */
 	$options_read = array();
 
-	foreach( $options_overwritable as $option_overwritable_name ) {
-		if ( isset(
-			$repo_options_arr[
-				$option_overwritable_name
-			]
-		) ) {
-			$options[
-				$option_overwritable_name
-			]
-			=
-			$options_read[
-				$option_overwritable_name
-			]
-			=
-			$repo_options_arr[
-				$option_overwritable_name
-			];
+	foreach(
+		$options_overwritable as
+			$option_overwritable_name =>
+			$option_overwritable_conf
+	) {
+		/*
+		 * Detect possible issues with
+		 * the arguments given, or value not defined
+		 * in the options-file.
+		 */
+		if (
+			( ! isset(
+				$repo_options_arr[
+					$option_overwritable_name
+				]
+			) )
+			||
+			( ! isset(
+				$option_overwritable_conf['type']
+			) )
+		) {
+			continue;
+		}
 
-			// FIXME: Need to check if set values are valid.
-		}		
+
+		$do_skip = false;
+
+		if ( 'integer' === $option_overwritable_conf['type'] ) {
+			if ( ! isset(
+				$option_overwritable_conf['valid_values']
+			) ) {
+				$do_skip = true;
+			}
+
+			if ( ! in_array(
+				$repo_options_arr[
+					$option_overwritable_name
+				],
+				$option_overwritable_conf['valid_values'],
+				true
+			) ) {
+				$do_skip = true;
+			}
+		}
+
+		else {
+			$do_skip = true;
+		}
+
+
+		if ( true === $do_skip ) {
+			vipgoci_log(
+				'Found invalid value for option in option-file, or invalid arguments passed internally',
+				array(
+					'option_overwritable_name'
+						=> $option_overwritable_name,
+
+					'option_overwritable_conf'
+						=> $option_overwritable_conf,
+				)
+			);
+
+			continue;
+		}
+
+			
+		$options[
+			$option_overwritable_name
+		]
+		=
+		$options_read[
+			$option_overwritable_name
+		]
+		=
+		$repo_options_arr[
+			$option_overwritable_name
+		];
 	}
 
 	vipgoci_log(

--- a/options.php
+++ b/options.php
@@ -27,7 +27,7 @@ function vipgoci_options_read_repo_file(
 
 	vipgoci_log(
 		'Reading options from repository, overwriting ' .
-			'already set values if applicable',
+			'already set option values if applicable',
 		array(
 			'repo_owner'		=> $options['repo-owner'],
 			'repo_name'		=> $options['repo-name'],

--- a/tests/OptionsReadRepoFile.php
+++ b/tests/OptionsReadRepoFile.php
@@ -42,6 +42,8 @@ final class OptionsReadRepoFile extends TestCase {
 			$this->options_options
 		);
 
+		$this->options[ 'phpcs-severity-repo-options-file' ] = true;
+
 		$this->options['token'] = null;
 
 	}
@@ -63,10 +65,6 @@ final class OptionsReadRepoFile extends TestCase {
 	 * @covers ::vipgoci_options_read_repo_file
 	 */
 	public function testOptionsReadRepoFileTest1() {
-		/*
-		 * File does not exist in repository,
-		 * so the test should not succeed.
-		 */
 		$this->options['commit'] =
 			$this->options['commit-test-options-read-repo-file-no-file'];
 
@@ -102,7 +100,7 @@ final class OptionsReadRepoFile extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			-100,
+			-100, // Should remain unchanged, no option file exists.
 			$this->options['phpcs-severity']
 		);
 	}
@@ -111,10 +109,6 @@ final class OptionsReadRepoFile extends TestCase {
 	 * @covers ::vipgoci_options_read_repo_file
 	 */
 	public function testOptionsReadRepoFileTest2() {
-		/*
-		 * File does exist in repository,
-		 * so the test should succeed.
-		 */
 		$this->options['commit'] =
 			$this->options['commit-test-options-read-repo-file-with-file'];
 
@@ -155,16 +149,13 @@ final class OptionsReadRepoFile extends TestCase {
 		);
 	}
 
-	/*
-	 * The following are tests to make sure internal
-	 * checks in the vipgoci_options_read_repo_file() function
-	 * work correctly.
-	 */
 
 	/**
 	 * @covers ::vipgoci_options_read_repo_file
 	 */
 	public function testOptionsReadRepoFileTest3() {
+		$this->options['phpcs-severity-repo-options-file'] = false;
+
 		$this->options['commit'] =
 			$this->options['commit-test-options-read-repo-file-with-file'];
 
@@ -184,14 +175,14 @@ final class OptionsReadRepoFile extends TestCase {
 		}
 
 
-		$this->options['phpcs-severity'] = 1;
+		$this->options['phpcs-severity'] = -100;
 
 		vipgoci_options_read_repo_file(
 			$this->options,
 			'.vipgoci_options',
 			array(
 				'phpcs-severity' => array(
-					'type'		=> 'integerrr', // invalid type here
+					'type'		=> 'integer',
 					'valid_values'	=> array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ),
 				),
 			)
@@ -200,10 +191,16 @@ final class OptionsReadRepoFile extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			1, // Should remain 1, as checks failed
+			-100, // Should remain unchanged, feature is turned off.
 			$this->options['phpcs-severity']
 		);
 	}
+
+	/*
+	 * The following are tests to make sure internal
+	 * checks in the vipgoci_options_read_repo_file() function
+	 * work correctly.
+	 */
 
 	/**
 	 * @covers ::vipgoci_options_read_repo_file
@@ -228,7 +225,51 @@ final class OptionsReadRepoFile extends TestCase {
 		}
 
 
-		$this->options['phpcs-severity'] = 1;
+		$this->options['phpcs-severity'] = -100;
+
+		vipgoci_options_read_repo_file(
+			$this->options,
+			'.vipgoci_options',
+			array(
+				'phpcs-severity' => array(
+					'type'		=> 'integerrr', // invalid type here
+					'valid_values'	=> array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ),
+				),
+			)
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertEquals(
+			-100, // Should remain unchanged, as checks failed
+			$this->options['phpcs-severity']
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_options_read_repo_file
+	 */
+	public function testOptionsReadRepoFileTest5() {
+		$this->options['commit'] =
+			$this->options['commit-test-options-read-repo-file-with-file'];
+
+		vipgoci_unittests_output_suppress();
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
+
+
+		if ( false === $this->options['local-git-repo'] ) {
+			$this->markTestSkipped(
+				'Could not set up git repository: ' .
+					vipgoci_unittests_output_get()
+			);
+		}
+
+
+		$this->options['phpcs-severity'] = -100;
 
 		vipgoci_options_read_repo_file(
 			$this->options,
@@ -244,7 +285,7 @@ final class OptionsReadRepoFile extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			1, // Should remain 1
+			-100, // Should remain unchanged
 			$this->options['phpcs-severity']
 		);
 	}

--- a/tests/OptionsReadRepoFile.php
+++ b/tests/OptionsReadRepoFile.php
@@ -1,0 +1,252 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class OptionsReadRepoFile extends TestCase {
+	var $options_git = array(
+		'git-path'		=> null,
+		'github-repo-url'	=> null,
+	);
+
+       var $options_patch_changed_lines = array(
+	       'repo-owner'	=> null,
+	       'repo-name'	=> null,
+       );
+
+	var $options_options = array(
+		'commit-test-options-read-repo-file-no-file'	=> null,
+		'commit-test-options-read-repo-file-with-file'	=> null,
+	);
+
+	protected function setUp() {
+		vipgoci_unittests_get_config_values(
+			'git',
+			$this->options_git
+		);
+
+		vipgoci_unittests_get_config_values(
+		       'patch-changed-lines',
+		       $this->options_patch_changed_lines
+		);
+
+		vipgoci_unittests_get_config_values(
+			'options',
+			$this->options_options
+		);
+
+		$this->options = array_merge(
+			$this->options_git,
+			$this->options_patch_changed_lines,
+			$this->options_options
+		);
+
+		$this->options['token'] = null;
+
+	}
+
+	protected function tearDown() {
+		if ( false !== $this->options['local-git-repo'] ) {
+			vipgoci_unittests_remove_git_repo(
+				$this->options['local-git-repo']
+			);
+		}
+
+		$this->options = null;
+		$this->options_options = null;
+		$this->options_patch_changed_lines = null;
+		$this->options_git = null;
+	}
+
+	/**
+	 * @covers ::vipgoci_options_read_repo_file
+	 */
+	public function testOptionsReadRepoFileTest1() {
+		/*
+		 * File does not exist in repository,
+		 * so the test should not succeed.
+		 */
+		$this->options['commit'] =
+			$this->options['commit-test-options-read-repo-file-no-file'];
+
+		vipgoci_unittests_output_suppress();
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
+
+
+		if ( false === $this->options['local-git-repo'] ) {
+			$this->markTestSkipped(
+				'Could not set up git repository: ' .
+					vipgoci_unittests_output_get()
+			);
+		}
+
+
+		$this->options['phpcs-severity'] = -100;
+
+		vipgoci_options_read_repo_file(
+			$this->options,
+			'.vipgoci_options',
+			array(
+				'phpcs-severity' => array(
+					'type'		=> 'integer',
+					'valid_values'	=> array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ),
+				),
+			)
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertEquals(
+			-100,
+			$this->options['phpcs-severity']
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_options_read_repo_file
+	 */
+	public function testOptionsReadRepoFileTest2() {
+		/*
+		 * File does exist in repository,
+		 * so the test should succeed.
+		 */
+		$this->options['commit'] =
+			$this->options['commit-test-options-read-repo-file-with-file'];
+
+		vipgoci_unittests_output_suppress();
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
+
+
+		if ( false === $this->options['local-git-repo'] ) {
+			$this->markTestSkipped(
+				'Could not set up git repository: ' .
+					vipgoci_unittests_output_get()
+			);
+		}
+
+
+		$this->options['phpcs-severity'] = -100;
+
+		vipgoci_options_read_repo_file(
+			$this->options,
+			'.vipgoci_options',
+			array(
+				'phpcs-severity' => array(
+					'type'		=> 'integer',
+					'valid_values'	=> array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ),
+				),
+			)
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertEquals(
+			1, // Options file should change this to 1
+			$this->options['phpcs-severity']
+		);
+	}
+
+	/*
+	 * The following are tests to make sure internal
+	 * checks in the vipgoci_options_read_repo_file() function
+	 * work correctly.
+	 */
+
+	/**
+	 * @covers ::vipgoci_options_read_repo_file
+	 */
+	public function testOptionsReadRepoFileTest3() {
+		$this->options['commit'] =
+			$this->options['commit-test-options-read-repo-file-with-file'];
+
+		vipgoci_unittests_output_suppress();
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
+
+
+		if ( false === $this->options['local-git-repo'] ) {
+			$this->markTestSkipped(
+				'Could not set up git repository: ' .
+					vipgoci_unittests_output_get()
+			);
+		}
+
+
+		$this->options['phpcs-severity'] = 1;
+
+		vipgoci_options_read_repo_file(
+			$this->options,
+			'.vipgoci_options',
+			array(
+				'phpcs-severity' => array(
+					'type'		=> 'integerrr', // invalid type here
+					'valid_values'	=> array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ),
+				),
+			)
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertEquals(
+			1, // Should remain 1, as checks failed
+			$this->options['phpcs-severity']
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_options_read_repo_file
+	 */
+	public function testOptionsReadRepoFileTest4() {
+		$this->options['commit'] =
+			$this->options['commit-test-options-read-repo-file-with-file'];
+
+		vipgoci_unittests_output_suppress();
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
+
+
+		if ( false === $this->options['local-git-repo'] ) {
+			$this->markTestSkipped(
+				'Could not set up git repository: ' .
+					vipgoci_unittests_output_get()
+			);
+		}
+
+
+		$this->options['phpcs-severity'] = 1;
+
+		vipgoci_options_read_repo_file(
+			$this->options,
+			'.vipgoci_options',
+			array(
+				'phpcs-severity' => array(
+					'type'		=> 'integer',
+					'valid_values'	=> array( 500 ), // the value in options-file out of range
+				),
+			)
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertEquals(
+			1, // Should remain 1
+			$this->options['phpcs-severity']
+		);
+	}
+}
+

--- a/unittests.ini
+++ b/unittests.ini
@@ -64,3 +64,7 @@ test-github-pr-reviews-event-get-username=gudmdharalds
 
 [labels]
 labels-pr-to-modify=12
+
+[options]
+commit-test-options-read-repo-file-no-file=5e95e2c3705695a62023c92ef5f09761ab057ba5
+commit-test-options-read-repo-file-with-file=7604b5c54a736d58678de0c5bf18de1c66f6c260

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -486,6 +486,7 @@ function vipgoci_run() {
 			'phpcs-severity:',
 			'phpcs-sniffs-exclude:',
 			'phpcs-runtime-set:',
+			'phpcs-severity-repo-options-file:',
 			'hashes-api-url:',
 			'hashes-oauth-token:',
 			'hashes-oauth-token-secret:',
@@ -575,6 +576,9 @@ function vipgoci_run() {
 			"\t" . '                               -- expected to be a comma-separated value string of ' . PHP_EOL .
 			"\t" . '                               key-value pairs.' . PHP_EOL .
 			"\t" . '                               For example: --phpcs-runtime-set="foo1 bar1, foo2,bar2"' . PHP_EOL .
+			"\t" . '--phpcs-severity-repo-options-file=BOOL     Whether to allow configuring phpcs-severity' . PHP_EOL .
+			"\t" . '                                            option via options file placed ' . PHP_EOL .
+			"\t" . '                                            in repository.' . PHP_EOL .
 			"\t" . '--autoapprove=BOOL             Whether to auto-approve Pull-Requests' . PHP_EOL .
 			"\t" . '                               altering only files of certain types' . PHP_EOL .
 			"\t" . '--autoapprove-filetypes=STRING Specify what file-types can be auto-' . PHP_EOL .
@@ -939,6 +943,8 @@ function vipgoci_run() {
 	vipgoci_option_bool_handle( $options, 'dry-run', 'false' );
 
 	vipgoci_option_bool_handle( $options, 'phpcs', 'true' );
+
+	vipgoci_option_bool_handle( $options, 'phpcs-severity-repo-options-file', 'true' );
 
 	vipgoci_option_bool_handle( $options, 'lint', 'true' );
 

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -1213,6 +1213,19 @@ function vipgoci_run() {
 		'dismissed-reviews-exclude-reviews-from-team'
 	);
 
+	/*
+	 * Certain options are configurable via
+	 * options-file in the repository. Set
+	 * these options here.
+	 */
+	vipgoci_read_repo_options_file(
+		$options,
+		'.vipgoci_options',
+		array(
+			'phpcs-severity',
+		)
+	);
+
 
 	/*
 	 * Log that we started working,

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -1219,7 +1219,7 @@ function vipgoci_run() {
 	 * options-file in the repository. Set
 	 * these options here.
 	 */
-	vipgoci_read_repo_options_file(
+	vipgoci_options_read_repo_file(
 		$options,
 		'.vipgoci_options',
 		array(

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -944,7 +944,7 @@ function vipgoci_run() {
 
 	vipgoci_option_bool_handle( $options, 'phpcs', 'true' );
 
-	vipgoci_option_bool_handle( $options, 'phpcs-severity-repo-options-file', 'true' );
+	vipgoci_option_bool_handle( $options, 'phpcs-severity-repo-options-file', 'false' );
 
 	vipgoci_option_bool_handle( $options, 'lint', 'true' );
 

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -5,6 +5,7 @@ require_once( __DIR__ . '/defines.php' );
 require_once( __DIR__ . '/github-api.php' );
 require_once( __DIR__ . '/git-repo.php' );
 require_once( __DIR__ . '/misc.php' );
+require_once( __DIR__ . '/options.php' ) ;
 require_once( __DIR__ . '/statistics.php' );
 require_once( __DIR__ . '/phpcs-scan.php' );
 require_once( __DIR__ . '/lint-scan.php' );

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -1223,7 +1223,10 @@ function vipgoci_run() {
 		$options,
 		'.vipgoci_options',
 		array(
-			'phpcs-severity',
+			'phpcs-severity' => array(
+				'type'		=> 'integer',
+				'valid_values'	=> array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ),
+			),
 		)
 	);
 


### PR DESCRIPTION
This Pull-Request introduces a new feature, whereby certain options can be set or overwritten via option file in repository. At this point, only `phpcs-severity` can be set.

Todo:
- [ ] Check if values are valid
- [ ] Create unit-tests for the new function