### PR TITLE
Feature: Add support level label to Pull-Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ To run the unitests for `vip-go-ci`, you will need to install `phpunit` and any 
 
 By using this command, you will run the whole test-suite and get feeback on any errors or warnings. 
 
-Note that by default, some tests will be skipped, as these will require a GitHub token to write to GitHub in order to complete, or access to the hashes-to-hashes database. To enable the testing of these, you need to set up a `unittests-secrets.ini` file in the root of the repository. It should include the following fields:
+Note that by default, some tests will be skipped, as these will require a GitHub token to write to GitHub in order to complete, need access to the hashes-to-hashes database, or to a repo-meta API. To enable the testing of these, you need to set up a `unittests-secrets.ini` file in the root of the repository. It should include the following fields:
 
 ```
 [auto-approvals-secrets]
@@ -434,6 +434,14 @@ github-token= ; Personal access token from GitHub
 team-id=      ; Team ID to test if present, this is a numeric
 team-slug=    ; Team slug to test if present, is a string. Should be referencing the same team as team-id.
 org-name=     ; GitHub organisation name to use in testing
+
+[repo-meta-api-secrets]
+repo-meta-api-base-url=         ; URL to base of meta API
+repo-meta-api-user-id=          ; User ID for the meta API
+repo-meta-api-access-token=     ; Access token for the meta API
+repo-owner=                     ; Repository owner for the test, should be found in meta API
+repo-name=                      ; Repository name for the test
+support-tier-name=              ; Name of support tier given by meta API
 ```
 
 This file is not included, and needs to be configured manually. When that is complete, the tests can be re-run.

--- a/README.md
+++ b/README.md
@@ -401,6 +401,14 @@ The feature can be used in the following fashion:
 
 The last parameter can be specified as 'any' to allow posting to any branch.
 
+### Support labels
+
+`vip-go-ci` can put labels on Pull-Requests indicating level of support provided. With this feature configured, `vip-go-ci` will attach a label to every new Pull-Request that does not have it. For this to work, it will need access to a `repo-meta API` that needs to be available and `vip-go-ci` has to be configured to work with.
+
+This feature can be used in the following way:
+
+> ./vip-go-ci.php --set-support-level-label=true --repo-meta-api-base-url="http://myrepometa-api.mycompany.is" --repo-meta-api-user-id=7334005 --repo-meta-api-access-token="MY-TOKEN"
+
 ### IRC support
 
 `vip-go-ci` supports posting certain information to a HTTP API that will eventually relay the information to a IRC channel. This can of course be any IRC-like system, as long as the HTTP API behaves the same. This is useful if you need to have some information submitted to a monitoring system, for instance.

