### PR TITLE
vipgoci_github_labels_get(): Do not cache based on $label_to_look_for

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -3324,7 +3324,7 @@ function vipgoci_github_labels_get(
 	 */
 	$cache_id = array(
 		__FUNCTION__, $repo_owner, $repo_name,
-		$github_token, $pr_number, $label_to_look_for
+		$github_token, $pr_number
 	);
 
 	$cached_data = vipgoci_cache( $cache_id );


### PR DESCRIPTION
Do not cache based on `$label_to_look_for`, as it is not used in requests to GitHub.