### PR TITLE
Adding support for generic support-comments on Pull-Requests

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -1650,13 +1650,13 @@ function vipgoci_github_pr_generic_comment_submit(
 /*
  * Post a generic PR comment to GitHub.
  */
-function vipgoci_github_pr_comments_error_msg(
+function vipgoci_github_pr_comments_generic_submit(
 	$repo_owner,
 	$repo_name,
 	$github_token,
-	$commit_id,
 	$pr_number,
-	$message
+	$message,
+	$commit_id = null
 ) {
 	vipgoci_log(
 		'Posting a comment to the Pull-Request',
@@ -1683,9 +1683,15 @@ function vipgoci_github_pr_comments_error_msg(
 
 	$github_postfields = array();
 	$github_postfields['body'] =
-		$message .
-			' (commit-ID: ' . $commit_id . ').' .
-			"\n\r";
+		$message;
+
+	if ( ! empty( $commit_id ) ) {
+		$github_postfields['body'] .=
+			' (commit-ID: ' . $commit_id . ').';
+	}
+
+	$github_postfields['body'] .=
+		"\n\r";
 
 	vipgoci_github_post_url(
 		$github_url,
@@ -1821,6 +1827,109 @@ function vipgoci_github_pr_generic_comment_delete(
 		$github_token,
 		true
 	);
+}
+
+/*
+ * Post generic comment to each Pull-Request
+ * that has target branch that matches the
+ * options given, but only if the same generic
+ * comment has not been posted before. Uses a
+ * comment given by one of the options.
+ */
+function vipgoci_github_pr_generic_support_comment(
+	$options,
+	$prs_implicated
+) {
+	vipgoci_log(
+		'Posting support-comments on Pull-Requests',
+		array(
+			'post-generic-pr-support-comments' =>
+				$options['post-generic-pr-support-comments'],
+
+			'post-generic-pr-support-comments-string' =>
+				$options['post-generic-pr-support-comments-string'],
+
+			'post-generic-pr-support-comments-branches' =>
+				$options['post-generic-pr-support-comments-branches']
+		)
+	);
+
+
+	foreach(
+		$prs_implicated as $pr_item
+	) {
+		/*
+		 * If not one of the target-branches,
+		 * skip this PR.
+		 */
+		if ( in_array(
+			$pr_item->base->ref,
+			$options['post-generic-pr-support-comments-branches'],
+			true
+		) === false ) {
+			vipgoci_log(
+				'Not posting support-comment to PR, not in list of target branches',
+				array(
+					'pr_number'	=> $pr_item->number,
+					'pr_base_ref'	=> $pr_item->base->ref,
+					'post-generic-pr-support-comments-branches' =>
+						$options['post-generic-pr-support-comments-branches'],
+				)
+			);
+
+			continue;
+		}
+
+		/*
+		 * Check if the comment we are set to
+		 * post already exists, and if so, do
+		 * not post anything.
+		 */
+
+		$existing_comments = vipgoci_github_pr_generic_comments_get(
+			$options['repo-owner'],
+			$options['repo-name'],
+			$pr_item->number,
+			$options['token']
+		);
+
+		$comment_exists_already = false;
+
+		foreach(
+			$existing_comments as
+				$existing_comment_item
+		) {
+
+			if ( strpos(
+				$existing_comment_item->body,
+				$options['post-generic-pr-support-comments-string']
+			) !== false ) {
+				$comment_exists_already = true;
+			}	
+		}
+
+		if ( true === $comment_exists_already ) {
+			vipgoci_log(
+				'Not submitting support-comment to Pull-Request as it already exists',
+				array(
+					'pr_number'	=> $pr_item->number,
+				)
+			);
+
+			continue;
+		}
+
+		/*
+		 * All checks successful, post comment.
+		 */
+		vipgoci_github_pr_comments_generic_submit(
+			$options['repo-owner'],
+			$options['repo-name'],
+			$options['token'],
+			$pr_item->number,
+			$options['post-generic-pr-support-comments-string']
+		);
+	}
 }
 
 /*
@@ -2381,13 +2490,13 @@ function vipgoci_github_pr_review_submit(
 		 * let humans know that there was a problem.
 		 */
 		if ( -1 === $github_post_res ) {
-			vipgoci_github_pr_comments_error_msg(
+			vipgoci_github_pr_comments_generic_submit(
 				$repo_owner,
 				$repo_name,
 				$github_token,
-				$commit_id,
 				$pr_number,
-				VIPGOCI_GITHUB_ERROR_STR
+				VIPGOCI_GITHUB_ERROR_STR,
+				$commit_id
 			);
 		}
 	}

--- a/github-api.php
+++ b/github-api.php
@@ -1648,7 +1648,8 @@ function vipgoci_github_pr_generic_comment_submit(
 }
 
 /*
- * Post a generic PR comment to GitHub.
+ * Post a generic PR comment to GitHub. Will
+ * include a commit_id in the comment if provided.
  */
 function vipgoci_github_pr_comments_generic_submit(
 	$repo_owner,
@@ -1659,12 +1660,12 @@ function vipgoci_github_pr_comments_generic_submit(
 	$commit_id = null
 ) {
 	vipgoci_log(
-		'Posting a comment to the Pull-Request',
+		'Posting a comment to a Pull-Request',
 		array(
 			'repo_owner' => $repo_owner,
 			'repo_name' => $repo_name,
-			'commit_id' => $commit_id,
 			'pr_number' => $pr_number,
+			'commit_id' => $commit_id,
 			'message' => $message,
 		),
 		0,

--- a/github-api.php
+++ b/github-api.php
@@ -1863,11 +1863,19 @@ function vipgoci_github_pr_generic_support_comment(
 		 * If not one of the target-branches,
 		 * skip this PR.
 		 */
-		if ( in_array(
-			$pr_item->base->ref,
-			$options['post-generic-pr-support-comments-branches'],
-			true
-		) === false ) {
+		if (
+			( in_array(
+				'any',
+				$options['post-generic-pr-support-comments-branches'],
+				true
+			) === false )
+			&&
+			( ( in_array(
+				$pr_item->base->ref,
+				$options['post-generic-pr-support-comments-branches'],
+				true
+			) === false ) )
+		) {
 			vipgoci_log(
 				'Not posting support-comment to PR, not in list of target branches',
 				array(

--- a/github-api.php
+++ b/github-api.php
@@ -1879,6 +1879,8 @@ function vipgoci_github_pr_generic_support_comment(
 			vipgoci_log(
 				'Not posting support-comment to PR, not in list of target branches',
 				array(
+					'repo-owner'	=> $options['repo-owner'],
+					'repo-name'	=> $options['repo-name'],
 					'pr_number'	=> $pr_item->number,
 					'pr_base_ref'	=> $pr_item->base->ref,
 					'post-generic-pr-support-comments-branches' =>

--- a/tests/GitHubPrGenericSupportCommentTest.php
+++ b/tests/GitHubPrGenericSupportCommentTest.php
@@ -63,6 +63,12 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		$this->options['commit'] =
 			$this->options['test-github-pr-generic-support-comment-1'];
 
+		if ( empty( $this->current_user_info ) ) {
+			$this->current_user_info = vipgoci_github_authenticated_user_get(
+				$this->options['github-token']
+			);
+		}
+
 		$this->_clearOldSupportComments();
 	}
 
@@ -140,10 +146,6 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 	protected function _clearOldSupportComments() {
 		$prs_implicated = $this->_getPrsImplicated();
 
-		$current_user_info = vipgoci_github_authenticated_user_get(
-			$this->options['github-token']
-		);
-
 		foreach( $prs_implicated as $pr_item ) {
 			// Check if any comments already exist
 			$pr_comments = $this->_getPrGenericComments(
@@ -151,7 +153,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			);
 
 			foreach ( $pr_comments as $pr_comment ) {
-				if ( $pr_comment->user->login !== $current_user_info->login ) {
+				if ( $pr_comment->user->login !== $this->current_user_info->login ) {
 					continue;
 				}
 
@@ -181,14 +183,10 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 	protected function _countSupportCommentsFromUs(
 		$pr_comments
 	) {	
-		$current_user_info = vipgoci_github_authenticated_user_get(
-			$this->options['github-token']
-		);
-
 		$valid_comments_found = 0;
 
 		foreach( $pr_comments as $pr_comment ) {
-			if ( $pr_comment->user->login !== $current_user_info->login ) {
+			if ( $pr_comment->user->login !== $this->current_user_info->login ) {
 				continue;
 			}
 

--- a/tests/GitHubPrGenericSupportCommentTest.php
+++ b/tests/GitHubPrGenericSupportCommentTest.php
@@ -1,0 +1,462 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class GitHubPrGenericSupportCommentTest extends TestCase {
+	var $options_git = array(
+		'repo-owner'	=> null,
+		'repo-name'	=> null,
+	);
+
+	var $options_git_repo_tests = array(
+		'test-github-pr-generic-support-comment-1'	=> null,
+	);
+
+	protected function setUp() {
+		/*
+		 * Many of the functions called
+		 * make use of caching, clear the cache
+		 * so the testing will not rely on
+		 * old data by accident.
+		 */
+		vipgoci_cache(
+			VIPGOCI_CACHE_CLEAR
+		);
+
+		vipgoci_unittests_get_config_values(
+			'git',
+			$this->options_git
+		);
+
+		vipgoci_unittests_get_config_values(
+			'git-repo-tests',
+			$this->options_git_repo_tests
+		);
+
+		$this->options = array();
+
+		$this->options['token'] =
+		$this->options['github-token'] =
+			vipgoci_unittests_get_config_value(
+				'git-secrets',
+				'github-token',
+				true // Fetch from secrets file
+			);
+
+		// We set this variable, but it has no functional implications
+		$this->options['post-generic-pr-support-comments'] = true;
+
+		$this->options['post-generic-pr-support-comments-string'] =
+			'This is a generic support message from `vip-go-ci`. We hope this is useful.';
+
+		$this->options['post-generic-pr-support-comments-branches'] =
+			array();
+
+		$this->options = array_merge(
+			$this->options_git,
+			$this->options_git_repo_tests,
+			$this->options,
+		);
+
+		$this->options['commit'] =
+			$this->options['test-github-pr-generic-support-comment-1'];
+
+		$this->_clearOldSupportComments();
+	}
+
+	protected function tearDown() {
+		$this->_clearOldSupportComments();
+
+		$this->options = null;
+		$this->options_git = null;
+		$this->options_git_repo_tests = null;
+	}
+
+	/*
+	 * Get Pull-Requests implicated.
+	 */
+	protected function _getPrsImplicated() {
+		return vipgoci_github_prs_implicated(
+			$this->options['repo-owner'],
+			$this->options['repo-name'],
+			$this->options['commit'],
+			$this->options['github-token'],
+			array()
+		);
+	}
+
+	/*
+	 * Get generic comments made to a Pull-Request
+	 * from GitHub, uncached.
+	 */
+	protected function _getPrGenericComments(
+		$pr_number
+	) {
+		$pr_comments_ret = array();
+
+		$page = 1;
+		$per_page = 100;
+
+		do {
+			$github_url =
+				VIPGOCI_GITHUB_BASE_URL . '/' .
+				'repos/' .
+				rawurlencode( $this->options['repo-owner'] ) . '/' .
+				rawurlencode( $this->options['repo-name'] ) . '/' .
+				'issues/' .
+				rawurlencode( $pr_number ) . '/' .
+				'comments' .
+				'?page=' . rawurlencode( $page ) . '&' .
+				'per_page=' . rawurlencode( $per_page );
+
+
+	                $pr_comments_raw = json_decode(
+	                        vipgoci_github_fetch_url(
+        	                        $github_url,
+                	                $this->options['github-token']
+                        	)
+	                );
+
+	                foreach ( $pr_comments_raw as $pr_comment ) {
+	                        $pr_comments_ret[] = $pr_comment;
+        	        }
+
+	                $page++;
+		} while ( count( $pr_comments_raw ) >= $per_page );
+
+		return $pr_comments_ret;
+	}
+
+	/*
+	 * Clear away any old support comments
+	 * left behind by us. Do this by looping
+	 * through any Pull-Requests implicated and
+	 * check if each one has any comments, then
+	 * remove them if they were made by us and
+	 * are support comments.
+	 */
+	protected function _clearOldSupportComments() {
+		$prs_implicated = $this->_getPrsImplicated();
+
+		$current_user_info = vipgoci_github_authenticated_user_get(
+			$this->options['github-token']
+		);
+
+		foreach( $prs_implicated as $pr_item ) {
+			// Check if any comments already exist
+			$pr_comments = $this->_getPrGenericComments(
+				$pr_item->number
+			);
+
+			foreach ( $pr_comments as $pr_comment ) {
+				if ( $pr_comment->user->login !== $current_user_info->login ) {
+					continue;
+				}
+
+				// Check if the comment contains the support-comment
+				if ( strpos(
+					$pr_comment->body,
+					$this->options['post-generic-pr-support-comments-string']
+				) !== 0 ) {
+					continue;
+				}
+
+				// Remove comment, submitted by us, is support comment.
+				vipgoci_github_pr_generic_comment_delete(
+					$this->options['repo-owner'],
+					$this->options['repo-name'],
+					$this->options['github-token'],
+					$pr_comment->id
+				);
+			}
+		}
+	}
+
+	/*
+	 * Count number of support comments posted
+	 * by the current token-holder.
+	 */
+	protected function _countSupportCommentsFromUs(
+		$pr_comments
+	) {	
+		$current_user_info = vipgoci_github_authenticated_user_get(
+			$this->options['github-token']
+		);
+
+		$valid_comments_found = 0;
+
+		foreach( $pr_comments as $pr_comment ) {
+			if ( $pr_comment->user->login !== $current_user_info->login ) {
+				continue;
+			}
+
+			// Check if the comment contains the support-comment
+			if ( strpos(
+				$pr_comment->body,
+				$this->options['post-generic-pr-support-comments-string']
+			) !== 0 ) {
+				continue;
+			}
+
+			// We have found support comment posted by us
+			$valid_comments_found++;
+		}
+
+		return $valid_comments_found;
+	}
+
+	/**
+	 * @covers ::vipgoci_github_pr_generic_support_comment
+	 */
+	public function testPostingWorksAnyBranch() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array(),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		// Configure branches we can post against
+		$this->options['post-generic-pr-support-comments-branches'] =
+			array( 'any' );
+
+		// Get Pull-Requests
+        	$prs_implicated = $this->_getPrsImplicated();
+
+		// Check we have at least one PR
+		$this->assertTrue(
+			count( $prs_implicated ) > 0
+		);
+
+		// Try to submit support comment
+		vipgoci_github_pr_generic_support_comment(
+			$this->options,
+			$prs_implicated
+		);
+
+		// Check if commenting succeeded
+		foreach( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->_getPrGenericComments(
+				$pr_item->number
+			);
+
+			$this->assertTrue(
+				count( $pr_comments ) > 0
+			);
+
+			$this->assertEquals(
+				1,
+				$this->_countSupportCommentsFromUs(
+					$pr_comments
+				)
+			);
+		}
+
+		/*
+		 * vipgoci_github_pr_generic_support_comment() will
+		 * call vipgoci_github_pr_generic_comments_get() that
+		 * caches results, causing it to give back wrong
+		 * results when called again. Clear the internal cache
+		 * here to circumvent this.
+		 */
+
+		vipgoci_cache(
+			VIPGOCI_CACHE_CLEAR
+		);
+		
+		// Try re-posting
+		vipgoci_github_pr_generic_support_comment(
+			$this->options,
+			$prs_implicated
+		);
+
+		// And make sure it did not succeed
+		foreach( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->_getPrGenericComments(
+				$pr_item->number
+			);
+
+			$this->assertTrue(
+				count( $pr_comments ) > 0
+			);
+
+			$this->assertEquals(
+				1,
+				$this->_countSupportCommentsFromUs(
+					$pr_comments
+				)
+			);
+		}
+	}
+
+	/**
+	 * @covers ::vipgoci_github_pr_generic_support_comment
+	 */
+	public function testPostingWorksSpecificBranch() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array(),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		// Configure branches we allow posting against
+		$this->options['post-generic-pr-support-comments-branches'] =
+			array( 'master' );
+
+		// Get Pull-Requests
+        	$prs_implicated = $this->_getPrsImplicated();
+
+		// Check we have at least one PR
+		$this->assertTrue(
+			count( $prs_implicated ) > 0
+		);
+
+		// Try to submit support comment
+		vipgoci_github_pr_generic_support_comment(
+			$this->options,
+			$prs_implicated
+		);
+
+		// Check if commenting succeeded
+		foreach( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->_getPrGenericComments(
+				$pr_item->number
+			);
+
+			$this->assertTrue(
+				count( $pr_comments ) > 0
+			);
+
+			$this->assertEquals(
+				1,
+				$this->_countSupportCommentsFromUs(
+					$pr_comments
+				)
+			);
+		}
+
+		/*
+		 * vipgoci_github_pr_generic_support_comment() will
+		 * call vipgoci_github_pr_generic_comments_get() that
+		 * caches results, causing it to give back wrong
+		 * results when called again. Clear the internal cache
+		 * here to circumvent this.
+		 */
+
+		vipgoci_cache(
+			VIPGOCI_CACHE_CLEAR
+		);
+		
+		// Try re-posting
+		vipgoci_github_pr_generic_support_comment(
+			$this->options,
+			$prs_implicated
+		);
+
+		// And make sure it did not succeed
+		foreach( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->_getPrGenericComments(
+				$pr_item->number
+			);
+
+			$this->assertTrue(
+				count( $pr_comments ) > 0
+			);
+
+			$this->assertEquals(
+				1,
+				$this->_countSupportCommentsFromUs(
+					$pr_comments
+				)
+			);
+		}
+	}
+
+	/**
+	 * @covers ::vipgoci_github_pr_generic_support_comment
+	 */
+	public function testPostingSkippedInvalidBranch() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array(),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		// Configure branches to post against
+		$this->options['post-generic-pr-support-comments-branches'] =
+			array( 'myinvalidbranch0xfff' );
+
+		// Get Pull-Requests
+        	$prs_implicated = $this->_getPrsImplicated();
+
+		// Check we have at least one PR
+		$this->assertTrue(
+			count( $prs_implicated ) > 0
+		);
+
+		// Try to submit support comment
+		vipgoci_github_pr_generic_support_comment(
+			$this->options,
+			$prs_implicated
+		);
+
+		// Check if commenting succeeded -- should not have, as branch is invalid
+		foreach( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->_getPrGenericComments(
+				$pr_item->number
+			);
+
+			$this->assertEquals(
+				0,
+				$this->_countSupportCommentsFromUs(
+					$pr_comments
+				)
+			);
+		}
+
+		/*
+		 * vipgoci_github_pr_generic_support_comment() will
+		 * call vipgoci_github_pr_generic_comments_get() that
+		 * caches results, causing it to give back wrong
+		 * results when called again. Clear the internal cache
+		 * here to circumvent this.
+		 */
+
+		vipgoci_cache(
+			VIPGOCI_CACHE_CLEAR
+		);
+		
+		// Try re-posting
+		vipgoci_github_pr_generic_support_comment(
+			$this->options,
+			$prs_implicated
+		);
+
+		// And make sure it did not succeed the second time
+		foreach( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->_getPrGenericComments(
+				$pr_item->number
+			);
+
+			$this->assertEquals(
+				0,
+				$this->_countSupportCommentsFromUs(
+					$pr_comments
+				)
+			);
+		}
+	}
+}

--- a/unittests.ini
+++ b/unittests.ini
@@ -62,6 +62,7 @@ pr-test-github-pr-reviews-get-1=11
 commit-test-github-pr-reviews-get-1=a23730447e46564d72b75d12d6bbf86737717c5f
 test-github-pr-reviews-event-get-pr-number=14
 test-github-pr-reviews-event-get-username=gudmdharalds
+test-github-pr-generic-support-comment-1=37a5be155aa03cf61f13842ab46e036b62d3cecb
 
 [labels]
 labels-pr-to-modify=12

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -262,15 +262,16 @@ function vipgoci_run() {
 			"\t" . '--informational-url=STRING     URL to documentation on what this bot does. Should ' . PHP_EOL .
 			"\t" . '                               start with https:// or https:// ' . PHP_EOL .
 			PHP_EOL .
-			"\t" . '--post-generic-pr-support-comments=BOOL            Post generic comment to Pull-Requests with ' . PHP_EOL .
-			"\t" . '                                                   support-related information for users. Will ' . PHP_EOL .
+			"\t" . '--post-generic-pr-support-comments=BOOL            Whether to post generic comment to Pull-Requests ' . PHP_EOL .
+			"\t" . '                                                   with support-related information for users. Will ' . PHP_EOL .
 			"\t" . '                                                   be posted only once per Pull-Request. ' . PHP_EOL .
 			"\t" . '--post-generic-pr-support-comments-string=STRING   String to use when posting support-comment. ' . PHP_EOL .
 			"\t" . '--post-generic-pr-support-comments-branches=ARRAY  Only post support-comments to Pull-Requests ' . PHP_EOL .
-			"\t" . '                                                   with these target branches. The parameter can  ' . PHP_EOL .
-			"\t" . '                                                   be a string with one value, or comma separated. ' . PHP_EOL .
-			"\t" . '                                                   A single "any" value will cause the message to ' . PHP_EOL .
-			"\t" . '                                                   be posted to any branch.' . PHP_EOL .
+			"\t" . '                                                   with the target branches specified. The ' . PHP_EOL .
+			"\t" . '                                                   parameter can be a string with one value, or ' . PHP_EOL .
+			"\t" . '                                                   comma separated. A single "any" value will ' . PHP_EOL .
+			"\t" . '                                                   cause the message to be posted to any ' . PHP_EOL .
+			"\t" . '                                                   branch.' . PHP_EOL .
 			PHP_EOL .
 			"\t" . '--phpcs=BOOL                   Whether to run PHPCS (true/false)' . PHP_EOL .
 			"\t" . '--phpcs-path=FILE              Full path to PHPCS script' . PHP_EOL .

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -269,6 +269,8 @@ function vipgoci_run() {
 			"\t" . '--post-generic-pr-support-comments-branches=ARRAY  Only post support-comments to Pull-Requests ' . PHP_EOL .
 			"\t" . '                                                   with these target branches. The parameter can  ' . PHP_EOL .
 			"\t" . '                                                   be a string with one value, or comma separated. ' . PHP_EOL .
+			"\t" . '                                                   A single "any" value will cause the message to ' . PHP_EOL .
+			"\t" . '                                                   be posted to any branch.' . PHP_EOL .
 			PHP_EOL .
 			"\t" . '--phpcs=BOOL                   Whether to run PHPCS (true/false)' . PHP_EOL .
 			"\t" . '--phpcs-path=FILE              Full path to PHPCS script' . PHP_EOL .
@@ -704,9 +706,9 @@ function vipgoci_run() {
 	vipgoci_option_bool_handle( $options, 'post-generic-pr-support-comments', 'false' );
 
 	$options['post-generic-pr-support-comments-string'] =
-		ltrim( rtrim(
+		trim(
 			$options['post-generic-pr-support-comments-string']
-		) );
+		);
 
 	vipgoci_option_array_handle(
 		$options,


### PR DESCRIPTION
When configured via options parameters, `vip-go-ci` will post generic comments to Pull-Requests with useful information. The comment is configurable via options, and branches the Pull-Requests have to be created against also. 

TODO:
- [ ] Unit-tests
- [ ] Documentation update in `README.md`
- [x] Documentation update in `--help` message