### PR TITLE
Posting support-messages only when a field is found in repo-meta API

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,14 @@ The feature can be used in the following fashion:
 
 The last parameter can be specified as 'any' to allow posting to any branch.
 
+You can limit what Pull-Requests the generic support message are posted to, given data from the repo-meta API and a criteria specified on the command line. This feature depends on the repo-meta API being configured.
+
+For example:
+
+> ./vip-go-ci.php --post-generic-pr-support-comments=true --post-generic-pr-support-comments-string="This ..." --post-generic-pr-support-comments-branches="master" --post-generic-pr-support-comments-repo-meta-match="support_message=true,support_plan=true" 
+
+With the `--post-generic-pr-support-comments-repo-meta-match` parameter added, `vip-go-ci` will look at the data returned by the repo-meta API, and check if these fields and their values are found in there for at least one entry. If so, the generic support message will be posted, and not otherwise.
+
 ### Support labels
 
 `vip-go-ci` can put labels on Pull-Requests indicating level of support provided. With this feature configured, `vip-go-ci` will attach a label to every new Pull-Request that does not have it. For this to work, it will need access to a `repo-meta API` that needs to be available and `vip-go-ci` has to be configured to work with.

--- a/github-api.php
+++ b/github-api.php
@@ -1890,8 +1890,7 @@ function vipgoci_github_pr_generic_support_comment(
 	if ( ! empty( $options['post-generic-pr-support-comments-repo-meta-match'] ) ) {
 		$repo_meta_api_data_match = vipgoci_repo_meta_api_data_match(
 			$options,
-			$options['post-generic-pr-support-comments-repo-meta-match'][0],
-			$options['post-generic-pr-support-comments-repo-meta-match'][1],
+			'post-generic-pr-support-comments-repo-meta-match',
 			false
 		);
 

--- a/github-api.php
+++ b/github-api.php
@@ -1841,8 +1841,8 @@ function vipgoci_github_pr_generic_support_comment(
 	$options,
 	$prs_implicated
 ) {
-	vipgoci_log(
-		'Posting support-comments on Pull-Requests',
+
+	$log_debugmsg = 
 		array(
 			'post-generic-pr-support-comments' =>
 				$options['post-generic-pr-support-comments'],
@@ -1851,9 +1851,60 @@ function vipgoci_github_pr_generic_support_comment(
 				$options['post-generic-pr-support-comments-string'],
 
 			'post-generic-pr-support-comments-branches' =>
-				$options['post-generic-pr-support-comments-branches']
-		)
-	);
+				$options['post-generic-pr-support-comments-branches'],
+
+			'post-generic-pr-support-comments-repo-meta-match' =>
+				$options['post-generic-pr-support-comments-repo-meta-match'],
+		);
+
+	/*
+	 * Detect if to run, or invalid configuration. 
+	 */
+	if (
+		( true !== $options['post-generic-pr-support-comments'] ) ||
+		( empty( $options['post-generic-pr-support-comments-string'] ) ) ||
+		( empty( $options['post-generic-pr-support-comments-branches'] ) )
+	) {
+		vipgoci_log(
+			'Not posting support-comments on Pull-Requests, as ' .
+				'either not configured to do so, or ' .
+				'incorrectly configured',
+			$log_debugmsg
+		);
+
+		return;
+	}
+
+	else {
+		vipgoci_log(
+			'Posting support-comments on Pull-Requests',
+			$log_debugmsg
+		);
+	}
+
+	/*
+	 * Check if a field value in response
+	 * from repo-meta API service
+	 * matches the field value given here.
+	 */
+	if ( ! empty( $options['post-generic-pr-support-comments-repo-meta-match'] ) ) {
+		$repo_meta_api_data_match = vipgoci_repo_meta_api_data_match(
+			$options,
+			$options['post-generic-pr-support-comments-repo-meta-match'][0],
+			$options['post-generic-pr-support-comments-repo-meta-match'][1],
+			false
+		);
+
+		if ( true !== $repo_meta_api_data_match ) {
+			vipgoci_log(
+				'Not posting generic support comment, as repo-meta API field-value did not match a given criteria',
+				array(
+				)
+			);
+
+			return;
+		}
+	}
 
 
 	foreach(

--- a/misc.php
+++ b/misc.php
@@ -82,6 +82,106 @@ function vipgoci_sysexit(
 }
 
 /*
+ * Check if a particular set of fields exist
+ * in a target array and if their values match a set
+ * given. Will return an array describing 
+ * which items of the array contain all the fields
+ * and the matching values.
+ *
+ * Example:
+ *	$fields_arr = array(
+ *		'a'	=> 920,
+ *		'b'	=> 700,
+ *	);
+ *
+ *	$data_arr = array(
+ *		array(
+ *			'a'	=> 920,
+ *			'b'	=> 500,
+ *			'c'	=> 0,
+ *			'd'	=> 1,
+ *			...
+ *		),
+ *		array(
+ *			'a'	=> 920,
+ *			'b'	=> 700,
+ *			'c'	=> 0,
+ *			'd'	=> 2,
+ *			...
+ *		),
+ *	);
+ *
+ *	$res = vipgoci_find_fields_in_array(
+ *		$fields_arr, $data_arr
+ *	);
+ *
+ *	$res will be:
+ *	array(
+ *		0 => false,
+ *		1 => true,
+ *	);
+ */
+function vipgoci_find_fields_in_array( $fields_arr, $data_arr ) {
+	$res_arr = array();
+
+	for(
+		$data_item_cnt = 0;
+		$data_item_cnt < count( $data_arr );
+		$data_item_cnt++
+	) {
+		$res_arr[ $data_item_cnt ] = 0;
+
+		foreach( $fields_arr as $field_name => $field_value ) {
+			if ( ! array_key_exists( $field_name, $data_arr[ $data_item_cnt ] ) ) {
+				continue;
+			}
+
+			if ( $data_arr[ $data_item_cnt ][ $field_name ] === $field_value ) {
+				$res_arr[ $data_item_cnt ]++;
+			}
+		}
+
+		$res_arr[
+			$data_item_cnt
+		] = (
+			$res_arr[ $data_item_cnt ]
+			===
+			count( array_keys( $fields_arr ) )
+		);
+
+		$data_item_cnt++;
+	}
+
+	return $res_arr;
+}
+
+/*
+ * Convert a string that contains "true", "false" or
+ * "null" to a variable of that type.
+ */
+function vipgoci_convert_string_to_type( $str ) {
+	switch( $str ) {
+		case 'true':
+			$ret = true;
+			break;
+
+		case 'false':
+			$ret = false;
+			break;
+
+		case 'null':
+			$ret = null;
+			break;
+
+		default:
+			$ret = $str;
+			break;
+	}
+
+	return $ret;
+}
+
+/*
  * Given a patch-file, the function will return an
  * associative array, mapping the patch-file
  * to the raw committed file.

--- a/misc.php
+++ b/misc.php
@@ -148,8 +148,6 @@ function vipgoci_find_fields_in_array( $fields_arr, $data_arr ) {
 			===
 			count( array_keys( $fields_arr ) )
 		);
-
-		$data_item_cnt++;
 	}
 
 	return $res_arr;

--- a/support-level-label.php
+++ b/support-level-label.php
@@ -423,12 +423,6 @@ function vipgoci_repo_meta_api_data_match(
 	$options,
 	$option_name
 ) {
-	$log_debug_arr = array(
-		'option_name'			=> $option_name,
-		'repo_meta_match'		=> $options[ $option_name ],
-		'repo_meta_api_base_url'	=> $options['repo-meta-api-base-url'],
-	);
-
 	if (
 		( empty( $option_name ) ) ||
 		( empty( $options['repo-meta-api-base-url'] ) ) ||
@@ -436,7 +430,18 @@ function vipgoci_repo_meta_api_data_match(
 	) {
 		vipgoci_log(
 			'Not attempting to match repo-meta API field-value to a criteria',
-			$log_debug_arr
+			array(
+				'option_name'
+					=> $option_name,
+
+				'repo_meta_api_base_url'
+					=> isset( $options['repo-meta-api-base-url'] ) ?
+						$options['repo-meta-api-base-url'] : '',
+
+				'repo_meta_match'
+					=> ( ( ! empty( $option_name ) ) && ( isset( $options[ $option_name ] ) ) ) ?
+						$options[ $option_name ] : '',
+			)
 		);
 
 		return false;
@@ -445,7 +450,11 @@ function vipgoci_repo_meta_api_data_match(
 	else {
 		vipgoci_log(
 			'Attempting to match repo-meta API field-value to a criteria',
-			$log_debug_arr
+			array(
+				'option_name'			=> $option_name,
+				'repo_meta_match'		=> $options[ $option_name ],
+				'repo_meta_api_base_url'	=> $options['repo-meta-api-base-url'],
+			)
 		);
 	}
 

--- a/support-level-label.php
+++ b/support-level-label.php
@@ -429,7 +429,8 @@ function vipgoci_repo_meta_api_data_match(
 		( empty( $options[ $option_name ] ) )
 	) {
 		vipgoci_log(
-			'Not attempting to match repo-meta API field-value to a criteria',
+			'Not attempting to match repo-meta API field-value ' .
+				'to a criteria due to invalid configuration',
 			array(
 				'option_name'
 					=> $option_name,

--- a/tests/GitHubPrGenericSupportCommentTest.php
+++ b/tests/GitHubPrGenericSupportCommentTest.php
@@ -71,11 +71,31 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			);
 		}
 
-		$this->_clearOldSupportComments();
+		/*
+		 * Don't attempt cleanup if not configured.
+		 */
+
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array(),
+			$this
+		);
+
+		if ( -1 !== $options_test ) {
+			$this->_clearOldSupportComments();
+		}
 	}
 
 	protected function tearDown() {
-		$this->_clearOldSupportComments();
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array(),
+			$this
+		);
+
+		if ( -1 !== $options_test ) {
+			$this->_clearOldSupportComments();
+		}
 
 		$this->options = null;
 		$this->options_git = null;

--- a/tests/MiscConvertStringToTypeTest.php
+++ b/tests/MiscConvertStringToTypeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class MiscConvertStringToTypeTest extends TestCase {
+	/**
+	 * @covers ::vipgoci_convert_string_to_type
+	 */
+	public function convertTest1() {
+		$this->assertEquals(
+			true,
+			vipgoci_convert_string_to_type('true')
+		);
+
+		$this->assertEquals(
+			false,
+			vipgoci_convert_string_to_type('false')
+		);
+
+		$this->assertEquals(
+			null,
+			vipgoci_convert_string_to_type('null')
+		);
+
+		$this->assertEquals(
+			'somestring',
+			vipgoci_convert_string_to_type('somestring')
+		);
+	}
+}

--- a/tests/MiscConvertStringToTypeTest.php
+++ b/tests/MiscConvertStringToTypeTest.php
@@ -8,7 +8,7 @@ final class MiscConvertStringToTypeTest extends TestCase {
 	/**
 	 * @covers ::vipgoci_convert_string_to_type
 	 */
-	public function convertTest1() {
+	public function testConvert1() {
 		$this->assertEquals(
 			true,
 			vipgoci_convert_string_to_type('true')

--- a/tests/MiscFindFieldsInArrayTest.php
+++ b/tests/MiscFindFieldsInArrayTest.php
@@ -1,0 +1,57 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class MiscFindFieldsInArrayTest extends TestCase {
+	/**
+	 * @covers ::vipgoci_find_fields_in_array
+	 */
+	public function testFindFields1() {
+		$this->assertEquals(
+			array(
+				0 => false,
+				1 => true,
+				2 => true,
+				3 => false,
+				4 => false,
+			),
+			vipgoci_find_fields_in_array(
+				array(
+					'a' => 920,
+					'b' => 700,
+				),
+				array(
+					array(
+						'a' => 920,
+						'b' => 500,
+						'c' => 0,
+						'd' => 1,
+					),
+					array(
+						'a' => 920,
+						'b' => 700,
+						'c' => 0,
+						'd' => 2,
+					),
+					array(
+						'a' => 920,
+						'b' => 700,
+						'c' => 0,
+						'd' => 2,
+					),
+					array(
+						'a' => 900,
+						'b' => 720,
+						'c' => 0,
+						'd' => 2,
+					),
+					array(
+						'a' => 900,
+					)
+				)
+			)
+		);
+	}
+}

--- a/tests/SupportLevelLabelRepoMetaApiDataMatchTest.php
+++ b/tests/SupportLevelLabelRepoMetaApiDataMatchTest.php
@@ -1,0 +1,142 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class SupportLevelLabelRepoMetaApiDataMatchTest extends TestCase {
+	var $options_meta_api_secrets = array(
+		'repo-meta-api-base-url'	=> null,
+		'repo-meta-api-user-id'		=> null,
+		'repo-meta-api-access-token'	=> null,
+
+		'repo-name'			=> null,
+		'repo-owner'			=> null,
+
+		'support-tier-name'		=> null,
+	);
+
+	protected function setUp() {
+		vipgoci_unittests_get_config_values(
+			'repo-meta-api-secrets',
+			$this->options_meta_api_secrets,
+			true
+		);
+
+		$this->options = $this->options_meta_api_secrets;
+
+		$this->options['data_match0'] = array(
+		);
+
+		$this->options['data_match1'] = array(
+			'__invalid_field'	=> '__somethinginvalid',
+		);
+
+		$this->options['data_match2'] = array(
+			'support_tier'		=> $this->options['support-tier-name'],
+		);
+
+		$this->options['branches-ignore'] = array();
+	}
+
+	protected function tearDown() {
+		$this->options = null;
+		$this->options_meta_api_secrets = null;
+	}
+
+	/**
+	 * @covers ::vipgoci_repo_meta_api_data_match
+	 */
+	public function test_repo_meta_api_data_match1() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'repo-meta-api-user-id', 'repo-meta-api-access-token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$this->assertEquals(
+			false,
+
+			vipgoci_repo_meta_api_data_match(
+				$this->options,
+				''
+			)
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_repo_meta_api_data_match
+	 */
+	public function test_repo_meta_api_data_match2() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'repo-meta-api-user-id', 'repo-meta-api-access-token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$this->assertEquals(
+			false,
+
+			vipgoci_repo_meta_api_data_match(
+				$this->options,
+				'data_match0'
+			)
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_repo_meta_api_data_match
+	 */
+	public function test_repo_meta_api_data_match3() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'repo-meta-api-user-id', 'repo-meta-api-access-token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$this->assertEquals(
+			false,
+
+			vipgoci_repo_meta_api_data_match(
+				$this->options,
+				'data_match1'
+			)
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_repo_meta_api_data_match
+	 */
+	public function test_repo_meta_api_data_match4() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'repo-meta-api-user-id', 'repo-meta-api-access-token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$this->assertEquals(
+			true,
+
+			vipgoci_repo_meta_api_data_match(
+				$this->options,
+				'data_match2'
+			)
+		);
+	}
+}

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -285,6 +285,10 @@ function vipgoci_run() {
 			"\t" . '                                                   comma separated. A single "any" value will ' . PHP_EOL .
 			"\t" . '                                                   cause the message to be posted to any ' . PHP_EOL .
 			"\t" . '                                                   branch.' . PHP_EOL .
+			"\t" . '--post-generic-pr-support-comments-repo-meta-match=ARRAY   Only post generic support ' . PHP_EOL .
+			"\t" . '                                                           messages when data from repo-meta API' . PHP_EOL .
+			"\t" . '                                                           matches the criteria specified here. ' . PHP_EOL .
+			"\t" . '                                                           See README.md for usage. ' . PHP_EOL .
 			PHP_EOL .
 			"\t" . '--set-support-level-label=BOOL       Whether to attach support level labels to Pull-Requests. ' . PHP_EOL .
 			"\t" . '                                     Will fetch information on support levels from repo-meta API. ' . PHP_EOL .

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -800,6 +800,10 @@ function vipgoci_run() {
 			continue;
 		}
 
+		/*
+		 * Convert "true" strings to true boolean variable,
+		 * same for "false" and "null". 
+		 */
 		$tmp_repo_meta_match[
 			$options['post-generic-pr-support-comments-repo-meta-match'][ $i ][0]
 		] = vipgoci_convert_string_to_type(

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -776,20 +776,40 @@ function vipgoci_run() {
 		array()
 	);
 
-	/*
-	 * If more than two items in array, it is invalid.
-	 */
-	if ( count(
-		$options['post-generic-pr-support-comments-repo-meta-match']
-	) > 2 ) {
-		vipgoci_sysexit(
-			'Invalid configuration of --post-generic-pr-support-comments-repo-meta-match',
-			array(
-				'post-generic-pr-support-comments-repo-meta-match'	=>
-					$options['post-generic-pr-support-comments-repo-meta-match']
-			)
+	$tmp_repo_meta_match = array();
+
+	for(
+		$i = 0;
+		$i < count(
+			$options['post-generic-pr-support-comments-repo-meta-match']
+		);
+		$i++
+	) {
+		$options['post-generic-pr-support-comments-repo-meta-match'][ $i ] =
+			explode(
+				'=',
+				$options['post-generic-pr-support-comments-repo-meta-match'][ $i ],
+				2 // Max one '='; any extra will be preserve
+			);
+
+		if ( count( $options['post-generic-pr-support-comments-repo-meta-match'][ $i ] ) != 2 ) {
+			continue;
+		}
+
+		$tmp_repo_meta_match[
+			$options['post-generic-pr-support-comments-repo-meta-match'][ $i ][0]
+		] = vipgoci_convert_string_to_type(
+			$options['post-generic-pr-support-comments-repo-meta-match'][ $i ][1]
 		);
 	}
+
+	$options[
+		'post-generic-pr-support-comments-repo-meta-match'
+	] = $tmp_repo_meta_match;
+
+	unset(
+		$tmp_repo_meta_match
+	);
 
 	/*
 	 * Handle option for setting support

--- a/vip-go-ci.php
+++ b/vip-go-ci.php
@@ -150,6 +150,7 @@ function vipgoci_run() {
 			'post-generic-pr-support-comments:',
 			'post-generic-pr-support-comments-string:',
 			'post-generic-pr-support-comments-branches:',
+			'post-generic-pr-support-comments-repo-meta-match:',
 			'set-support-level-label:',
 			'repo-meta-api-base-url:',
 			'repo-meta-api-user-id:',
@@ -769,6 +770,27 @@ function vipgoci_run() {
 		array()
 	);
 
+	vipgoci_option_array_handle(
+		$options,
+		'post-generic-pr-support-comments-repo-meta-match',
+		array()
+	);
+
+	/*
+	 * If more than two items in array, it is invalid.
+	 */
+	if ( count(
+		$options['post-generic-pr-support-comments-repo-meta-match']
+	) > 2 ) {
+		vipgoci_sysexit(
+			'Invalid configuration of --post-generic-pr-support-comments-repo-meta-match',
+			array(
+				'post-generic-pr-support-comments-repo-meta-match'	=>
+					$options['post-generic-pr-support-comments-repo-meta-match']
+			)
+		);
+	}
+
 	/*
 	 * Handle option for setting support
 	 * labels.
@@ -1342,19 +1364,11 @@ function vipgoci_run() {
 	 * If configured to do so, post a generic comment
 	 * on the Pull-Request(s) with some helpful information.
 	 * Comment is set via option.
-	 * 
-	 * Make sure not to post comment again if it is already posted.
 	 */
-	if (
-		( true === $options['post-generic-pr-support-comments'] ) &&
-		( ! empty( $options['post-generic-pr-support-comments-string'] ) ) &&
-		( ! empty( $options['post-generic-pr-support-comments-branches'] ) )
-	) {
-		vipgoci_github_pr_generic_support_comment(
-			$options,
-			$prs_implicated
-		);
-	}
+	vipgoci_github_pr_generic_support_comment(
+		$options,
+		$prs_implicated
+	);
 
 	/*
 	 * Add support level label, if:


### PR DESCRIPTION
With this patch applied, and the feature configured, generic support-messages will only be posted when a certain field is found in repo-meta API response.

TODO:
- [x] Unit-tests
   - [x] vipgoci_convert_string_to_type()
   - [x] vipgoci_find_fields_in_array()
   - [x] vipgoci_repo_meta_api_data_match()
   - [x] Update GitHubPrGenericSupportCommentTest unit-test
- [x] README.md
- [x] --help message
- [x] Final review