### PR TITLE
Implement --skip-draft-prs

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Any parameter can be read from the environment, not just those shown. Parameters
 
 ### Configuration via repository config-file
 
-A few options can currently be configured via a repository config-file. This way, users with commit-access to a git repository can influence the behaviour of `vip-go-ci`. The idea is to allow users flexibility in how scanning is performed. Various sanity checks are made to the configuration options read. The options that can be specified via repository options are outlined below. Any default configuration is overwritten during run-time by the new value, should it be valid. 
+A few options can currently be configured via a repository config-file. This way, users with commit-access to a git repository can influence the behaviour of `vip-go-ci` when it scans the repository. The idea is to allow users flexibility in how scanning is performed. Various sanity checks are made to the configuration options read. The options that can be specified via repository options are outlined below. A default configuration option is overwritten during run-time by the new value, should it be valid. 
 
 The feature can be enabled or disabled via `--repo-options`; by default it is disabled. To use the feature, make sure a `.vipgoci_options` file can be found at the root of the relevant git-repository, containing something similar to this:
 
@@ -271,11 +271,9 @@ The feature can be enabled or disabled via `--repo-options`; by default it is di
 
 Then run `vip-go-ci` like this:
 
-> ./vip-go-ci.php --repo-options=true 
-
-If you wish to limit the options configurable via repository config-file, you can specify which options can be configured by using `--repo-options-allowed`, like this:
-
 > ./vip-go-ci.php --repo-options=true --repo-options-allowed="phpcs-severity"
+
+`--repo-options-allowed` specifies which options can be specified via `.vipgoci_options`, and that can be used to limit which options are allowed.
 
 Should the configuration file not be found, any configuration value not be valid, or altering of the particular option is not allowed, the relevant option will not be altered on run-time. Note that not all options need to be set in the configuration file, only those desired. The file is expected to be a parsable, valid JSON.
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Should the configuration file not be found, any configuration value not be valid
 
 You can use any combination of options you wish. Individual options are documented below.
 
-* Option `--phpcs-severity`
+#### Option `--phpcs-severity`
 
 Specifies the severity level to pass to PHPCS when executed.
 
@@ -289,7 +289,7 @@ For example:
 {"phpcs-severity":5}
 ```
 
-* Option `--post-generic-pr-support-comments`
+#### Option `--post-generic-pr-support-comments`
 
 Specifies if to post generic support comments, should be a boolean.
 
@@ -299,7 +299,7 @@ For example:
 {"post-generic-pr-support-comments":false}
 ```
 
-* Options `phpcs-sniffs-exclude` and `phpcs-sniffs-include`
+#### Options `phpcs-sniffs-exclude` and `phpcs-sniffs-include`
 
 These are array parameters and if it is specified in the options file, the items specified will be appended to the options specified on the command line. To configure this option, one can specify something like this in the repository options file:
 
@@ -311,7 +311,7 @@ The `phpcs-sniffs-include` option is also available, and it is configured in the
 
 Please note that should any of the PHPCS sniffs specified be invalid, a warning will be posted on any Pull-Request scanned. The warning will be removed during next scan and not posted again if the issue is fixed.
 
-* Option `skip-execution`
+#### Option `skip-execution`
 
 This will make execution of `vip-go-ci` stop after initial startup, avoiding all further processing and scanning.
 

--- a/README.md
+++ b/README.md
@@ -261,23 +261,49 @@ Any parameter can be read from the environment, not just those shown. Parameters
 
 ### Configuration via repository config-file
 
-Two options can currently be configured via a repository config-file. This way, users with commit-access to a git repository can influence the behaviour of `vip-go-ci`. The idea is to allow users flexibility in how scanning is performed. Various sanity checks are made to the configuration options read. Currently, the options that can be specified via repository options are `--phpcs-severity` and `--post-generic-pr-support-comments`. Any default configuration is overwritten during run-time by the new value, should it be valid. 
+A few options can currently be configured via a repository config-file. This way, users with commit-access to a git repository can influence the behaviour of `vip-go-ci`. The idea is to allow users flexibility in how scanning is performed. Various sanity checks are made to the configuration options read. The options that can be specified via repository options are outlined below. Any default configuration is overwritten during run-time by the new value, should it be valid. 
 
