### PR TITLE
Invalid INI sections specified for optional GitHub token fetching

### DIFF
--- a/tests/1StatsStatsPerFileTest.php
+++ b/tests/1StatsStatsPerFileTest.php
@@ -34,8 +34,8 @@ final class StatsStatsPerFileTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'github-token',
 				'git-secrets',
+				'github-token',
 				true // Fetch from secrets file
 			);
 	}

--- a/tests/9LintLintScanCommitTest.php
+++ b/tests/9LintLintScanCommitTest.php
@@ -36,7 +36,7 @@ final class LintLintScanCommitTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);

--- a/tests/ApFileTypesTest.php
+++ b/tests/ApFileTypesTest.php
@@ -33,7 +33,7 @@ final class ApFileTypesTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);

--- a/tests/ApHashesApiFileApprovedTest.php
+++ b/tests/ApHashesApiFileApprovedTest.php
@@ -33,7 +33,7 @@ final class ApHashesApiFileApprovedTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);

--- a/tests/ApHashesApiScanCommitTest.php
+++ b/tests/ApHashesApiScanCommitTest.php
@@ -35,7 +35,7 @@ final class ApHashesApiScanCommitTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);

--- a/tests/ApSvgFilesTest.php
+++ b/tests/ApSvgFilesTest.php
@@ -46,7 +46,7 @@ final class ApSvgFilesTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);

--- a/tests/GitHubDiffsFetchTest.php
+++ b/tests/GitHubDiffsFetchTest.php
@@ -38,7 +38,7 @@ final class GitHubDiffsFetchTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);

--- a/tests/GitHubFetchCommitInfoTest.php
+++ b/tests/GitHubFetchCommitInfoTest.php
@@ -34,7 +34,7 @@ final class GitHubFetchCommitInfoTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);

--- a/tests/GitHubLabelsFetchTest.php
+++ b/tests/GitHubLabelsFetchTest.php
@@ -34,7 +34,7 @@ final class GitHubLabelsFetchTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);

--- a/tests/GitHubPrGenericCommentsGetTest.php
+++ b/tests/GitHubPrGenericCommentsGetTest.php
@@ -32,7 +32,7 @@ final class GitHubPrGenericCommentsGetTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);

--- a/tests/GitHubPrReviewsCommentsGetByPrTest.php
+++ b/tests/GitHubPrReviewsCommentsGetByPrTest.php
@@ -32,7 +32,7 @@ final class GitHubPrReviewsCommentsGetByPrTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);

--- a/tests/GitHubPrReviewsCommentsGetTest.php
+++ b/tests/GitHubPrReviewsCommentsGetTest.php
@@ -32,7 +32,7 @@ final class GitHubPrReviewsCommentsGet extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);

--- a/tests/GitHubPrReviewsGetTest.php
+++ b/tests/GitHubPrReviewsGetTest.php
@@ -32,7 +32,7 @@ final class GitHubPrReviewsGetTest extends TestCase {
 
 		$this->options[ 'github-token' ] =
 			vipgoci_unittests_get_config_value(
-				'git',
+				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file
 			);


### PR DESCRIPTION
Invalid INI sections were specified for optional GitHub token fetching. This had no performance implications, as these tokens were optional. However, the calls with with no tokens amounted to anonymous calls to the GitHub API, and those have a much lower quota. This patch fixes this issue.