### PR TITLE
Enforce HTTPS for all URLs in parameters, do not follow redirects

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -73,6 +73,28 @@ function vipgoci_curl_headers( $ch, $header ) {
 	return $header_len;
 }
 
+/*
+ * Set a few options for cURL that enhance security.
+ */
+function vipgoci_curl_set_security_options( $ch ) {
+	/*
+	 * Maximum number of redirects to zero.
+	 */
+	curl_setopt(
+		$ch,
+		CURLOPT_MAXREDIRS,
+		0
+	);	
+
+	/*
+	 * Do not follow any "Location:" headers.
+	 */
+	curl_setopt(
+		$ch,
+		CURLOPT_FOLLOWLOCATION,
+		false
+	);
+}
 
 /**
  * Detect if we exceeded the GitHub rate-limits,
@@ -442,6 +464,10 @@ function vipgoci_github_post_url(
 			array( 'Authorization: token ' . $github_token )
 		);
 
+		vipgoci_curl_set_security_options(
+			$ch
+		);
+
 		// Make sure to pause between GitHub-requests
 		vipgoci_github_wait();
 
@@ -654,6 +680,10 @@ function vipgoci_github_fetch_url(
 			}
 		}
 
+		vipgoci_curl_set_security_options(
+			$ch
+		);
+
 
 		// Make sure to pause between GitHub-requests
 		vipgoci_github_wait();
@@ -806,6 +836,10 @@ function vipgoci_github_put_url(
 			$ch,
 			CURLOPT_HTTPHEADER,
 			array( 'Authorization: token ' . $github_token )
+		);
+
+		vipgoci_curl_set_security_options(
+			$ch
 		);
 
 		// Make sure to pause between GitHub-requests

--- a/latest-release.php
+++ b/latest-release.php
@@ -16,6 +16,8 @@ curl_setopt( $ch, CURLOPT_URL,			$github_url );
 curl_setopt( $ch, CURLOPT_RETURNTRANSFER,	1 );
 curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT,	20 );
 curl_setopt( $ch, CURLOPT_USERAGENT,	$client_id );
+curl_setopt( $ch, CURLOPT_MAXREDIRS,	0 );
+curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, false );
 
 
 $resp_data_raw = curl_exec( $ch );

--- a/main.php
+++ b/main.php
@@ -152,6 +152,7 @@ function vipgoci_run() {
 			'repo-name:',
 			'commit:',
 			'token:',
+			'enforce-https-urls:',
 			'skip-draft-prs:',
 			'results-comments-sort:',
 			'review-comments-max:',
@@ -223,6 +224,14 @@ function vipgoci_run() {
 	);
 
 	/*
+	 * Handle --enforce-https-urls absolutely first,
+	 * as that is used in processing parameters expecting
+	 * URLs.
+	 */
+	vipgoci_option_bool_handle( $options, 'enforce-https-urls', 'true' );
+
+
+	/*
 	 * Try to read configuration from
 	 * environmental variables.
 	 */
@@ -261,6 +270,9 @@ function vipgoci_run() {
 			"\t" . '--repo-name=STRING             Specify name of the repository' . PHP_EOL .
 			"\t" . '--commit=STRING                Specify the exact commit to scan (SHA)' . PHP_EOL .
 			"\t" . '--token=STRING                 The access-token to use to communicate with GitHub' . PHP_EOL .
+			PHP_EOL .
+			"\t" . '--enforce-https-urls=BOOL      Check and enforce that all URLs provided to parameters ' .PHP_EOL .
+			"\t" . '                               that expect a URL are HTTPS and not HTTP. Default is true.' . PHP_EOL .
 			PHP_EOL .
 			"\t" . '--skip-draft-prs=BOOL          If true, skip scanning of all Pull-Requests that are in draft mode.' . PHP_EOL .
 			"\t" . '                               Default is false.' . PHP_EOL .

--- a/options.php
+++ b/options.php
@@ -972,6 +972,19 @@ function vipgoci_option_url_handle(
 			);
 		}
 	}
+
+	if (
+		( true === $options['enforce-https-urls'] ) &&
+		( 0 !== strpos( $options[ $option_name ], 'https://' ) )
+	) {
+		vipgoci_sysexit(
+			'Option --' . $option_name . ' should ' .
+				'be an URL starting with https://',
+			array(
+			),
+			VIPGOCI_EXIT_USAGE_ERROR
+		);
+	}
 }
 
 /*

--- a/other-web-services.php
+++ b/other-web-services.php
@@ -92,6 +92,10 @@ function vipgoci_irc_api_alerts_send(
 			array( 'Authorization: Bearer ' . $irc_api_token )
 		);
 
+		vipgoci_curl_set_security_options(
+			$ch
+		);
+
 		/*
 		 * Execute query, keep record of how long time it
 		 * took, and keep count of how many requests we do.

--- a/support-level-label.php
+++ b/support-level-label.php
@@ -86,6 +86,10 @@ function vipgoci_repo_meta_api_data_fetch(
 			'vipgoci_curl_headers'
 		);
 
+		vipgoci_curl_set_security_options(
+			$ch
+		);
+
 		vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'repo_meta_data_endpoint_api_request' );
 
 		vipgoci_counter_report(


### PR DESCRIPTION
When checking validity of URLs, make sure they are all HTTPS (start with `https://`). This is to ensure all transfer is done securely.

Also, set curl not to follow any redirects; this is to make sure data is not passed to any host that should not receive it even if redirected.

Resolves #129.