-The feature can be enabled or disabled via `--repo-options`; by default it is disabled. To use the feature, make sure a `.vipgoci_options` file can be found at the root of the relevant git-repository, containing something like this:
+The feature can be enabled or disabled via `--repo-options`; by default it is disabled. To use the feature, make sure a `.vipgoci_options` file can be found at the root of the relevant git-repository, containing something similar to this:
 
 ```
-{"phpcs-severity":5,"post-generic-pr-support-comments":false}
+{"phpcs-severity":5,"skip-draft-prs":true}
 ```
 
 Then run `vip-go-ci` like this:
 
 > ./vip-go-ci.php --repo-options=true 
 
-If you wish to limit the options configurable via repository options file, you can specify which options can be configured by using --repo-options-allowed, like this:
+If you wish to limit the options configurable via repository config-file, you can specify which options can be configured by using `--repo-options-allowed`, like this:
 
-> ./vip-go-ci.php --repo-options=true --repo-options-allowed="phpcs-severity,post-generic-pr-support-comments"
+> ./vip-go-ci.php --repo-options=true --repo-options-allowed="phpcs-severity"
 
-Also supported is the `phpcs-sniffs-exclude` option. This is an array parameter and if it is specified in the options file, the items specified will be appended to the options specified on the command line. To configure this option, one can specify something like this in the repository options file:
+Should the configuration file not be found, any configuration value not be valid, or altering of the particular option is not allowed, the relevant option will not be altered on run-time. Note that not all options need to be set in the configuration file, only those desired. The file is expected to be a parsable, valid JSON.
+
+You can use any combination of options you wish. Individual options are documented below.
+
+* Option `--phpcs-severity`
+
+Specifies the severity level to pass to PHPCS when executed.
+
+For example:
+
+```
+{"phpcs-severity":5}
+```
+
+* Option `--post-generic-pr-support-comments`
+
+Specifies if to post generic support comments, should be a boolean.
+
+For example:
+
+```
+{"post-generic-pr-support-comments":false}
+```
+
+* Options `phpcs-sniffs-exclude` and `phpcs-sniffs-include`
+
+These are array parameters and if it is specified in the options file, the items specified will be appended to the options specified on the command line. To configure this option, one can specify something like this in the repository options file:
 
 > {"phpcs-sniffs-exclude":["WordPressVIPMinimum.JS.InnerHTML", "WordPress.WP.CronInterval"]} 
 
@@ -287,15 +313,13 @@ The `phpcs-sniffs-include` option is also available, and it is configured in the
 
 Please note that should any of the PHPCS sniffs specified be invalid, a warning will be posted on any Pull-Request scanned. The warning will be removed during next scan and not posted again if the issue is fixed.
 
-Also available is the `skip-execution` option:
-
-> {"skip-execution":true}
+* Option `skip-execution`
 
 This will make execution of `vip-go-ci` stop after initial startup, avoiding all further processing and scanning.
 
-Should the configuration file not be found, any configuration value not be valid, or altering of the particular option is not allowed, the option will not be altered on run-time. Note that not all options need to be set in the configuration file, only those desired. The file is expected to be a parsable, valid JSON.
+For example:
 
-This feature might be extended to other options in the future.
+> {"skip-execution":true}
 
 ### Informational URL
 

--- a/README.md
+++ b/README.md
@@ -301,11 +301,11 @@ For example:
 
 #### Options `phpcs-sniffs-exclude` and `phpcs-sniffs-include`
 
-These are array parameters and if it is specified in the options file, the items specified will be appended to the options specified on the command line. To configure this option, one can specify something like this in the repository options file:
+These are array parameters and if specified in the options file, the items specified will be appended to the options specified on the command line. To configure the `phpcs-sniffs-exclude` option, one can specify something like this in the repository options file:
 
 > {"phpcs-sniffs-exclude":["WordPressVIPMinimum.JS.InnerHTML", "WordPress.WP.CronInterval"]} 
 
-The `phpcs-sniffs-include` option is also available, and it is configured in the same way as the `phpcs-sniffs-exclude` option. Note that it works differently behind the scenes, as it will write out a new PHPCS standard on run-time, containing the sniffs to be included as well as the original PHPCS standard, and will then use this standard from then on. The `phpcs-sniffs-include` option is used in this way:
+The `phpcs-sniffs-include` is configured in the same way as the `phpcs-sniffs-exclude` option. Note that it works differently behind the scenes, as it will write out a new PHPCS standard on run-time, containing the sniffs to be included as well as the original PHPCS standard, and will then use this standard from then on. The `phpcs-sniffs-include` option is used in this way:
 
 > {"phpcs-sniffs-include":["WordPress.DB.DirectDatabaseQuery"]} 
 