--- a/support-level-label.php
+++ b/support-level-label.php
@@ -1,0 +1,239 @@
+<?php
+
+/*
+ * Fetch meta-data for repository from
+ * repo meta API, cache the results in memory.
+ */
+function vipgoci_repo_meta_api_data_fetch(
+) {
+	return array();
+}
+
+/*
+ * Attach support level label to
+ * Pull-Request, if configured to 
+ * do so. Will fetch information
+ * about support-level from an API.
+ */
+function vipgoci_support_level_label_set(
+	$options
+) {
+
+	if ( true !== $options['set-support-level-label'] ) {
+		vipgoci_log(
+			'Not attaching support label to Pull-Requests ' .
+				'implicated by commit, as not configured ' .
+				'to do so',
+			array(
+				'set_support_level_label'
+					=> $options['set-support-level-label']
+			)
+		);
+
+		return;
+	}
+
+	vipgoci_log(
+		'Attaching support-level label to Pull-Requests implicated by commit',
+		array(
+			'repo_owner'		=> $options['repo-owner'],
+			'repo_name'		=> $options['repo-name'],
+			'commit'		=> $options['commit'],
+		)
+	);
+
+	/*
+	 * Get information from API about the
+	 * repository, including support level.
+	 */
+	$repo_meta_data = vipgoci_repo_meta_api_data_fetch(
+	);
+
+	/*
+	 * Construct support-level label
+	 * from information found in API,
+	 * if available.
+	 */
+	$support_label_prefix = '[Support Level]';
+	$support_label_from_api = '';
+
+	if (
+		( ! empty(
+			$repo_meta_data['data']
+		) )
+		&&
+		( ! empty(
+			$repo_meta_data['data'][0]['support_tier']
+		) )
+	) {
+		/*
+		 * Construct the label itself
+		 * from prefix and support level
+		 * found in API.
+		 */
+		$support_label_from_api =
+			$support_label_prefix .
+			' ' .
+			ucfirst(
+				$repo_meta_data['data'][0]['support_tier']
+			);
+	}
+
+	/*
+	 * No support label found in API, so
+	 * do not do anything.
+	 */
+	if ( empty( $support_label_from_api ) ) {
+		vipgoci_log(
+			'Found no valid support level in API, so not ' .
+				'attaching any label (nor removing)',
+			array(
+				'repo_owner'		=> $options['repo-owner'],
+				'repo_name'		=> $options['repo-name'],
+				'support_tier'		=> (
+					isset( $repo_meta_data['data'][0]['support_tier'] ) ?
+					$repo_meta_data['data'][0]['support_tier'] :
+					''
+				),
+			)
+		);
+
+		return;
+	}
+
+	else {
+		vipgoci_log(
+			'Found valid support level in API, making alterations as needed',
+			array(
+				'repo_owner'			=> $options['repo-owner'],
+				'repo_name'			=> $options['repo-name'],
+				'support_tier'			=> (
+					isset( $repo_meta_data['data'][0]['support_tier'] ) ?
+					$repo_meta_data['data'][0]['support_tier'] :
+					''
+				),
+				'support_label_from_api'	=> $support_label_from_api,
+			)
+		);
+	}
+
+	/*
+	 * Get Pull-Requests associated with the
+	 * commit and repository.
+	 */
+	$prs_implicated = vipgoci_github_prs_implicated(
+		$options['repo-owner'],
+		$options['repo-name'],
+		$options['commit'],
+		$options['token'],
+		$options['branches-ignore']
+	);
+
+	/*
+	 * Loop through each Pull-Request,
+	 * remove any invalid support levels
+	 * and add a correct one.
+	 *
+	 * If everything is correct, will not
+	 * make any alterations.
+	 */
+	foreach ( $prs_implicated as $pr_item ) {
+		$pr_correct_support_label_found = false;
+
+		/*
+		 * Get labels for PR.
+		 */
+		$pr_item_labels =
+			vipgoci_github_labels_get(
+				$options['repo-owner'],
+				$options['repo-name'],
+				$options['token'],
+				$pr_item->number
+			);
+
+
+		/*
+		 * If no found, substitute boolean for empty array.
+		 */
+		if ( false === $pr_item_labels ) {
+			$pr_item_labels = array();
+		}
+
+		/*
+		 * Loop through each label found for
+		 * Pull-Request, figure out if is support
+		 * label, remove if not the same as is supposed
+		 * to be set.
+		 */
+		foreach(
+			$pr_item_labels as $pr_item_label
+		) {
+			if ( strpos(
+				$pr_item_label->name,
+				$support_label_prefix . ' '
+			) !== 0 ) {
+				/*
+				 * Not support level
+				 * label, skip.
+				 */
+				continue;
+			}
+
+			if ( $pr_item_label->name === $support_label_from_api ) {
+				$pr_correct_support_label_found = true;
+
+				/*
+				 * We found correct support label
+				 * associated, note that for later
+				 * use.
+				 */
+				continue;
+			}
+
+			/*
+			 * All conditions met; is support level
+			 * label, but incorrect one, so remove label.
+			 */
+			vipgoci_github_label_remove_from_pr(
+				$options['repo-owner'],
+				$options['repo-name'],
+				$options['token'],
+				$pr_item->number,
+				$pr_item_label->name,
+				false
+			);
+		}
+
+		/*
+		 * Add support label if found in API but
+		 * not if correct one is associated on
+		 * GitHub already.
+		 */
+		if ( $pr_correct_support_label_found === true ) {
+			vipgoci_log(
+				'Correct support label already attached to Pull-Request, skipping',
+				array(
+					'repo_owner'			=> $options['repo-owner'],
+					'repo_name'			=> $options['repo-name'],
+					'support_label_from_api'	=> $support_label_from_api,
+				)
+			);
+		}
+
+		/*
+		 * A support label was found in API and
+		 * a correct one was not associated on
+		 * GitHub already, so add one.
+		 */
+		else if ( $pr_correct_support_label_found === false ) {
+			vipgoci_github_label_add_to_pr(
+				$options['repo-owner'],
+				$options['repo-name'],
+				$options['token'],
+				$pr_item->number,
+				$support_label_from_api,
+				false
+			);
+		}
+	}
+}

