### PR TITLE
Fixing strtolower() in vipgoci_option_phpcs_runtime_set(), adding unit-test

### DIFF
--- a/main.php
+++ b/main.php
@@ -339,7 +339,7 @@ function vipgoci_run() {
 			"\t" . '--phpcs-runtime-set=STRING     Specify --runtime-set values passed on to PHPCS' . PHP_EOL .
 			"\t" . '                               -- expected to be a comma-separated value string of ' . PHP_EOL .
 			"\t" . '                               key-value pairs.' . PHP_EOL .
-			"\t" . '                               For example: --phpcs-runtime-set="foo1 bar1, foo2,bar2"' . PHP_EOL .
+			"\t" . '                               For example: --phpcs-runtime-set="key1 value1,key2 value2"' . PHP_EOL .
 			"\t" . '--phpcs-skip-scanning-via-labels-allowed=BOOL    Whether to allow users to skip ' . PHP_EOL .
 			"\t" . '                                                 PHPCS scanning of Pull-Requests ' . PHP_EOL .
 			"\t" . '                                                 via labels attached to them. ' . PHP_EOL .

--- a/options.php
+++ b/options.php
@@ -1389,7 +1389,8 @@ function vipgoci_option_phpcs_runtime_set(
 		$option_name,
 		array(),
 		array(),
-		','
+		',',
+		false
 	);
 
 	foreach(

--- a/tests/OptionsPhpcsRuntimeSetTest.php
+++ b/tests/OptionsPhpcsRuntimeSetTest.php
@@ -1,0 +1,55 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class VipgociOptionsPhpcsRuntimeSetTest extends TestCase {
+	/**
+	 * @covers ::vipgoci_option_phpcs_runtime_set
+	 */
+	public function testOptionsPhpcsRuntimeSet1() {
+		$this->options = array(
+			'myphpcsruntimeoption' => 'testVersion 7.4-,allowUnusedVariablesBeforeRequire true,allowUndefinedVariablesInFileScope false',
+			'other-option1' => '123 456',
+			'other-option2' => array(
+				'1',
+				'2',
+			)
+		);
+
+		vipgoci_option_phpcs_runtime_set(
+			$this->options,
+			'myphpcsruntimeoption',
+		);
+
+		$this->assertEquals(
+			array(
+				'myphpcsruntimeoption' => array(
+					array(
+						'testVersion',
+						'7.4-'
+					),
+					array(
+						'allowUnusedVariablesBeforeRequire',
+						'true',
+					),
+					array(
+						'allowUndefinedVariablesInFileScope',
+						'false'
+					),
+				),
+				'other-option1' => '123 456',
+				'other-option2' => array(
+					'1',
+					'2',
+				)
+			),
+			$this->options
+		);
+
+		unset(
+			$this->options
+		);
+	}
+}


### PR DESCRIPTION
Do not use `strtolower()` on configuration parameters passed to `vipgoci_option_phpcs_runtime_set()`. Add unit-test.