@@ -318,6 +318,15 @@ This will make execution of `vip-go-ci` stop after initial startup, avoiding all
 For example:
 
 > {"skip-execution":true}
+
+#### Option `skip-draft-prs`
+
+This will let `vip-go-ci` skip scanning of any Pull-Requests that are marked as `draft` on GitHub. This applies to all types of scanning, PHPCS, linting, etc.
+
+For example:
+
+> {"skip-draft-prs":true}
+
 
 ### Informational URL
 

--- a/ap-file-types.php
+++ b/ap-file-types.php
@@ -37,7 +37,8 @@ function vipgoci_ap_file_types(
 		$options['repo-name'],
 		$options['commit'],
 		$options['token'],
-		$options['branches-ignore']
+		$options['branches-ignore'],
+		$options['skip-draft-prs']
 	);
 
 

--- a/ap-hashes-api.php
+++ b/ap-hashes-api.php
@@ -285,7 +285,8 @@ function vipgoci_ap_hashes_api_scan_commit(
 		$options['repo-name'],
 		$options['commit'],
 		$options['token'],
-		$options['branches-ignore']
+		$options['branches-ignore'],
+		$options['skip-draft-prs']
 	);
 
 

--- a/ap-nonfunctional-changes.php
+++ b/ap-nonfunctional-changes.php
@@ -33,7 +33,8 @@ function vipgoci_ap_nonfunctional_changes(
 		$options['repo-name'],
 		$options['commit'],
 		$options['token'],
-		$options['branches-ignore']
+		$options['branches-ignore'],
+		$options['skip-draft-prs']
 	);
 
 

--- a/ap-svg-files.php
+++ b/ap-svg-files.php
@@ -33,7 +33,8 @@ function vipgoci_ap_svg_files(
 		$options['repo-name'],
 		$options['commit'],
 		$options['token'],
-		$options['branches-ignore']
+		$options['branches-ignore'],
+		$options['skip-draft-prs']
 	);
 
 

--- a/auto-approval.php
+++ b/auto-approval.php
@@ -529,7 +529,8 @@ function vipgoci_auto_approval_scan_commit(
 		$options['repo-name'],
 		$options['commit'],
 		$options['token'],
-		$options['branches-ignore']
+		$options['branches-ignore'],
+		$options['skip-draft-prs']
 	);
 
 

--- a/github-api.php
+++ b/github-api.php
@@ -2902,7 +2902,15 @@ function vipgoci_github_prs_implicated(
 	);
 
 	if ( false !== $cached_data ) {
-		// FIXME: Implement skipping
+		/*
+		 * Filter away draft Pull-Requests if requested.
+		 */
+		if ( true === $skip_draft_prs ) {
+			$cached_data = vipgoci_github_pr_remove_drafts(
+				$cached_data
+			);
+		}
+
 		return $cached_data;
 	}
 
@@ -2995,7 +3003,14 @@ function vipgoci_github_prs_implicated(
 
 	vipgoci_cache( $cached_id, $prs_implicated );
 
-	// FIXME: Skip draft PRs
+	/*
+	 * Filter away draft Pull-Requests if requested.
+	 */
+	if ( true === $skip_draft_prs ) {
+		$prs_implicated = vipgoci_github_pr_remove_drafts(
+			$prs_implicated
+		);
+	}
 
 	return $prs_implicated;
 }

