### PR TITLE
Handle filename in PHPCS output without leading '/'

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -41,9 +41,28 @@ function vipgoci_curl_headers( $ch, $header ) {
 
 
 	/*
-	 * Turn the header into an array
+	 * Get header length
 	 */
 	$header_len = strlen( $header );
+
+	/*
+	 * Construct 'status' HTTP header based on the
+	 * HTTP status code. This used to be provided
+	 * by GitHub, but is not anymore.
+	 */
+
+	if ( strpos( $header, 'HTTP/' ) === 0 ) {
+		$header = explode(
+			' ',
+			$header
+		);
+
+		$header = 'Status: ' . $header[1] . "\n\r";
+	}
+
+	/*
+	 * Turn the header into an array
+	 */
 	$header = explode( ':', $header, 2 );
 
 	if ( count( $header ) < 2 ) {

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -182,7 +182,8 @@ function vipgoci_lint_parse_results(
 
 			$file_issues_arr_new[ $file_line ][] = array(
 				'message' => $message,
-				'level' => 'ERROR'
+				'level' => 'ERROR',
+				'severity' => 5,
 			);
 		}
 	}

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -552,6 +552,49 @@ function vipgoci_phpcs_scan_commit(
 		unset( $file_issues_str );
 
 		/*
+		 * In some cases filename in PHPCS output
+		 * is without leading "/", but usually it is
+		 * with leading "/". Make sure we cover both
+		 * cases here.
+		 */
+	
+		/* First attempt the default, with leading "/" */
+		if ( isset(
+			$file_issues_arr_master
+				['files']
+				[ $temp_file_name ]
+		) ) {
+			$file_issues_arr_index = 
+				$temp_file_name;
+		}
+
+		/* If this fails, try without leading "/" */
+		else if ( isset(
+			$file_issues_arr_master
+				['files']
+				[ ltrim( $temp_file_name, '/' ) ]
+		) ) {
+			$file_issues_arr_index = 
+				ltrim( $temp_file_name, '/' );
+		}
+
+		/* Everything failed, print error and continue */
+		else {
+			/* Empty placeholder, to avoid warnings. */
+			$files_issues_arr[ $file_name ] = array();
+
+			vipgoci_log(
+				'Unable to read results of PHPCS scanning, missing index',
+				array(
+					'temp_file_name'	=> $temp_file_name,
+					'file_issues_arr_index'	=> $file_issues_arr_index,
+				)
+			);
+
+			continue;
+		}
+
+		/*
 		 * Make sure items in $file_issues_arr_master have
 		 * 'level' key and value.
 		 */
@@ -563,7 +606,7 @@ function vipgoci_phpcs_scan_commit(
 			},
 			$file_issues_arr_master
 				['files']
-				[ $temp_file_name ]
+				[ $file_issues_arr_index ]
 				['messages']
 		);
 

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -587,7 +587,6 @@ function vipgoci_phpcs_scan_commit(
 				'Unable to read results of PHPCS scanning, missing index',
 				array(
 					'temp_file_name'	=> $temp_file_name,
-					'file_issues_arr_index'	=> $file_issues_arr_index,
 				)
 			);
 

--- a/tests/A09LintLintScanCommitTest.php
+++ b/tests/A09LintLintScanCommitTest.php
@@ -162,6 +162,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 						'issue' => array(
 							'message'	=> "syntax error, unexpected end of file, expecting ',' or ';'",
 							'level'		=> 'ERROR',
+							'severity'	=> 5,
 						)
 					)
 				)
@@ -288,6 +289,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 						'issue' => array(
 							'message'	=> "syntax error, unexpected end of file, expecting ',' or ';'",
 							'level'		=> 'ERROR',
+							'severity'	=> 5,
 						)
 					),
 					array(
@@ -297,6 +299,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 						'issue' => array(
 							'message'	=> "syntax error, unexpected end of file, expecting ',' or ';'",
 							'level'		=> 'ERROR',
+							'severity'	=> 5,
 						)
 					),
 					/*

--- a/tests/GitHubApiCurlHeadersTest.php
+++ b/tests/GitHubApiCurlHeadersTest.php
@@ -56,4 +56,53 @@ final class GitHubApiCurlHeadersTest extends TestCase {
 			$actual_results
 		);
 	}
+
+	/**
+	 * Test Status compatibility header.
+	 *
+	 * @covers ::vipgoci_curl_headers
+	 */
+	public function testCurlHeaders2() {
+		/*
+		 * Make sure it is empty before starting.
+		 */
+		vipgoci_curl_headers(
+			null,
+			null
+		);
+
+		/*
+		 * Populate headers
+		 */
+
+		vipgoci_curl_headers(
+			'',
+			'HTTP/2 205'
+		);
+
+		vipgoci_curl_headers(
+			'',
+			'Date: Mon, 04 Mar 2020 16:43:35 GMT'
+		);
+
+		vipgoci_curl_headers(
+			'',
+			'Location: https://www.kernel.org/'
+		);
+
+
+		$actual_results = vipgoci_curl_headers(
+			null,
+			null
+		);
+
+		$this->assertEquals(
+			array(
+				'date'		=> array( 'Mon, 04 Mar 2020 16:43:35 GMT' ),
+				'location'	=> array( 'https://www.kernel.org/' ),
+				'status'	=> array( 205 ),
+			),
+			$actual_results
+		);
+	}
 }

--- a/tests/LintLintGetIssuesTest.php
+++ b/tests/LintLintGetIssuesTest.php
@@ -119,6 +119,7 @@ final class LintLintGetIssuesTest extends TestCase {
 					array(
 						'message' 	=> "syntax error, unexpected end of file, expecting ',' or ';'",
 						'level'		=> 'ERROR',
+						'severity'	=> 5,
 					)
 				)
 			),


### PR DESCRIPTION
With some PHPCS rulesets, the following notice might be printed:

> Notice: Undefined index: /tmp/vipgoci-phpcs-scan-WEevWG.php in /home/circleci/project/vip-go-ci/phpcs-scan.php on line 566

This is because `vip-go-ci` will look for results returned by PHPCS by using the full file-path to the file, but in some cases the leading `/` is skipped in the file-path. This patch will cover both cases.

Note that with PHPCS, the leading `/` can be skipped by using this configuration in the ruleset:

```
<arg name="basepath" value="."/>
```

TODO:
- [N/A] Specify a parameter to make [feature] configurable
- [x] Fix problem with file-path while processing results from PHPCS
- [x] Add unit-test to cover both with and without `/` in file-path
- [N/A] Update README
- [x] Run full-unit tests 
- [x] Check automated unit-tests
