### PR TITLE
PHPCS tmp file index issue

### DIFF
--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -551,6 +551,13 @@ function vipgoci_phpcs_scan_commit(
 
 		unset( $file_issues_str );
 
+		if ( isset( $file_issues_arr_master['files'][ $temp_file_name ] ) ) {
+			$file_issues_arr_index = $file_issues_arr_master['files'][ $temp_file_name ];
+		} else {
+			$file_issues_arr_index = $file_issues_arr_master['files'][ ltrim( $temp_file_name, '/' ) ];
+		}
+
+
 		/*
 		 * Make sure items in $file_issues_arr_master have
 		 * 'level' key and value.
@@ -563,7 +570,7 @@ function vipgoci_phpcs_scan_commit(
 			},
 			$file_issues_arr_master
 				['files']
-				[ ltrim( $temp_file_name, '/' ) ]
+				[ $file_issues_arr_index ]
 				['messages']
 		);
 

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -563,7 +563,7 @@ function vipgoci_phpcs_scan_commit(
 			},
 			$file_issues_arr_master
 				['files']
-				[ $temp_file_name ]
+				[ ltrim( $temp_file_name, '/' ) ]
 				['messages']
 		);
 


### PR DESCRIPTION
**ERROR:**
`
Notice: Undefined index: /tmp/vipgoci-phpcs-scan-WEevWG.php in /home/circleci/project/vip-go-ci/phpcs-scan.php on line 566`

**FIX:**
When PHPCS runs on the temp file it stores the results in an array with the file path being the index key. But the [index key](https://github.com/Automattic/vip-go-ci/blob/master/phpcs-scan.php#L566) doesn't have the preceding `/` in it, but the [temp file name](https://github.com/Automattic/vip-go-ci/blob/master/misc.php#L399) which was passed to the function has `/` in it. In this PR, I'm checking for the index key existence if it is not there then I'm removing the preceding `/` and using it.