--- a/github-api.php
+++ b/github-api.php
@@ -1703,6 +1703,7 @@ function vipgoci_github_pr_comments_cleanup(
 	$commit_id,
 	$github_token,
 	$branches_ignore,
+	$skip_draft_prs,
 	$comments_remove
 ) {
 	vipgoci_log(
@@ -1713,6 +1714,7 @@ function vipgoci_github_pr_comments_cleanup(
 			'commit_id' => $commit_id,
 			'branches_ignore' => $branches_ignore,
 			'comments_remove' => $comments_remove,
+			'skip_draft_prs' => $skip_draft_prs,
 		)
 	);
 
@@ -1727,7 +1729,8 @@ function vipgoci_github_pr_comments_cleanup(
 		$repo_name,
 		$commit_id,
 		$github_token,
-		$branches_ignore
+		$branches_ignore,
+		$skip_draft_prs
 	);
 
 	foreach ( $prs_implicated as $pr_item ) {
@@ -2871,7 +2874,8 @@ function vipgoci_github_prs_implicated(
 	$repo_name,
 	$commit_id,
 	$github_token,
-	$branches_ignore
+	$branches_ignore,
+	$skip_draft_prs = false
 ) {
 
 	/*
@@ -2893,10 +2897,12 @@ function vipgoci_github_prs_implicated(
 			'repo_name' => $repo_name,
 			'commit_id' => $commit_id,
 			'branches_ignore' => $branches_ignore,
+			'skip_draft_prs' => $skip_draft_prs,
 		)
 	);
 
 	if ( false !== $cached_data ) {
+		// FIXME: Implement skipping
 		return $cached_data;
 	}
 
@@ -2988,6 +2994,8 @@ function vipgoci_github_prs_implicated(
 	}
 
 	vipgoci_cache( $cached_id, $prs_implicated );
+
+	// FIXME: Skip draft PRs
 
 	return $prs_implicated;
 }

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -250,7 +250,8 @@ function vipgoci_lint_scan_commit(
 		$repo_name,
 		$commit_id,
 		$github_token,
-		$options['branches-ignore']
+		$options['branches-ignore'],
+		$options['skip-draft-prs']
 	);
 
 

--- a/main.php
+++ b/main.php
@@ -1510,6 +1510,12 @@ function vipgoci_run() {
 		);
 	}
 
+	vipgoci_log(
+		'Found implicated Pull-Requests',
+		array(
+			'prs_implicated' => array_keys( $prs_implicated ),
+		)
+	);
 
 	/*
 	 * Make sure we are working with the latest

--- a/main.php
+++ b/main.php
@@ -246,6 +246,9 @@ function vipgoci_run() {
 			"\t" . '--repo-name=STRING             Specify name of the repository' . PHP_EOL .
 			"\t" . '--commit=STRING                Specify the exact commit to scan (SHA)' . PHP_EOL .
 			"\t" . '--token=STRING                 The access-token to use to communicate with GitHub' . PHP_EOL .
+			PHP_EOL .
+			"\t" . '--skip-draft-prs=BOOL          Skip scanning of all Pull-Requests that are in draft mode.' .
+			PHP_EOL .
 			"\t" . '--results-comments-sort=BOOL     Sort issues found according to severity, from high ' . PHP_EOL .
 			"\t" . '                               to low, before submitting to GitHub. Not sorted by default.' . PHP_EOL .
 			"\t" . '--review-comments-max=NUMBER   Maximum number of inline comments to submit' . PHP_EOL .
@@ -278,6 +281,7 @@ function vipgoci_run() {
 			"\t" . '                                                      avoiding double-posting; they would be ' . PHP_EOL .
 			"\t" . '                                                      excluded. Note that this parameter ' . PHP_EOL .
 			"\t" . '                                                      only works in conjunction with ' . PHP_EOL .
+			PHP_EOL .
 			"\t" . '                                                      --dismissed-reviews-repost-comments' . PHP_EOL .
 			"\t" . '--informational-url=STRING     URL to documentation on what this bot does. Should ' . PHP_EOL .
 			"\t" . '                               start with https:// or https:// ' . PHP_EOL .

--- a/main.php
+++ b/main.php
@@ -138,6 +138,7 @@ function vipgoci_run() {
 			'repo-name:',
 			'commit:',
 			'token:',
+			'skip-draft-prs:',
 			'results-comments-sort:',
 			'review-comments-max:',
 			'review-comments-total-max:',
@@ -743,6 +744,8 @@ function vipgoci_run() {
 	/*
 	 * Handle boolean parameters
 	 */
+
+	vipgoci_option_bool_handle( $options, 'skip-draft-prs', 'false' );
 
 	vipgoci_option_bool_handle( $options, 'phpcs', 'true' );
 
@@ -1401,6 +1404,11 @@ function vipgoci_run() {
 				'valid_values'	=> array( true, false ),
 			),
 
+			'skip-draft-prs'	=> array(
+				'type'		=> 'boolean',
+				'valid_values'	=> array( true, false ),
+			),
+
 			'phpcs-severity' => array(
 				'type'		=> 'integer',
 				'valid_values'	=> array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ),
@@ -1485,7 +1493,8 @@ function vipgoci_run() {
 		$options['repo-name'],
 		$options['commit'],
 		$options['token'],
-		$options['branches-ignore']
+		$options['branches-ignore'],
+		$options['skip-draft-prs']
 	);
 
 	if ( empty( $prs_implicated ) ) {
@@ -1600,6 +1609,7 @@ function vipgoci_run() {
 		$options['commit'],
 		$options['token'],
 		$options['branches-ignore'],
+		$options['skip-draft-prs'],
 		array(
 			VIPGOCI_SYNTAX_ERROR_STR,
 			VIPGOCI_GITHUB_ERROR_STR,

--- a/main.php
+++ b/main.php
@@ -989,10 +989,12 @@ function vipgoci_run() {
 		$options,
 		'repo-options-allowed',
 		array(
+			'skip-execution',
+			'skip-draft-prs',
 			'phpcs-severity',
+			'post-generic-pr-support-comments',
 			'phpcs-sniffs-include',
 			'phpcs-sniffs-exclude',
-			'post-generic-pr-support-comments',
 		)
 	);
 

--- a/main.php
+++ b/main.php
@@ -247,7 +247,8 @@ function vipgoci_run() {
 			"\t" . '--commit=STRING                Specify the exact commit to scan (SHA)' . PHP_EOL .
 			"\t" . '--token=STRING                 The access-token to use to communicate with GitHub' . PHP_EOL .
 			PHP_EOL .
-			"\t" . '--skip-draft-prs=BOOL          Skip scanning of all Pull-Requests that are in draft mode.' .
+			"\t" . '--skip-draft-prs=BOOL          If true, skip scanning of all Pull-Requests that are in draft mode.' . PHP_EOL .
+			"\t" . '                               Default is false.' . PHP_EOL .
 			PHP_EOL .
 			"\t" . '--results-comments-sort=BOOL     Sort issues found according to severity, from high ' . PHP_EOL .
 			"\t" . '                               to low, before submitting to GitHub. Not sorted by default.' . PHP_EOL .

--- a/misc.php
+++ b/misc.php
@@ -506,8 +506,8 @@ function vipgoci_github_transform_to_emojis( $text_string ) {
  * provided.
  */
 function vipgoci_github_pr_remove_drafts( $prs_array ) {
-	$prs_implicated = array_filter(
-		$prs_implicated,
+	$prs_array = array_filter(
+		$prs_array,
 		function( $pr_item ) {
 			if ( (bool) $pr_item->draft === true ) {
 				return false;
@@ -517,7 +517,7 @@ function vipgoci_github_pr_remove_drafts( $prs_array ) {
 		}
 	);
 
-	return $prs_implicated;
+	return $prs_array;
 }
 
 /*

--- a/misc.php
+++ b/misc.php
@@ -501,6 +501,24 @@ function vipgoci_github_transform_to_emojis( $text_string ) {
 	return '';
 }
 
+/*
+ * Remove any draft Pull-Requests from the array
+ * provided.
+ */
+function vipgoci_github_pr_remove_drafts( $prs_array ) {
+	$prs_implicated = array_filter(
+		$prs_implicated,
+		function( $pr_item ) {
+			if ( (bool) $pr_item->draft === true ) {
+				return false;
+			}
+
+			return true;
+		}
+	);
+
+	return $prs_implicated;
+}
 
 /*
  * Determine if the presented file has an

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -342,7 +342,8 @@ function vipgoci_phpcs_scan_commit(
 		$repo_name,
 		$commit_id,
 		$github_token,
-		$options['branches-ignore']
+		$options['branches-ignore'],
+		$options['skip-draft-prs']
 	);
 
 
@@ -1204,7 +1205,8 @@ function vipgoci_phpcs_validate_sniffs_in_options_and_report(
 			$options['repo-name'],
 			$options['commit'],
 			$options['token'],
-			$options['branches-ignore']
+			$options['branches-ignore'],
+			$options['skip-draft-prs']
 		);
 
 		foreach ( $prs_implicated as $pr_item ) {

--- a/support-level-label.php
+++ b/support-level-label.php
@@ -422,7 +422,8 @@ function vipgoci_support_level_label_set(
 		$options['repo-name'],
 		$options['commit'],
 		$options['token'],
-		$options['branches-ignore']
+		$options['branches-ignore'],
+		$options['skip-draft-prs']
 	);
 
 	/*

--- a/tests/GitHubPrsImplicatedTest.php
+++ b/tests/GitHubPrsImplicatedTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 final class GitHubPrsImplicatedTest extends TestCase {
 	var $options_git_repo_tests = array(
 		'commit-test-repo-pr-files-changed-1'	=> null,
+		'commit-test-repo-pr-files-changed-2'	=> null,
 	);
 
 	var $options_git = array(
@@ -55,7 +56,7 @@ final class GitHubPrsImplicatedTest extends TestCase {
 	/**
 	 * @covers ::vipgoci_github_prs_implicated
 	 */
-	public function testGitHubPrsImplicated1() {
+	public function testGitHubPrsImplicatedIncludeDraftPrs() {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array( 'github-token', 'token' ),
@@ -94,6 +95,121 @@ final class GitHubPrsImplicatedTest extends TestCase {
 		$this->assertEquals(
 			'open',
 			$prs_implicated[9]->state
+		);
+
+		unset( $this->options['commit'] );
+	}
+
+	/**
+	 * @covers ::vipgoci_github_prs_implicated
+	 */
+	public function testGitHubPrsImplicatedSkipDraftPrs() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'github-token', 'token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$this->options['commit'] =
+			$this->options['commit-test-repo-pr-files-changed-2'];
+
+		vipgoci_unittests_output_suppress();
+
+		/*
+		 * Get all PRs, draft and non-draft.
+		 */
+		$prs_implicated = vipgoci_github_prs_implicated(
+			$this->options['repo-owner'],
+			$this->options['repo-name'],
+			$this->options['commit'],
+			$this->options['github-token'],
+			$this->options['branches-ignore'],
+			false
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertCount(
+			2,
+			$prs_implicated
+		);
+
+		/*
+		 * Verify non-draft PR.
+		 */
+		$this->assertEquals(
+			'open',
+			$prs_implicated[33]->state
+		);
+
+		$this->assertEquals(
+			463586588,
+			$prs_implicated[33]->id
+		);
+
+		$this->assertEquals(
+			'ac10d1f29e64504d7741cd8ca22981c426c26e9a',
+			$prs_implicated[33]->base->sha
+		);
+
+		/*
+		 * Verify draft PR.
+		 */
+		$this->assertEquals(
+			'open',
+			$prs_implicated[34]->state
+		);
+
+		$this->assertEquals(
+			463587649,
+			$prs_implicated[34]->id
+		);
+
+		$this->assertEquals(
+			'027de6d804e1d40dbe1b13a3ede7cfa758787b85',
+			$prs_implicated[34]->base->sha
+		);
+
+
+		/*
+		 * Now fetch all PRs, draft and non-draft.
+		 */
+		$prs_implicated = vipgoci_github_prs_implicated(
+			$this->options['repo-owner'],
+			$this->options['repo-name'],
+			$this->options['commit'],
+			$this->options['github-token'],
+			$this->options['branches-ignore'],
+			true
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertCount(
+			1,
+			$prs_implicated
+		);
+
+		/*
+		 * Verify non-draft PR.
+		 */
+		$this->assertEquals(
+			'open',
+			$prs_implicated[33]->state
+		);
+
+		$this->assertEquals(
+			463586588,
+			$prs_implicated[33]->id
+		);
+
+		$this->assertEquals(
+			'ac10d1f29e64504d7741cd8ca22981c426c26e9a',
+			$prs_implicated[33]->base->sha
 		);
 
 		unset( $this->options['commit'] );

--- a/tests/GitHubPrsImplicatedTest.php
+++ b/tests/GitHubPrsImplicatedTest.php
@@ -117,11 +117,12 @@ final class GitHubPrsImplicatedTest extends TestCase {
 		$this->options['commit'] =
 			$this->options['commit-test-repo-pr-files-changed-2'];
 
-		vipgoci_unittests_output_suppress();
-
 		/*
 		 * Get all PRs, draft and non-draft.
 		 */
+
+		vipgoci_unittests_output_suppress();
+
 		$prs_implicated = vipgoci_github_prs_implicated(
 			$this->options['repo-owner'],
 			$this->options['repo-name'],
@@ -174,10 +175,38 @@ final class GitHubPrsImplicatedTest extends TestCase {
 			$prs_implicated[34]->base->sha
 		);
 
+		/*
+		 * Repeat fetching of PRs, and check
+		 * if we get the same result as earlier.
+		 */
+
+		vipgoci_unittests_output_suppress();
+
+		$prs_implicated_2 = vipgoci_github_prs_implicated(
+			$this->options['repo-owner'],
+			$this->options['repo-name'],
+			$this->options['commit'],
+			$this->options['github-token'],
+			$this->options['branches-ignore'],
+			false
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertEquals(
+			$prs_implicated,
+			$prs_implicated_2
+		);
+
+		unset( $prs_implicated );
+		unset( $prs_implicated_2 );
 
 		/*
 		 * Now fetch all PRs, draft and non-draft.
 		 */
+	
+		vipgoci_unittests_output_suppress();
+
 		$prs_implicated = vipgoci_github_prs_implicated(
 			$this->options['repo-owner'],
 			$this->options['repo-name'],
@@ -211,6 +240,33 @@ final class GitHubPrsImplicatedTest extends TestCase {
 			'ac10d1f29e64504d7741cd8ca22981c426c26e9a',
 			$prs_implicated[33]->base->sha
 		);
+
+		/*
+		 * Repeat and check if we get the same
+		 * results again. This is to check if
+		 * the caching-functionality works correctly.
+		 */
+		vipgoci_unittests_output_suppress();
+
+		$prs_implicated_2 = vipgoci_github_prs_implicated(
+			$this->options['repo-owner'],
+			$this->options['repo-name'],
+			$this->options['commit'],
+			$this->options['github-token'],
+			$this->options['branches-ignore'],
+			true
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertEquals(
+			$prs_implicated,
+			$prs_implicated_2
+		);
+
+
+		unset( $prs_implicated );
+		unset( $prs_implicated_2 );
 
 		unset( $this->options['commit'] );
 	}

--- a/tests/GitHubPrsImplicatedTest.php
+++ b/tests/GitHubPrsImplicatedTest.php
@@ -157,6 +157,11 @@ final class GitHubPrsImplicatedTest extends TestCase {
 			$prs_implicated[33]->base->sha
 		);
 
+		$this->assertEquals(
+			false,
+			$prs_implicated[33]->draft
+		);
+
 		/*
 		 * Verify draft PR.
 		 */
@@ -173,6 +178,11 @@ final class GitHubPrsImplicatedTest extends TestCase {
 		$this->assertEquals(
 			'027de6d804e1d40dbe1b13a3ede7cfa758787b85',
 			$prs_implicated[34]->base->sha
+		);
+
+		$this->assertEquals(
+			true,
+			$prs_implicated[33]->draft
 		);
 
 		/*
@@ -239,6 +249,11 @@ final class GitHubPrsImplicatedTest extends TestCase {
 		$this->assertEquals(
 			'ac10d1f29e64504d7741cd8ca22981c426c26e9a',
 			$prs_implicated[33]->base->sha
+		);
+
+		$this->assertEquals(
+			true,
+			$prs_implicated[33]->draft
 		);
 
 		/*

--- a/tests/GitHubPrsImplicatedTest.php
+++ b/tests/GitHubPrsImplicatedTest.php
@@ -182,7 +182,7 @@ final class GitHubPrsImplicatedTest extends TestCase {
 
 		$this->assertEquals(
 			true,
-			$prs_implicated[33]->draft
+			$prs_implicated[34]->draft
 		);
 
 		/*
@@ -252,7 +252,7 @@ final class GitHubPrsImplicatedTest extends TestCase {
 		);
 
 		$this->assertEquals(
-			true,
+			false,
 			$prs_implicated[33]->draft
 		);
 

--- a/tests/GitHubPrsImplicatedTest.php
+++ b/tests/GitHubPrsImplicatedTest.php
@@ -103,7 +103,7 @@ final class GitHubPrsImplicatedTest extends TestCase {
 	/**
 	 * @covers ::vipgoci_github_prs_implicated
 	 */
-	public function testGitHubPrsImplicatedSkipDraftPrs() {
+	public function testGitHubPrsImplicatedSkipDraftPrsFalse() {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array( 'github-token', 'token' ),
@@ -207,9 +207,25 @@ final class GitHubPrsImplicatedTest extends TestCase {
 			$prs_implicated,
 			$prs_implicated_2
 		);
+	}
 
-		unset( $prs_implicated );
-		unset( $prs_implicated_2 );
+	/**
+	 * @covers ::vipgoci_github_prs_implicated
+	 */
+	public function testGitHubPrsImplicatedSkipDraftPrsTrue() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'github-token', 'token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$this->options['commit'] =
+			$this->options['commit-test-repo-pr-files-changed-2'];
+
 
 		/*
 		 * Now fetch all PRs, draft and non-draft.
@@ -278,10 +294,6 @@ final class GitHubPrsImplicatedTest extends TestCase {
 			$prs_implicated,
 			$prs_implicated_2
 		);
-
-
-		unset( $prs_implicated );
-		unset( $prs_implicated_2 );
 
 		unset( $this->options['commit'] );
 	}

--- a/tests/MiscGitHubPrRemoveDraftsTest.php
+++ b/tests/MiscGitHubPrRemoveDraftsTest.php
@@ -33,7 +33,7 @@ final class MiscGitHubPrRemoveDraftsTest extends TestCase {
 
 		$this->assertEquals(
 			array(
-				(object) array(
+				1 => (object) array(
 	 				'url'		=> 'https://myapi2.mydomain.is',
 					'id'		=> 999,
 					'node_id'	=> 'testing2',

--- a/tests/MiscGitHubPrRemoveDraftsTest.php
+++ b/tests/MiscGitHubPrRemoveDraftsTest.php
@@ -27,7 +27,7 @@ final class MiscGitHubPrRemoveDraftsTest extends TestCase {
 			)
 		);
 
-		vipgoci_github_pr_remove_drafts(
+		$prs_array = vipgoci_github_pr_remove_drafts(
 			$prs_array
 		);
 

--- a/tests/MiscGitHubPrRemoveDraftsTest.php
+++ b/tests/MiscGitHubPrRemoveDraftsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class MiscGitHubPrRemoveDraftsTest extends TestCase {
+	/**
+	 * @covers ::vipgoci_github_pr_remove_drafts
+	 */
+	public function testRemoveDraftPrs() {
+		$prs_array = array(
+			(object) array(
+				'url'		=> 'https://myapi.mydomain.is',
+				'id'		=> 123,
+				'node_id'	=> 'testing',
+				'state'		=> 'open',
+				'draft'		=> true
+			),
+
+			(object) array(
+ 				'url'		=> 'https://myapi2.mydomain.is',
+				'id'		=> 999,
+				'node_id'	=> 'testing2',
+				'state'		=> 'open',
+				'draft'		=> false
+			)
+		);
+
+		vipgoci_github_pr_remove_drafts(
+			$prs_array
+		);
+
+		$this->assertEquals(
+			array(
+				(object) array(
+	 				'url'		=> 'https://myapi2.mydomain.is',
+					'id'		=> 999,
+					'node_id'	=> 'testing2',
+					'state'		=> 'open',
+					'draft'		=> false
+				)
+			),
+			$prs_array
+		);
+	}
+}

--- a/unittests.ini
+++ b/unittests.ini
@@ -68,6 +68,7 @@ commit-test-scandir-repo-test-2=ec9baf6e10a617f67ae1d8414634092b40b16faf
 pr-test-labels-fetch-test-1=7
 commit-test-repo-fetch-commit-info-1=2533219d08192025f3209a17ddcf9ff21845a08c
 commit-test-repo-pr-files-changed-1=2533219d08192025f3209a17ddcf9ff21845a08c
+commit-test-repo-pr-files-changed-2=2ff5983d07a285612391372aef86b12b5f357bac
 commit-test-repo-prs-commits-list-1=2533219d08192025f3209a17ddcf9ff21845a08c
 pr-test-repo-prs-commits-list-1=9
 commit-test-repo-pr-diffs-1-a=8aec166b17a264cf0277ade9904e3c25a98649b0


### PR DESCRIPTION
Implements `--skip-draft-prs` so that Pull-Requests that are in draft-mode can be skipped from scanning in entirety. 

Resolves #101.

***

TODO:
- [x] Finish implementing changes to `vipgoci_github_prs_implicated()`
- [x] Add unit-tests for the new option
- [x] Test the changes
- [x] Update README