### PR TITLE
Add severity level to output

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -2255,7 +2255,8 @@ function vipgoci_github_pr_review_submit(
 	$commit_id,
 	$results,
 	$informational_url,
-	$github_review_comments_max
+	$github_review_comments_max,
+	$github_review_comments_include_severity
 ) {
 
 	$stats_types_to_process = array(
@@ -2355,6 +2356,18 @@ function vipgoci_github_pr_review_submit(
 					ucfirst( strtolower(
 						$commit_issue['issue']['level']
 						)) .
+
+					(
+						true === $github_review_comments_include_severity ?
+							(
+								'( severity ' .
+								$commit_issue['issue']['severity'] .
+								' )'
+							)
+							:
+							( '' )
+					) .
+
 					'**: ' .
 
 					// Then the message it self

--- a/main.php
+++ b/main.php
@@ -158,6 +158,7 @@ function vipgoci_run() {
 			'review-comments-max:',
 			'review-comments-total-max:',
 			'review-comments-ignore:',
+			'review-comments-include-severity:',
 			'dismiss-stale-reviews:',
 			'dismissed-reviews-repost-comments:',
 			'dismissed-reviews-exclude-reviews-from-team:',
@@ -291,6 +292,9 @@ function vipgoci_run() {
 			"\t" . '                                    -- e.g. useful if one type of message is to be ignored' . PHP_EOL .
 			"\t" . '                                    rather than a whole PHPCS sniff. Should be a ' . PHP_EOL .
 			"\t" . '                                    whole string with items separated by \"|||\".' . PHP_EOL .
+			"\t" . '--review-comments-include-severity=BOOL  Whether to include severity level with' . PHP_EOL .
+			"\t" . '                                         each review comment. Default is false' . PHP_EOL .
+			PHP_EOL .
 			"\t" . '--dismiss-stale-reviews=BOOL   Dismiss any reviews associated with Pull-Requests ' . PHP_EOL .
 			"\t" . '                               that we process which have no active comments. ' . PHP_EOL .
 			"\t" . '                               The Pull-Requests we process are those associated ' . PHP_EOL .
@@ -743,6 +747,8 @@ function vipgoci_run() {
 	vipgoci_option_bool_handle( $options, 'dismissed-reviews-repost-comments', 'true' );
 
 	vipgoci_option_bool_handle( $options, 'results-comments-sort', 'false' );
+
+	vipgoci_option_bool_handle( $options, 'review-comments-include-severity', 'false' );
 
 	if (
 		( false === $options['lint'] ) &&
@@ -1947,7 +1953,8 @@ function vipgoci_run() {
 		$options['commit'],
 		$results,
 		$options['informational-url'],
-		$options['review-comments-max']
+		$options['review-comments-max'],
+		$options['review-comments-include-severity']
 	);
 
 	if ( true === $options['dismiss-stale-reviews'] ) {

--- a/misc.php
+++ b/misc.php
@@ -840,6 +840,16 @@ function vipgoci_github_comment_match(
 		);
 
 		/*
+		 * The comment might include severity level
+		 * -- remove that.
+		 */
+		$comment_made_body = preg_replace(
+			'/\( severity \d{1,2} \)/',
+			'',
+			$comment_made_body
+		);
+
+		/*
 		 * The comment might be prefixed with ': ',
 		 * remove that as well.
 		 */

--- a/tests/MiscGitHubCommentMatchTest.php
+++ b/tests/MiscGitHubCommentMatchTest.php
@@ -40,6 +40,12 @@ final class MiscGitHubCommentMatchTest extends TestCase {
 					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
 				),
 			),
+
+			'bla-11.php:5' => array(
+				json_decode(
+					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-11.php","position":5,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error( severity 11 )**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+				),
+			),
 		);
 
 
@@ -97,5 +103,29 @@ final class MiscGitHubCommentMatchTest extends TestCase {
 				$prs_comments	
 			)
 		);
+
+
+		/*
+		 * Test with severity level
+		 */
+		$this->assertTrue(
+			vipgoci_github_comment_match(
+				'bla-11.php',
+				5,
+				'Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
+				$prs_comments	
+			)
+		);
+
+		$this->assertFalse(
+			vipgoci_github_comment_match(
+				'bla-11.php',
+				5,
+				'Extension \'mysql_\' is deprecated since PHP 300 and removed since PHP 700; Use mysqli instead',
+				$prs_comments	
+			)
+		);
+
+
 	}
 }


### PR DESCRIPTION
Patch so that severity level is printed in review comments, if configured to do so. Is disabled by default.

TODO:
- [x] Specify a parameter to make this configurable
- [x] Actually output severity
- [x] Update unit-tests as needed
- [x] Update README [not needed]

Resolves #137.