### PR TITLE
Add severity for PHP linting

### DIFF
--- a/lint-scan.php
+++ b/lint-scan.php
@@ -182,7 +182,8 @@ function vipgoci_lint_parse_results(
 
 			$file_issues_arr_new[ $file_line ][] = array(
 				'message' => $message,
-				'level' => 'ERROR'
+				'level' => 'ERROR',
+				'severity' => 5,
 			);
 		}
 	}

--- a/tests/A09LintLintScanCommitTest.php
+++ b/tests/A09LintLintScanCommitTest.php
@@ -162,6 +162,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 						'issue' => array(
 							'message'	=> "syntax error, unexpected end of file, expecting ',' or ';'",
 							'level'		=> 'ERROR',
+							'severity'	=> 5,
 						)
 					)
 				)
@@ -288,6 +289,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 						'issue' => array(
 							'message'	=> "syntax error, unexpected end of file, expecting ',' or ';'",
 							'level'		=> 'ERROR',
+							'severity'	=> 5,
 						)
 					),
 					array(
@@ -297,6 +299,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 						'issue' => array(
 							'message'	=> "syntax error, unexpected end of file, expecting ',' or ';'",
 							'level'		=> 'ERROR',
+							'severity'	=> 5,
 						)
 					),
 					/*

--- a/tests/LintLintGetIssuesTest.php
+++ b/tests/LintLintGetIssuesTest.php
@@ -119,6 +119,7 @@ final class LintLintGetIssuesTest extends TestCase {
 					array(
 						'message' 	=> "syntax error, unexpected end of file, expecting ',' or ';'",
 						'level'		=> 'ERROR',
+						'severity'	=> 5,
 					)
 				)
 			),


### PR DESCRIPTION
This Pull-Request adds severity field for PHP linting results.

TODO:
- [X]  Add severity field to results
- [X] Add/update unit-tests
- [X] Update README
- [x] Run full-unit tests 
- [x] Check automated unit-tests
