### PR TITLE
Ability to read options from environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,58 @@
+# PHP CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-php/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # Specify the version you desire here
+      - image: circleci/php:7.1-node-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # Using the RAM variation mitigates I/O contention
+      # for database intensive operations.
+      # - image: circleci/mysql:5.7-ram
+      #
+      # - image: redis:2.8.19
+
+    steps:
+      - checkout
+
+      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
+      - run: sudo docker-php-ext-install zip
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            # "composer.lock" can be used if it is committed to the repo
+            - v1-dependencies-{{ checksum "composer.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: composer install -n --prefer-dist
+
+      - save_cache:
+          key: v1-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+      - restore_cache:
+          keys:
+            - node-v1-{{ checksum "package.json" }}
+            - node-v1-
+      - run: yarn install
+      - save_cache:
+          key: node-v1-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+
+      # prepare the database
+      - run: touch storage/testing.sqlite
+      - run: php artisan migrate --env=testing --database=sqlite_testing --force
+
+      # run tests with phpunit or codecept
+      #- run: ./vendor/bin/phpunit
+      - run: ./vendor/bin/codecept build
+      - run: ./vendor/bin/codecept run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the version you desire here
-      - image: circleci/php:7.1-node-browsers
+      - image: circleci/php:7.1-apache
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -22,7 +22,6 @@ jobs:
       - checkout
       - run: sudo apt update 
       - run: sudo docker-php-ext-install zip
-      - run: sudo apt install phpunit
 
       - run: find .
       - run: phpunit -vv  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,9 @@ jobs:
 
     steps:
       - checkout
+      - run: sudo apt update 
+      - run: sudo docker-php-ext-install zip
+      - run: sudo apt install phpunit
 
-      - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
-      - run: sudo docker-php-ext-install 
-      - run: sudo apt install zip phpunit
-
-      # run tests with phpunit or codecept
-      - run: phpunit -vv  
       - run: find .
+      - run: phpunit -vv  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Specify the version you desire here
-      - image: circleci/php:7.4.1-buster
+      - image: circleci/php:7.3.9-stretch
 
       # List of images at: https://circleci.com/docs/2.0/circleci-images/
       # Using the RAM variation mitigates I/O contention

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,8 @@ jobs:
       - checkout
       - run: sudo apt update 
       - run: sudo docker-php-ext-install zip
-      - run: sudo apt search phpunit
-#      - run: sudo apt install -y phpunit
-      - run: find .
-      - run: phpunit -vv  
+      - run: sudo ln -s /usr/local/bin/php /usr/bin/php
+      - run: composer require --dev phpunit/phpunit ^7
+      - run: bash ~/projects/tools-init.sh
+      - run: rm -rf ~/vip-go-ci-tools/vip-go-ci
+      - run: ./vendor/bin/phpunit -vv ~/project/tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,6 @@ jobs:
       - run: sudo apt update 
       - run: sudo docker-php-ext-install zip
       - run: sudo apt search phpunit
-      - run: sudo apt install -y phpunit
+#      - run: sudo apt install -y phpunit
       - run: find .
       - run: phpunit -vv  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,35 +24,5 @@ jobs:
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
       - run: sudo docker-php-ext-install zip
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            # "composer.lock" can be used if it is committed to the repo
-            - v1-dependencies-{{ checksum "composer.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      - run: composer install -n --prefer-dist
-
-      - save_cache:
-          key: v1-dependencies-{{ checksum "composer.json" }}
-          paths:
-            - ./vendor
-      - restore_cache:
-          keys:
-            - node-v1-{{ checksum "package.json" }}
-            - node-v1-
-      - run: yarn install
-      - save_cache:
-          key: node-v1-{{ checksum "package.json" }}
-          paths:
-            - node_modules
-
-      # prepare the database
-      - run: touch storage/testing.sqlite
-      - run: php artisan migrate --env=testing --database=sqlite_testing --force
-
       # run tests with phpunit or codecept
-      #- run: ./vendor/bin/phpunit
-      - run: ./vendor/bin/codecept build
-      - run: ./vendor/bin/codecept run
+      - run: ./vendor/bin/phpunit -vv  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/php:7.3.9-stretch
+      - image: circleci/php:7.4.1-cli
 
       # List of images at: https://circleci.com/docs/2.0/circleci-images/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
       - checkout
       - run: sudo apt update 
       - run: sudo docker-php-ext-install zip
-      - run: sudo ln -s /usr/local/bin/php /usr/bin/php
       - run: composer require --dev phpunit/phpunit ^7
-      - run: bash ~/projects/tools-init.sh
+      - run: sudo ln -s /usr/local/bin/php /usr/bin/php
+      - run: bash ~/project/tools-init.sh
       - run: rm -rf ~/vip-go-ci-tools/vip-go-ci
       - run: ./vendor/bin/phpunit -vv ~/project/tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,6 @@ jobs:
       - checkout
       - run: sudo apt update 
       - run: sudo docker-php-ext-install zip
-
+      - run: sudo apt install -y phpunit
       - run: find .
       - run: phpunit -vv  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
-      - run: sudo docker-php-ext-install zip
+      - run: sudo docker-php-ext-install zip phpunit php
 
       # run tests with phpunit or codecept
-      - run: ./vendor/bin/phpunit -vv  
+      - run: phpunit -vv  
+      - run: find .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - checkout
       - run: sudo apt update 
       - run: sudo docker-php-ext-install zip
+      - run: sudo apt search phpunit
       - run: sudo apt install -y phpunit
       - run: find .
       - run: phpunit -vv  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
       - checkout
 
       - run: sudo apt update # PHP CircleCI 2.0 Configuration File# PHP CircleCI 2.0 Configuration File sudo apt install zlib1g-dev libsqlite3-dev
-      - run: sudo docker-php-ext-install zip phpunit php
+      - run: sudo docker-php-ext-install 
+      - run: sudo apt install zip phpunit
 
       # run tests with phpunit or codecept
       - run: phpunit -vv  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,4 +24,6 @@ jobs:
       - run: sudo ln -s /usr/local/bin/php /usr/bin/php
       - run: bash ~/project/tools-init.sh
       - run: rm -rf ~/vip-go-ci-tools/vip-go-ci
+      - run: sed 's/\/home\/phpunit\//\/home\/circleci\//' < ~/project/unittests.ini > ~/project/unittests2.ini 
+      - run: mv ~/project/unittests2.ini ~/project/unittests.ini
       - run: ./vendor/bin/phpunit -vv ~/project/tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,25 +6,26 @@ version: 2
 jobs:
   build:
     docker:
-      # Specify the version you desire here
       - image: circleci/php:7.3.9-stretch
 
       # List of images at: https://circleci.com/docs/2.0/circleci-images/
-      # Using the RAM variation mitigates I/O contention
-      # for database intensive operations.
-      # - image: circleci/mysql:5.7-ram
-      #
-      # - image: redis:2.8.19
 
     steps:
+      # Get the code
       - checkout
-      - run: sudo apt update 
+      # Update software and install a few things
+      - run: sudo apt update
       - run: sudo docker-php-ext-install zip
       - run: composer require --dev phpunit/phpunit ^7
+      # By default, php is not available in /usr/bin, fix that
       - run: sudo ln -s /usr/local/bin/php /usr/bin/php
+      # Install all the tools vip-go-ci needs, remove vip-go-ci itself though
       - run: bash ~/project/tools-init.sh
       - run: rm -rf ~/vip-go-ci-tools/vip-go-ci
-      - run: sed 's/\/home\/phpunit\//\/home\/circleci\//' < ~/project/unittests.ini > ~/project/unittests2.ini 
+      # Change path to vital tools needed
+      - run: sed 's/\/home\/phpunit\//\/home\/circleci\//' < ~/project/unittests.ini > ~/project/unittests2.ini
       - run: mv ~/project/unittests2.ini ~/project/unittests.ini
+      # No secrets available for unit-tests
       - run: touch ~/project/unittests-secrets.ini
+      # Run unit-tests
       - run: ./vendor/bin/phpunit -vv ~/project/tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,4 +26,5 @@ jobs:
       - run: rm -rf ~/vip-go-ci-tools/vip-go-ci
       - run: sed 's/\/home\/phpunit\//\/home\/circleci\//' < ~/project/unittests.ini > ~/project/unittests2.ini 
       - run: mv ~/project/unittests2.ini ~/project/unittests.ini
+      - run: touch ~/project/unittests-secrets.ini
       - run: ./vendor/bin/phpunit -vv ~/project/tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,9 @@ jobs:
   build:
     docker:
       # Specify the version you desire here
-      - image: circleci/php:7.1-apache
+      - image: circleci/php:7.4.1-buster
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # List of images at: https://circleci.com/docs/2.0/circleci-images/
       # Using the RAM variation mitigates I/O contention
       # for database intensive operations.
       # - image: circleci/mysql:5.7-ram

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -43,8 +43,8 @@ function vipgoci_lint_do_scan(
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'php_lint_cli' );
 
 	/*
-	 * Some PHP version output empty lines
-	 * when linting PHP files, remove them.
+	 * Some PHP versions output empty lines
+	 * when linting PHP files, remove those.
 	 *
 	 */
 	$file_issues_arr =
@@ -56,7 +56,7 @@ function vipgoci_lint_do_scan(
 		);
 
 	/*
-	 * Some PHP versions of PHP use slightly
+	 * Some PHP versions use slightly
 	 * different output when linting PHP files,
 	 * make the output compatibile.
 	 */

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -138,7 +138,7 @@ function vipgoci_lint_get_issues(
 
 		if (
 			( false !== strpos( $message, ' on line ' ) ) &&
-			( false !== strpos( $message, 'Parse error:' ) )
+			( false !== strpos( $message, 'PHP Parse error:' ) )
 		) {
 			/*
 			 * Get rid of 'PHP Parse...' which is not helpful

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -55,8 +55,7 @@ function vipgoci_lint_do_scan(
 					return '' !== $array_item;
 				}
 			)
-		)
-	);
+		);
 
 
 	vipgoci_log(

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -46,20 +46,49 @@ function vipgoci_lint_do_scan(
 	 * Some PHP version output empty lines
 	 * when linting PHP files, remove them.
 	 *
-	 * Also, for some reason some PHP versions
-	 * output the same errors two times, remove
-	 * any duplicates.
+	 */
+	$file_issues_arr =
+		array_filter(
+			$file_issues_arr,
+			function( $array_item ) {
+				return '' !== $array_item;
+			}
+		);
+
+	/*
+	 * Some PHP versions of PHP use slightly
+	 * different output when linting PHP files,
+	 * make the output compatibile.
 	 */
 
-	$file_issues_arr = 
+	$file_issues_arr = array_map(
+		function ( $str ) {
+			if ( strpos(
+				$str,
+				'Parse error: '
+			) === 0 ) {
+				$str = str_replace(
+					'Parse error: ',
+					'PHP Parse error:  ',
+					$str
+				);
+			}
+
+			return $str;
+		},
+		$file_issues_arr
+	);
+
+	/*
+	 * For some reason some PHP versions
+	 * output the same errors two times, remove
+	 * any duplicates. 
+	 */
+
+	$file_issues_arr =
 		array_values(
 			array_unique(
-				array_filter(
-					$file_issues_arr,
-					function( $array_item ) {
-						return '' !== $array_item;
-					}
-				)
+				$file_issues_arr
 			)
 		);
 
@@ -117,14 +146,8 @@ function vipgoci_lint_get_issues(
 			 */
 
 			$message = str_replace(
-				array(
-					'PHP Parse error:',
-					'Parse error:',
-				),
-				array(
-					'',
-					'',
-				),
+				'PHP Parse error:',
+				'',
 				$message
 			);
 

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -24,7 +24,7 @@ function vipgoci_lint_do_scan(
 		escapeshellcmd( $php_path ),
 		escapeshellarg( 'error_reporting=24575' ),
 		escapeshellarg( 'error_log=null' ),
-		escapeshellarg( 'display_errors=off' ), // Needs to be off, otherwise errors may be reported twice
+		escapeshellarg( 'display_errors=on' ),
 		escapeshellarg( $temp_file_name )
 	);
 
@@ -43,17 +43,23 @@ function vipgoci_lint_do_scan(
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'php_lint_cli' );
 
 	/*
-	 * Some PHP version output empty lines 
+	 * Some PHP version output empty lines
 	 * when linting PHP files, remove them.
+	 *
+	 * Also, for some reason some PHP versions
+	 * output the same errors two times, remove
+	 * any duplicates.
 	 */
 
 	$file_issues_arr = 
 		array_values(
-			array_filter(
-				$file_issues_arr,
-				function( $array_item ) {
-					return '' !== $array_item;
-				}
+			array_unique(
+				array_filter(
+					$file_issues_arr,
+					function( $array_item ) {
+						return '' !== $array_item;
+					}
+				)
 			)
 		);
 

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -42,6 +42,22 @@ function vipgoci_lint_do_scan(
 
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'php_lint_cli' );
 
+	/*
+	 * Some PHP version output empty lines 
+	 * when linting PHP files, remove them.
+	 */
+
+	$file_issues_arr = 
+		array_values(
+			array_filter(
+				$file_issues_arr,
+				function( $array_item ) {
+					return '' !== $array_item;
+				}
+			)
+		)
+	);
+
 
 	vipgoci_log(
 		'PHP linting execution details',
@@ -88,7 +104,7 @@ function vipgoci_lint_get_issues(
 
 		if (
 			( false !== strpos( $message, ' on line ' ) ) &&
-			( false !== strpos( $message, 'PHP Parse error:' ) )
+			( false !== strpos( $message, 'Parse error:' ) )
 		) {
 			/*
 			 * Get rid of 'PHP Parse...' which is not helpful
@@ -96,8 +112,14 @@ function vipgoci_lint_get_issues(
 			 */
 
 			$message = str_replace(
-				'PHP Parse error:',
-				'',
+				array(
+					'PHP Parse error:',
+					'Parse error:',
+				),
+				array(
+					'',
+					'',
+				),
 				$message
 			);
 

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -24,7 +24,7 @@ function vipgoci_lint_do_scan(
 		escapeshellcmd( $php_path ),
 		escapeshellarg( 'error_reporting=24575' ),
 		escapeshellarg( 'error_log=null' ),
-		escapeshellarg( 'display_errors=on' ),
+		escapeshellarg( 'display_errors=off' ), // Needs to be off, otherwise errors may be reported twice
 		escapeshellarg( $temp_file_name )
 	);
 

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -24,7 +24,7 @@ function vipgoci_lint_do_scan(
 		escapeshellcmd( $php_path ),
 		escapeshellarg( 'error_reporting=24575' ),
 		escapeshellarg( 'error_log=null' ),
-		escapeshellarg( 'display_errors=off' ),
+		escapeshellarg( 'display_errors=on' ),
 		escapeshellarg( $temp_file_name )
 	);
 

--- a/options.php
+++ b/options.php
@@ -210,22 +210,22 @@ function vipgoci_options_read_env(
 	$options_configured = array();
 
 	foreach(
-		$options['env-options'] as $option
+		$options['env-options'] as $option_unparsed
 	) {
 		/*
 		 * Try to parse option from the command-line
 		 * to figure out which environmental variable to use
 		 * for which option.
 		 */
-		$option_val = explode(
+		$option_parsed = explode(
 			'=',
-			$option,
+			$option_unparsed,
 			2 // Max one '='; any extra will be preserved in the option-env-var
 		);
 
-		$option_name = $option_val[0];
-		$option_env_var = $option_val[1];
-		unset( $option_val );
+		$option_name = $option_parsed[0];
+		$option_env_var = $option_parsed[1];
+		unset( $option_parsed );
 
 		/*
 		 * If option-name or env-var is too short, skip.
@@ -300,15 +300,25 @@ function vipgoci_options_read_env(
 		}
 
 		/*
-		 * Already configured? Skip.
+		 * Already configured and not
+		 * configured by us in an earlier
+		 * round? Then skip.
 		 */
-		if ( isset(
-			$options[
-				$option_name
-			]
-		) ) {
+		if (
+			( isset(
+				$options[
+					$option_name
+				]
+			) )
+			&&
+			( ! isset(
+				$options_configured[
+					$option_name
+				]
+			) )
+		) {
 			vipgoci_log(
-				'Skipping option from environment as it is already configured via command-line parameter',
+				'Skipping option from environment as it is already configured',
 				array(
 					'option_name' =>
 						$option_name,

--- a/options.php
+++ b/options.php
@@ -500,21 +500,16 @@ function vipgoci_option_array_handle(
 	}
 
 	else {
-		if ( false === $strlower_option_value ) {
-			$options[ $option_name ] = explode(
-				$array_separator,
+		if ( true === $strlower_option_value ) {
+			$options[ $option_name ] = strtolower(
 				$options[ $option_name ]
 			);
 		}
 
-		else {
-			$options[ $option_name ] = explode(
-				$array_separator,
-				strtolower(
-					$options[ $option_name ]
-				)
-			);
-		}
+		$options[ $option_name ] = explode(
+			$array_separator,
+			$options[ $option_name ]
+		);
 
 		if ( ! empty( $forbidden_value ) ) {
 			if ( in_array(

--- a/tests/9LintLintScanCommitTest.php
+++ b/tests/9LintLintScanCommitTest.php
@@ -147,7 +147,7 @@ final class LintLintScanCommitTest extends TestCase {
 			str_replace(
 				"syntax error, unexpected end of file, expecting ';' or ','",
 				"syntax error, unexpected end of file, expecting ',' or ';'",
-				$issues_submit[ $pr_item->number][0]['issue']
+				$issues_submit[ $pr_item->number][0]['issue']['message']
 			);
 
 		$this->assertEquals(

--- a/tests/9LintLintScanCommitTest.php
+++ b/tests/9LintLintScanCommitTest.php
@@ -144,9 +144,7 @@ final class LintLintScanCommitTest extends TestCase {
 		 * in the string below; deal with that.
 		 */
 		$issues_submit[ $pr_item->number ][0]['issue']['message'] =
-			str_replace(
-				"syntax error, unexpected end of file, expecting ';' or ','",
-				"syntax error, unexpected end of file, expecting ',' or ';'",
+			vipgoci_unittests_php_syntax_error_compat(
 				$issues_submit[ $pr_item->number][0]['issue']['message']
 			);
 

--- a/tests/9LintLintScanCommitTest.php
+++ b/tests/9LintLintScanCommitTest.php
@@ -143,7 +143,7 @@ final class LintLintScanCommitTest extends TestCase {
 		 * Some versions of PHP reverse the ',' and ';'
 		 * in the string below; deal with that.
 		 */
-		$issues_submit = array_map(
+		$issues_submit[ $pr_item->number][0]['issue'] = array_map(
 			function ( $str ) {
 				return str_replace(
 					"syntax error, unexpected end of file, expecting ';' or ','",
@@ -151,7 +151,7 @@ final class LintLintScanCommitTest extends TestCase {
 					$str
 				);
 			},
-			$issues_submit
+			$issues_submit[ $pr_item->number][0]['issue']
 		);
 
 		$this->assertEquals(

--- a/tests/9LintLintScanCommitTest.php
+++ b/tests/9LintLintScanCommitTest.php
@@ -139,6 +139,21 @@ final class LintLintScanCommitTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
+		/*
+		 * Some versions of PHP reverse the ',' and ';'
+		 * in the string below; deal with that.
+		 */
+		$issues_submit = array_map(
+			function ( $str ) {
+				return str_replace(
+					"syntax error, unexpected end of file, expecting ';' or ','",
+					"syntax error, unexpected end of file, expecting ',' or ';'",
+					$str
+				);
+			},
+			$issues_submit
+		);
+
 		$this->assertEquals(
 			array(
 				$pr_item->number => array(

--- a/tests/9LintLintScanCommitTest.php
+++ b/tests/9LintLintScanCommitTest.php
@@ -143,16 +143,12 @@ final class LintLintScanCommitTest extends TestCase {
 		 * Some versions of PHP reverse the ',' and ';'
 		 * in the string below; deal with that.
 		 */
-		$issues_submit[ $pr_item->number][0]['issue'] = array_map(
-			function ( $str ) {
-				return str_replace(
-					"syntax error, unexpected end of file, expecting ';' or ','",
-					"syntax error, unexpected end of file, expecting ',' or ';'",
-					$str
-				);
-			},
-			$issues_submit[ $pr_item->number][0]['issue']
-		);
+		$issues_submit[ $pr_item->number ][0]['issue']['message'] =
+			str_replace(
+				"syntax error, unexpected end of file, expecting ';' or ','",
+				"syntax error, unexpected end of file, expecting ',' or ';'",
+				$issues_submit[ $pr_item->number][0]['issue']
+			);
 
 		$this->assertEquals(
 			array(

--- a/tests/IncludesForTests.php
+++ b/tests/IncludesForTests.php
@@ -313,5 +313,17 @@ function vipgoci_unittests_output_unsuppress() {
 	}
 }
 
+/*
+ * Some versions of PHP reverse the ',' and ';'
+ * in output from PHP linting; deal with that here.
+ */
+function vipgoci_unittests_php_syntax_error_compat( $str ) {
+	return str_replace(
+		"syntax error, unexpected end of file, expecting ';' or ','",
+		"syntax error, unexpected end of file, expecting ',' or ';'",
+		$str
+	);
+}
+
 require_once( __DIR__ . '/../vip-go-ci.php' );
 

--- a/tests/LintLintDoScanTest.php
+++ b/tests/LintLintDoScanTest.php
@@ -96,9 +96,25 @@ final class LintLintDoScanTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
+		/*
+		 * Some PHP version have different
+		 * output format, this is compatibility
+		 * for that.
+		 */
+		$ret = array_map(
+			function( $str ) {
+				return str_replace(
+					'PHP Parse error:  s',
+					'Parse error: s',
+					$str
+				);
+			},
+			$ret
+		);
+
 		$this->assertEquals(
 			array(
-				"PHP Parse error:  syntax error, unexpected end of file, expecting ',' or ';' in " . $php_file_path . " on line 3",
+				"Parse error: syntax error, unexpected end of file, expecting ',' or ';' in " . $php_file_path . " on line 3",
 				'Errors parsing ' . $php_file_path
 			),
 			$ret

--- a/tests/LintLintDoScanTest.php
+++ b/tests/LintLintDoScanTest.php
@@ -112,6 +112,10 @@ final class LintLintDoScanTest extends TestCase {
 			$ret
 		);
 
+		$ret[0] = vipgoci_unittests_php_syntax_error_compat(
+			$ret[0]
+		);
+
 		$this->assertEquals(
 			array(
 				"Parse error: syntax error, unexpected end of file, expecting ',' or ';' in " . $php_file_path . " on line 3",

--- a/tests/LintLintDoScanTest.php
+++ b/tests/LintLintDoScanTest.php
@@ -96,21 +96,6 @@ final class LintLintDoScanTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		/*
-		 * Some PHP version have different
-		 * output format, this is compatibility
-		 * for that.
-		 */
-		$ret = array_map(
-			function( $str ) {
-				return str_replace(
-					'PHP Parse error:  s',
-					'Parse error: s',
-					$str
-				);
-			},
-			$ret
-		);
 
 		$ret[0] = vipgoci_unittests_php_syntax_error_compat(
 			$ret[0]
@@ -118,7 +103,7 @@ final class LintLintDoScanTest extends TestCase {
 
 		$this->assertEquals(
 			array(
-				"Parse error: syntax error, unexpected end of file, expecting ',' or ';' in " . $php_file_path . " on line 3",
+				"PHP Parse error:  syntax error, unexpected end of file, expecting ',' or ';' in " . $php_file_path . " on line 3",
 				'Errors parsing ' . $php_file_path
 			),
 			$ret

--- a/tests/LintLintGetIssuesTest.php
+++ b/tests/LintLintGetIssuesTest.php
@@ -107,6 +107,12 @@ final class LintLintGetIssuesTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
+		/* Fix PHP compatibility issue */
+		$lint_issues_parsed[3][0]['message'] = 
+			vipgoci_unittests_php_syntax_error_compat(
+				$lint_issues_parsed[3][0]['message']
+			);
+
 		$this->assertEquals(
 			array(
 				3 => array(

--- a/tests/OptionsArrayHandleTest.php
+++ b/tests/OptionsArrayHandleTest.php
@@ -53,4 +53,57 @@ final class VipgociOptionsArrayHandleTest extends TestCase {
 			$options['mytestoption']
 		);
 	}
+
+	/**
+	 * @covers ::vipgoci_option_array_handle
+	 */
+	public function testOptionsArrayHandle3() {
+		$options = array(
+			'mytestoption' => 'myvalue1,myvalue2,MYVALUE3',
+		);
+
+		vipgoci_option_array_handle(
+			$options,
+			'mytestoption',
+			'myvalue',
+			null,
+			','
+		);
+
+		$this->assertEquals(
+			array(
+				'myvalue1',
+				'myvalue2',
+				'myvalue3', // should be transformed to lower-case by default
+			),
+			$options['mytestoption']
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_option_array_handle
+	 */
+	public function testOptionsArrayHandle4() {
+		$options = array(
+			'mytestoption' => 'myvalue1,myvalue2,MYVALUE3',
+		);
+
+		vipgoci_option_array_handle(
+			$options,
+			'mytestoption',
+			'myvalue',
+			null,
+			',',
+			false
+		);
+
+		$this->assertEquals(
+			array(
+				'myvalue1',
+				'myvalue2',
+				'MYVALUE3',
+			),
+			$options['mytestoption']
+		);
+	}
 }

--- a/tests/OptionsArrayHandleTest.php
+++ b/tests/OptionsArrayHandleTest.php
@@ -94,7 +94,7 @@ final class VipgociOptionsArrayHandleTest extends TestCase {
 			'myvalue',
 			null,
 			',',
-			false
+			false // do not strtolower()
 		);
 
 		$this->assertEquals(

--- a/tests/OptionsReadEnv.php
+++ b/tests/OptionsReadEnv.php
@@ -10,12 +10,20 @@ final class VipgociOptionsReadEnvTest extends TestCase {
 		putenv(
 			'PHP_ROWNER=repo-test-owner'
 		);
+
+		putenv(
+			'PHP_ROWNER2=repo-test-owner2'
+		);
 	}
 
 	protected function tearDown() {
 		// Remove environmental variable
 		putenv(
 			'PHP_ROWNER'
+		);
+	
+		putenv(
+			'PHP_ROWNER2'
 		);
 	}
 
@@ -301,4 +309,56 @@ final class VipgociOptionsReadEnvTest extends TestCase {
 			$options
 		);
 	}
+
+	/**
+	 * @covers ::vipgoci_options_read_env
+	 */
+	public function testOptionsReadEnv7() {
+		$options = array(
+			'repo-name' => 'repo-test-name',
+			'env-options' => 'repo-owner=PHP_ROWNER,repo-owner=PHP_ROWNER2', // Should be allowed to overwrite
+		);
+
+		$options_recognized = array(
+			'repo-name:',
+			'repo-owner:',
+			'env-options:',
+		);
+
+		vipgoci_unittests_output_suppress();
+ 
+		vipgoci_option_array_handle(
+			$options,
+			'env-options',
+			array(),
+			null,
+			',',
+			false
+		);
+       
+		vipgoci_options_read_env(
+			$options,
+			$options_recognized
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		/*
+		 * Should not have read from environment.
+		 */
+		$this->assertEquals(
+			array(
+				'repo-name' => 'repo-test-name',
+				'repo-owner' => 'repo-test-owner2',
+				'env-options' => array(
+					0 => 'repo-owner=PHP_ROWNER',
+					1 => 'repo-owner=PHP_ROWNER2',
+				),
+			),
+			$options
+		);
+	}
+
+
+
 }

--- a/tests/OptionsReadEnv.php
+++ b/tests/OptionsReadEnv.php
@@ -1,0 +1,304 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class VipgociOptionsReadEnvTest extends TestCase {
+	protected function setUp() {
+		// Add environmental variable
+		putenv(
+			'PHP_ROWNER=repo-test-owner'
+		);
+	}
+
+	protected function tearDown() {
+		// Remove environmental variable
+		putenv(
+			'PHP_ROWNER'
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_options_read_env
+	 */
+	public function testOptionsReadEnv1() {
+		$options = array(
+			'repo-name' => 'repo-test-name',
+			'env-options' => 'repo-owner=PHP_ROWNER'
+		);
+
+		$options_recognized = array(
+			'repo-name:',
+			'repo-owner:',
+			'env-options:',
+		);
+
+		vipgoci_unittests_output_suppress();
+ 
+		vipgoci_option_array_handle(
+			$options,
+			'env-options',
+			array(),
+			null,
+			',',
+			false
+		);
+       
+		vipgoci_options_read_env(
+			$options,
+			$options_recognized
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		/*
+		 * Should successfully read from environment.
+		 */
+		$this->assertEquals(
+			array(
+				'repo-owner' => 'repo-test-owner',
+				'repo-name' => 'repo-test-name',
+				'env-options' => array(
+					0 => 'repo-owner=PHP_ROWNER',
+				),
+			),
+			$options
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_options_read_env
+	 */
+	public function testOptionsReadEnv2() {
+		$options = array(
+			'repo-name' => 'repo-test-name',
+			'env-options' => 'repo-owner=PHP_ROWNER500' // invalid env var
+		);
+
+		$options_recognized = array(
+			'repo-name:',
+			'repo-owner:',
+			'env-options:',
+		);
+
+		vipgoci_unittests_output_suppress();
+ 
+		vipgoci_option_array_handle(
+			$options,
+			'env-options',
+			array(),
+			null,
+			',',
+			false
+		);
+       
+		vipgoci_options_read_env(
+			$options,
+			$options_recognized
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		/*
+		 * Should not have read from environment.
+		 */
+		$this->assertEquals(
+			array(
+				'repo-name' => 'repo-test-name',
+				'env-options' => array(
+					0 => 'repo-owner=PHP_ROWNER500',
+				),
+			),
+			$options
+		);
+	}
+
+
+	/**
+	 * @covers ::vipgoci_options_read_env
+	 */
+	public function testOptionsReadEnv3() {
+		$options = array(
+			'repo-name' => 'repo-test-name',
+			// No env-options
+		);
+
+		$options_recognized = array(
+			'repo-name:',
+			'repo-owner:',
+			'env-options:',
+		);
+
+		vipgoci_unittests_output_suppress();
+ 
+		vipgoci_option_array_handle(
+			$options,
+			'env-options',
+			array(),
+			null,
+			',',
+			false
+		);
+       
+		vipgoci_options_read_env(
+			$options,
+			$options_recognized
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		/*
+		 * Should not have read from environment.
+		 */
+		$this->assertEquals(
+			array(
+				'repo-name' => 'repo-test-name',
+				'env-options' => array(
+				),
+			),
+			$options
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_options_read_env
+	 */
+	public function testOptionsReadEnv4() {
+		$options = array(
+			'repo-name' => 'repo-test-name',
+			'env-options' => 'FOO=TEST', // invalid option, is not recognized
+		);
+
+		$options_recognized = array(
+			'repo-name:',
+			'repo-owner:',
+			'env-options:',
+		);
+
+		vipgoci_unittests_output_suppress();
+ 
+		vipgoci_option_array_handle(
+			$options,
+			'env-options',
+			array(),
+			null,
+			',',
+			false
+		);
+       
+		vipgoci_options_read_env(
+			$options,
+			$options_recognized
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		/*
+		 * Should not have read from environment.
+		 */
+		$this->assertEquals(
+			array(
+				'repo-name' => 'repo-test-name',
+				'env-options' => array(
+					0 => 'FOO=TEST',
+				),
+			),
+			$options
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_options_read_env
+	 */
+	public function testOptionsReadEnv5() {
+		$options = array(
+			'repo-name' => 'repo-test-name',
+			'env-options' => 'env-options=TEST', // invalid option, is not allowed
+		);
+
+		$options_recognized = array(
+			'repo-name:',
+			'repo-owner:',
+			'env-options:',
+		);
+
+		vipgoci_unittests_output_suppress();
+ 
+		vipgoci_option_array_handle(
+			$options,
+			'env-options',
+			array(),
+			null,
+			',',
+			false
+		);
+       
+		vipgoci_options_read_env(
+			$options,
+			$options_recognized
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		/*
+		 * Should not have read from environment.
+		 */
+		$this->assertEquals(
+			array(
+				'repo-name' => 'repo-test-name',
+				'env-options' => array(
+					0 => 'env-options=TEST',
+				),
+			),
+			$options
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_options_read_env
+	 */
+	public function testOptionsReadEnv6() {
+		$options = array(
+			'repo-name' => 'repo-test-name',
+			'env-options' => 'repo-name=PHP_ROWNER', // invalid option, already specified
+		);
+
+		$options_recognized = array(
+			'repo-name:',
+			'repo-owner:',
+			'env-options:',
+		);
+
+		vipgoci_unittests_output_suppress();
+ 
+		vipgoci_option_array_handle(
+			$options,
+			'env-options',
+			array(),
+			null,
+			',',
+			false
+		);
+       
+		vipgoci_options_read_env(
+			$options,
+			$options_recognized
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		/*
+		 * Should not have read from environment.
+		 */
+		$this->assertEquals(
+			array(
+				'repo-name' => 'repo-test-name',
+				'env-options' => array(
+					0 => 'repo-name=PHP_ROWNER',
+				),
+			),
+			$options
+		);
+	}
+}

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -315,7 +315,17 @@ function vipgoci_run() {
 			"\t" . '                               on GitHub -- no comments will be submitted, etc.' . PHP_EOL .
 			"\t" . '--output=FILE                  Where to save output made from running PHPCS' . PHP_EOL .
 			"\t" . '--lint=BOOL                    Whether to do PHP linting (true/false)' . PHP_EOL .
+			PHP_EOL .
 			"\t" . '--help                         Displays this message' . PHP_EOL .
+			"\t" . '--env-options=STRING           Specifies configuration options to be read from environmental ' . PHP_EOL .
+			"\t" . '                               variables -- any variable can be specified. For instance, with ' . PHP_EOL . 
+			"\t" . '                               --env-options="repo-owner=U_ROWNER,output=U_FOUTPUT" specified ' . PHP_EOL .
+			"\t" . '                               vip-go-ci will attempt to read the --repo-owner and --output ' . PHP_EOL .
+			"\t" . '                               from the $U_ROWNER and $U_FOUTPUT environmental variables, ' . PHP_EOL .
+			"\t" . '                               respectively. This is useful for environments, such as ' . PHP_EOL .
+			"\t" . '                               TeamCity or GitHub Actions, where vital configuration. ' . PHP_EOL .
+			"\t" . '                               are specified via environmental variables. ' . PHP_EOL .
+			PHP_EOL .
 			"\t" . '--debug-level=NUMBER           Specify minimum debug-level of messages to print' . PHP_EOL .
 			"\t" . '                                -- higher number indicates more detailed debugging-messages.' . PHP_EOL .
 			"\t" . '                               Default is zero' . PHP_EOL;

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -127,9 +127,9 @@ function vipgoci_run() {
 
 	$startup_time = time();
 
-	$options = getopt(
-		null,
+	$options_recognized = 
 		array(
+			'env-options:',
 			'repo-owner:',
 			'repo-name:',
 			'commit:',
@@ -174,7 +174,34 @@ function vipgoci_run() {
 			'help',
 			'debug-level:',
 			'hashes-api:',
-	)
+		);
+
+	/*
+	 * Try to read options from command-line parameters.
+	 */
+
+	$options = getopt(
+		null,
+		$options_recognized
+	);
+
+	/*
+	 * Try to read configuration from
+	 * environmental variables.
+	 */
+
+	vipgoci_option_array_handle(
+		$options,
+		'env-options',
+		array(),
+		null,
+		',',
+		false
+	);
+
+	vipgoci_options_read_env(
+		$options,
+		$options_recognized
 	);
 
 	// Validate args


### PR DESCRIPTION
This change gives users the ability to read options from environmental variables, configurable via the command-line. This is useful for various environments, such as GitHub Actions.

New function to read options via environment: `vipgoci_options_read_env().` Will attempt to read options specified via environmental variables, but according to specifications given via command-line parameters. This effectively gives users the ability to control from which environmental variables to read options, if any.

An existing function, `vipgoci_option_array_handle()`, was improved so that one could specify if it should transform option-values to lower-case or not -- by default is transforming, to keep compatibility.