--- a/tests/IncludesForTests.php
+++ b/tests/IncludesForTests.php
@@ -51,14 +51,15 @@ function vipgoci_unittests_get_config_value(
 	return null;
 }
 
-function vipgoci_unittests_get_config_values( $section, &$config_arr ) {
+function vipgoci_unittests_get_config_values( $section, &$config_arr, $secret_file = false ) {
 	foreach (
 		array_keys( $config_arr ) as $config_key
 	) {
 		$config_arr[ $config_key ] =
 			vipgoci_unittests_get_config_value(
 				$section,
-				$config_key
+				$config_key,
+				$secret_file
 			);
 
 		if ( empty( $config_arr[ $config_key ] ) ) {

--- a/tests/SupportLevelLabelMetaApiDataFetchTest.php
+++ b/tests/SupportLevelLabelMetaApiDataFetchTest.php
@@ -1,0 +1,89 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class SupportLevelLabelMetaApiDataFetchTest extends TestCase {
+	var $options_meta_api = array(
+		'api-base-url'		=> null,
+		'api-user-id'		=> null,
+		'api-access-token'	=> null,
+
+		'repo-owner'		=> null,
+		'repo-name'		=> null,
+
+		'support-tier-name'	=> null,
+	);
+
+	protected function setUp() {
+		vipgoci_unittests_get_config_values(
+			'repo-meta-api',
+			$this->options_meta_api,
+			true
+		);
+
+		$this->options = $this->options_meta_api;
+	}
+
+	protected function tearDown() {
+		$this->options_meta_api = null;
+		$this->options = null;
+	}
+
+	/**
+	 * @covers ::vipgoci_repo_meta_api_data_fetch
+	 */
+	public function testMetaApiDataFetch() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'api-user-id', 'api-access-token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$repo_meta_data = vipgoci_repo_meta_api_data_fetch(
+			$this->options['api-base-url'],
+			$this->options['api-user-id'],
+			$this->options['api-access-token'],
+			$this->options['repo-owner'],
+			$this->options['repo-name']
+		);
+
+		$this->assertTrue(
+			count(
+				$repo_meta_data['data']
+			) > 0
+		);
+
+		$this->assertTrue(
+			( ! empty(
+				$repo_meta_data['data'][0]['support_tier']
+			) )
+		);
+
+		$this->assertEquals(
+			$this->options['support-tier-name'],
+			$repo_meta_data['data'][0]['support_tier']
+		);
+
+		/*
+		 * Re-test due to caching.
+		 */
+		$repo_meta_data_2 = vipgoci_repo_meta_api_data_fetch(
+			$this->options['api-base-url'],
+			$this->options['api-user-id'],
+			$this->options['api-access-token'],
+			$this->options['repo-owner'],
+			$this->options['repo-name']
+		);
+
+		$this->assertEquals(
+			$repo_meta_data,
+			$repo_meta_data_2
+		);
+	}
+}

--- a/tests/SupportLevelLabelMetaApiDataFetchTest.php
+++ b/tests/SupportLevelLabelMetaApiDataFetchTest.php
@@ -5,29 +5,29 @@ require_once( __DIR__ . '/IncludesForTests.php' );
 use PHPUnit\Framework\TestCase;
 
 final class SupportLevelLabelMetaApiDataFetchTest extends TestCase {
-	var $options_meta_api = array(
-		'api-base-url'		=> null,
-		'api-user-id'		=> null,
-		'api-access-token'	=> null,
+	var $options_meta_api_secrets = array(
+		'repo-meta-api-base-url'	=> null,
+		'repo-meta-api-user-id'		=> null,
+		'repo-meta-api-access-token'	=> null,
 
-		'repo-owner'		=> null,
-		'repo-name'		=> null,
+		'repo-owner'			=> null,
+		'repo-name'			=> null,
 
-		'support-tier-name'	=> null,
+		'support-tier-name'		=> null,
 	);
 
 	protected function setUp() {
 		vipgoci_unittests_get_config_values(
-			'repo-meta-api',
-			$this->options_meta_api,
+			'repo-meta-api-secrets',
+			$this->options_meta_api_secrets,
 			true
 		);
 
-		$this->options = $this->options_meta_api;
+		$this->options = $this->options_meta_api_secrets;
 	}
 
 	protected function tearDown() {
-		$this->options_meta_api = null;
+		$this->options_meta_api_secrets = null;
 		$this->options = null;
 	}
 
@@ -37,7 +37,7 @@ final class SupportLevelLabelMetaApiDataFetchTest extends TestCase {
 	public function testMetaApiDataFetch() {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
-			array( 'api-user-id', 'api-access-token' ),
+			array( 'repo-meta-api-user-id', 'repo-meta-api-access-token' ),
 			$this
 		);
 
@@ -46,9 +46,9 @@ final class SupportLevelLabelMetaApiDataFetchTest extends TestCase {
 		}
 
 		$repo_meta_data = vipgoci_repo_meta_api_data_fetch(
-			$this->options['api-base-url'],
-			$this->options['api-user-id'],
-			$this->options['api-access-token'],
+			$this->options['repo-meta-api-base-url'],
+			$this->options['repo-meta-api-user-id'],
+			$this->options['repo-meta-api-access-token'],
 			$this->options['repo-owner'],
 			$this->options['repo-name']
 		);
@@ -74,9 +74,9 @@ final class SupportLevelLabelMetaApiDataFetchTest extends TestCase {
 		 * Re-test due to caching.
 		 */
 		$repo_meta_data_2 = vipgoci_repo_meta_api_data_fetch(
-			$this->options['api-base-url'],
-			$this->options['api-user-id'],
-			$this->options['api-access-token'],
+			$this->options['repo-meta-api-base-url'],
+			$this->options['repo-meta-api-user-id'],
+			$this->options['repo-meta-api-access-token'],
 			$this->options['repo-owner'],
 			$this->options['repo-name']
 		);

--- a/tests/SupportLevelLabelSetTest.php
+++ b/tests/SupportLevelLabelSetTest.php
@@ -1,0 +1,241 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class SupportLevelLabelSetTest extends TestCase {
+	var $options_meta_api_secrets = array(
+		'repo-meta-api-base-url'	=> null,
+		'repo-meta-api-user-id'		=> null,
+		'repo-meta-api-access-token'	=> null,
+
+		'support-tier-name'		=> null,
+	);
+
+	var $options_git = array(
+		'git-path'		=> null,
+		'github-repo-url'	=> null,
+		'repo-name'		=> null,
+		'repo-owner'		=> null,
+	);
+
+	protected function setUp() {
+		vipgoci_unittests_get_config_values(
+			'repo-meta-api-secrets',
+			$this->options_meta_api_secrets,
+			true
+		);
+
+		vipgoci_unittests_get_config_values(
+			'git',
+			$this->options_git
+		);
+
+		$this->options = array_merge(
+			$this->options_meta_api_secrets,
+			$this->options_git
+		);
+
+		$this->options['branches-ignore'] = array();
+
+		$this->options['token'] =
+			vipgoci_unittests_get_config_value(
+				'git-secrets',
+				'github-token',
+				true // Fetch from secrets file
+			);
+
+		$this->options['commit'] =
+			vipgoci_unittests_get_config_value(
+				'repo-meta-api',
+				'commit-support-level-set-test',
+			);
+	}
+
+	protected function tearDown() {
+		$this->options_meta_api_secrets = null;
+		$this->options_git = null;
+		$this->options = null;
+	}
+
+	protected function _findPrsImplicated() {
+		return vipgoci_github_prs_implicated(
+			$this->options['repo-owner'],
+			$this->options['repo-name'],
+			$this->options['commit'],
+			$this->options['token'],
+			$this->options['branches-ignore']
+		);
+	}
+
+	/*
+	 * Loop through each PR, count 
+	 * number of support-level labels
+	 * found and return.
+	 */
+
+	protected function _findSupportLabelstoPrs() {
+		$support_labels_cnt = 0;
+
+		$prs_implicated = $this->_findPrsImplicated();
+
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_item_labels = vipgoci_github_labels_get(
+				$this->options['repo-owner'],
+				$this->options['repo-name'],
+				$this->options['token'],
+				$pr_item->number,
+				null,
+				true // Avoid cache
+			);
+
+			/*
+			 * False can indicate none was found.
+			 */
+
+			if ( false === $pr_item_labels ) {
+				continue;
+			}
+
+			foreach( $pr_item_labels as $label_item ) {
+				if ( 
+					'[Support Level] ' . ucfirst( strtolower( $this->options['support-tier-name'] ) )
+					===
+					$label_item->name
+				) {
+					$support_labels_cnt++;
+				}
+			}
+		}
+
+		return $support_labels_cnt;
+	}
+
+	/**
+	 * @covers ::vipgoci_support_level_label_set
+	 */
+	public function testSupportLevelSet1() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'repo-meta-api-user-id', 'repo-meta-api-access-token' ),
+			$this
+		);
+
+		$this->options['set-support-level-label'] = false;
+	
+		$level_label = vipgoci_support_level_label_set(
+			$this->options
+		);
+
+		$this->assertFalse(
+			$level_label
+		);
+
+		$support_labels_cnt = $this->_findSupportLabelstoPrs();
+
+		$this->assertEquals(
+			0,
+			$support_labels_cnt
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_support_level_label_set
+	 */
+	public function testSupportLevelSet2() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'repo-meta-api-user-id', 'repo-meta-api-access-token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$this->options['set-support-level-label'] = true;
+
+		/*
+		 * Get any PRs attached, verify we got at least one.
+		 */
+		$prs_implicated = $this->_findPrsImplicated();
+
+		$this->assertNotEmpty(
+			$prs_implicated
+		);
+
+		/*
+		 * Look for support labels, should be none.
+		 */
+		$support_labels_cnt = $this->_findSupportLabelstoPrs();
+
+		$this->assertEquals(
+			0,
+			$support_labels_cnt
+		);
+	
+		/*
+		 * Attempt to set support level label.
+		 */
+		$level_label_ret = vipgoci_support_level_label_set(
+			$this->options
+		);
+
+		$this->assertTrue(
+			$level_label_ret
+		);
+
+		/*
+		 * Loop through each PR, looking for
+		 * support level label. Then delete any
+		 * we find to clean up.
+		 */
+	
+		$this->assertNotEmpty(
+			$prs_implicated
+		);
+
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_item_labels = vipgoci_github_labels_get(
+				$this->options['repo-owner'],
+				$this->options['repo-name'],
+				$this->options['token'],
+				$pr_item->number,
+				null,
+				true // Avoid cache
+			);
+
+			$this->assertNotEmpty(
+				$pr_item_labels
+			);
+
+			$found_support_level_label = false;
+
+			foreach( $pr_item_labels as $label_item ) {
+				if (
+					'[Support Level] ' . ucfirst( strtolower( $this->options['support-tier-name'] ) ) ===
+					$label_item->name
+				) {
+					/*
+					 * Clean up label and indicate we found it.
+					 */	
+					vipgoci_github_label_remove_from_pr(
+						$this->options['repo-owner'],
+						$this->options['repo-name'],
+						$this->options['token'],
+						$pr_item->number,
+						$label_item->name,
+						false
+					);
+
+					$found_support_level_label = true;
+				}
+			}
+
+			$this->assertTrue(
+				$found_support_level_label
+			);
+		}
+	}
+}

--- a/unittests.ini
+++ b/unittests.ini
@@ -79,3 +79,7 @@ commit-test-options-read-repo-file-no-file=5e95e2c3705695a62023c92ef5f09761ab057
 commit-test-options-read-repo-file-with-file=7604b5c54a736d58678de0c5bf18de1c66f6c260
 commit-test-options-read-repo-file-with-file-2=fe24a89ee9e9184681c6482ca60af57cc4c0b1be
 commit-test-options-read-repo-file-with-file-3=1615b03f6997878feb1a25926631c4165e2efeec
+
+[repo-meta-api]
+commit-support-level-set-test=4e56c433e2e7c0de62e333cdf719949ea0a1ccb5
+

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -16,6 +16,7 @@ require_once( __DIR__ . '/ap-hashes-api.php' );
 require_once( __DIR__ . '/ap-svg-files.php' );
 require_once( __DIR__ . '/svg-scan.php' );
 require_once( __DIR__ . '/other-web-services.php' );
+require_once( __DIR__ . '/support-level-label.php' );
 
 
 /**
@@ -149,6 +150,7 @@ function vipgoci_run() {
 			'post-generic-pr-support-comments:',
 			'post-generic-pr-support-comments-string:',
 			'post-generic-pr-support-comments-branches:',
+			'set-support-level-label:',
 			'phpcs-path:',
 			'phpcs-standard:',
 			'phpcs-severity:',
@@ -277,6 +279,9 @@ function vipgoci_run() {
 			"\t" . '                                                   comma separated. A single "any" value will ' . PHP_EOL .
 			"\t" . '                                                   cause the message to be posted to any ' . PHP_EOL .
 			"\t" . '                                                   branch.' . PHP_EOL .
+			PHP_EOL .
+			"\t" . '--set-support-level-label=BOOL    Whether to attach support level labels to Pull-Requests. ' . PHP_EOL .
+			"\t" . '                                  Will fetch information on support levels from an API. ' . PHP_EOL .
 			PHP_EOL .
 			"\t" . '--phpcs=BOOL                   Whether to run PHPCS (true/false)' . PHP_EOL .
 			"\t" . '--phpcs-path=FILE              Full path to PHPCS script' . PHP_EOL .
@@ -740,6 +745,12 @@ function vipgoci_run() {
 		array()
 	);
 
+	/*
+	 * Handle option for setting support
+	 * labels.
+	 */
+	
+	vipgoci_option_bool_handle( $options, 'set-support-level-label', 'false' );
 
 	/*
 	 * Handle IRC API parameters
@@ -1556,6 +1567,14 @@ function vipgoci_run() {
 		}
 	}
 
+	/*
+	 * Add support level label, if:
+	 * - configured to do so
+	 * - data is available in repo-meta API
+	 */
+	vipgoci_support_level_label_set(
+		$options
+	);
 
 	/*
 	 * At this point, we have started to prepare

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -151,6 +151,9 @@ function vipgoci_run() {
 			'post-generic-pr-support-comments-string:',
 			'post-generic-pr-support-comments-branches:',
 			'set-support-level-label:',
+			'repo-meta-api-base-url:',
+			'repo-meta-api-user-id:',
+			'repo-meta-api-access-token:',
 			'phpcs-path:',
 			'phpcs-standard:',
 			'phpcs-severity:',
@@ -280,8 +283,12 @@ function vipgoci_run() {
 			"\t" . '                                                   cause the message to be posted to any ' . PHP_EOL .
 			"\t" . '                                                   branch.' . PHP_EOL .
 			PHP_EOL .
-			"\t" . '--set-support-level-label=BOOL    Whether to attach support level labels to Pull-Requests. ' . PHP_EOL .
-			"\t" . '                                  Will fetch information on support levels from an API. ' . PHP_EOL .
+			"\t" . '--set-support-level-label=BOOL       Whether to attach support level labels to Pull-Requests. ' . PHP_EOL .
+			"\t" . '                                     Will fetch information on support levels from repo-meta API. ' . PHP_EOL .
+			"\t" . '--repo-meta-api-base-url=STRING      Base URL to repo-meta API, containing support level and other ' . PHP_EOL .
+			"\t" . '                                     information. ' . PHP_EOL .
+			"\t" . '--repo-meta-api-user-id=STRING       Authentication detail for the repo-meta API. ' . PHP_EOL .
+			"\t" . '--repo-meta-api-access-token=STRING  Access token for the repo-meta API. ' . PHP_EOL .                                
 			PHP_EOL .
 			"\t" . '--phpcs=BOOL                   Whether to run PHPCS (true/false)' . PHP_EOL .
 			"\t" . '--phpcs-path=FILE              Full path to PHPCS script' . PHP_EOL .
@@ -751,6 +758,40 @@ function vipgoci_run() {
 	 */
 	
 	vipgoci_option_bool_handle( $options, 'set-support-level-label', 'false' );
+
+	/*
+	 * Handle options for repo-meta API.
+	 */
+	if ( isset( $options['repo-meta-api-base-url' ] ) ) {
+		vipgoci_option_url_handle( $options, 'repo-meta-api-base-url', null );
+	}
+
+	if ( isset( $options['repo-meta-api-user-id'] ) ) {
+		vipgoci_option_integer_handle( $options, 'repo-meta-api-user-id', 0 );
+	}
+
+	else {
+		$options['repo-meta-api-user-id'] = null;
+	}
+
+	if ( isset(
+		$options['repo-meta-api-access-token']
+	) ) {
+		$options['repo-meta-api-access-token'] = trim(
+			$options['repo-meta-api-access-token']
+		);
+	}
+
+	else {
+		$options['repo-meta-api-access-token'] = null;
+	}
+
+	vipgoci_options_sensitive_clean(
+		null,
+		array(
+			'repo-meta-api-access-token'
+		)
+	);
 
 	/*
 	 * Handle IRC API parameters
@@ -1289,6 +1330,15 @@ function vipgoci_run() {
 	}
 
 	/*
+	 * Add support level label, if:
+	 * - configured to do so
+	 * - data is available in repo-meta API
+	 */
+	vipgoci_support_level_label_set(
+		$options
+	);
+
+	/*
 	 * Run all checks requested and store the
 	 * results in an array
 	 */
@@ -1566,15 +1616,6 @@ function vipgoci_run() {
 			);
 		}
 	}
-
-	/*
-	 * Add support level label, if:
-	 * - configured to do so
-	 * - data is available in repo-meta API
-	 */
-	vipgoci_support_level_label_set(
-		$options
-	);
 
 	/*
 	 * At this point, we have started to prepare


### PR DESCRIPTION
This patch adds support for adding labels indicating client-support for any PRs scanned by `vip-go-ci`. 

TODO:

- [x] Unit tests
- [x] Final review
- [x] README.md updates for the feature
- [x] Final testing
