### PR TITLE
Use PHP 7.2 compatible syntax

### DIFF
--- a/support-level-label.php
+++ b/support-level-label.php
@@ -196,7 +196,7 @@ function vipgoci_support_level_label_set(
 		( empty( $options['repo-meta-api-base-url'] ) )
 	) {
 		vipgoci_log(
-			'Missing configuration for repo-meta API, skipping',
+			'Missing configuration for repo-meta API, skipping'
 		);
 
 		return false;

--- a/tests/GitHubPrGenericSupportCommentTest.php
+++ b/tests/GitHubPrGenericSupportCommentTest.php
@@ -59,7 +59,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		$this->options = array_merge(
 			$this->options_git,
 			$this->options_git_repo_tests,
-			$this->options,
+			$this->options
 		);
 
 		$this->options['commit'] =

--- a/tests/SupportLevelLabelSetTest.php
+++ b/tests/SupportLevelLabelSetTest.php
@@ -49,7 +49,7 @@ final class SupportLevelLabelSetTest extends TestCase {
 		$this->options['commit'] =
 			vipgoci_unittests_get_config_value(
 				'repo-meta-api',
-				'commit-support-level-set-test',
+				'commit-support-level-set-test'
 			);
 
 		$this->options['set-support-level-label-prefix'] =


### PR DESCRIPTION
This fixes PHP compile errors when the vip-go-ci.php is run with PHP 7.2.