### PR TITLE
Compatibility for Status HTTP header

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -41,9 +41,28 @@ function vipgoci_curl_headers( $ch, $header ) {
 
 
 	/*
-	 * Turn the header into an array
+	 * Get header length
 	 */
 	$header_len = strlen( $header );
+
+	/*
+	 * Construct 'status' HTTP header based on the
+	 * HTTP status code. This used to be provided
+	 * by GitHub, but is not anymore.
+	 */
+
+	if ( strpos( $header, 'HTTP/' ) === 0 ) {
+		$header = explode(
+			' ',
+			$header
+		);
+
+		$header = 'Status: ' . $header[1] . "\n\r";
+	}
+
+	/*
+	 * Turn the header into an array
+	 */
 	$header = explode( ':', $header, 2 );
 
 	if ( count( $header ) < 2 ) {

--- a/tests/GitHubApiCurlHeadersTest.php
+++ b/tests/GitHubApiCurlHeadersTest.php
@@ -56,4 +56,53 @@ final class GitHubApiCurlHeadersTest extends TestCase {
 			$actual_results
 		);
 	}
+
+	/**
+	 * Test Status compatibility header.
+	 *
+	 * @covers ::vipgoci_curl_headers
+	 */
+	public function testCurlHeaders2() {
+		/*
+		 * Make sure it is empty before starting.
+		 */
+		vipgoci_curl_headers(
+			null,
+			null
+		);
+
+		/*
+		 * Populate headers
+		 */
+
+		vipgoci_curl_headers(
+			'',
+			'HTTP/2 205'
+		);
+
+		vipgoci_curl_headers(
+			'',
+			'Date: Mon, 04 Mar 2020 16:43:35 GMT'
+		);
+
+		vipgoci_curl_headers(
+			'',
+			'Location: https://www.kernel.org/'
+		);
+
+
+		$actual_results = vipgoci_curl_headers(
+			null,
+			null
+		);
+
+		$this->assertEquals(
+			array(
+				'date'		=> array( 'Mon, 04 Mar 2020 16:43:35 GMT' ),
+				'location'	=> array( 'https://www.kernel.org/' ),
+				'status'	=> array( 205 ),
+			),
+			$actual_results
+		);
+	}
 }


### PR DESCRIPTION
This patch will add a `Status` HTTP header into the array of headers returned by the `vipgoci_curl_headers` function. This header used to be returned by the GitHub API but this seems not to be the case anymore. This patch will solve this issue.

TODO:
- [X] Add compatibility for `Status` header.
- [x] Add/update unit-tests
- [x] Run full-unit tests 
- [x] Check automated unit-tests
