### PR TITLE
Make support level field configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ repo-meta-api-user-id=          ; User ID for the meta API
 repo-meta-api-access-token=     ; Access token for the meta API
 repo-owner=                     ; Repository owner for the test, should be found in meta API
 repo-name=                      ; Repository name for the test
-support-tier-name=              ; Name of support tier given by meta API
+support-level=                  ; Name of support tier given by meta API
 ```
 
 This file is not included, and needs to be configured manually. When that is complete, the tests can be re-run.

--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ For example:
 
 This feature can be used in the following way:
 
-> ./vip-go-ci.php --set-support-level-label=true --repo-meta-api-base-url="http://myrepometa-api.mycompany.is" --repo-meta-api-user-id=7334005 --repo-meta-api-access-token="MY-TOKEN"
+> ./vip-go-ci.php --set-support-level-label=true --set-support-level-field="support-level" --repo-meta-api-base-url="http://myrepometa-api.mycompany.is" --repo-meta-api-user-id=7334005 --repo-meta-api-access-token="MY-TOKEN"
 
 Note that by default, all support level labels have a prefix: `[Support Level]`. This can be changed by using the `--set-support-level-label-prefix` option.
 

--- a/README.md
+++ b/README.md
@@ -621,7 +621,8 @@ repo-meta-api-user-id=          ; User ID for the meta API
 repo-meta-api-access-token=     ; Access token for the meta API
 repo-owner=                     ; Repository owner for the test, should be found in meta API
 repo-name=                      ; Repository name for the test
-support-level=                  ; Name of support tier given by meta API
+support-level=                  ; Name of support level given by meta API
+support-level-field-name=       ; Support level field name in meta API
 ```
 
 This file is not included, and needs to be configured manually. When that is complete, the tests can be re-run.

--- a/main.php
+++ b/main.php
@@ -173,6 +173,7 @@ function vipgoci_run() {
 			'post-generic-pr-support-comments-repo-meta-match:',
 			'set-support-level-label:',
 			'set-support-level-label-prefix:',
+			'set-support-level-field:',
 			'repo-meta-api-base-url:',
 			'repo-meta-api-user-id:',
 			'repo-meta-api-access-token:',
@@ -339,6 +340,7 @@ function vipgoci_run() {
 			"\t" . '--set-support-level-label=BOOL       Whether to attach support level labels to Pull-Requests. ' . PHP_EOL .
 			"\t" . '                                     Will fetch information on support levels from repo-meta API. ' . PHP_EOL .
 			"\t" . '--set-support-level-label-prefix=STRING    Prefix to use for support level labels. Should be longer than five letters.' . PHP_EOL .
+			"\t" . '--set-support-level-field=STRING     Name for field in responses from repo-meta API which we use to extract support level. ' . PHP_EOL .
 			"\t" . '--repo-meta-api-base-url=STRING      Base URL to repo-meta API, containing support level and other ' . PHP_EOL .
 			"\t" . '                                     information. ' . PHP_EOL .
 			"\t" . '--repo-meta-api-user-id=STRING       Authentication detail for the repo-meta API. ' . PHP_EOL .
@@ -831,7 +833,7 @@ function vipgoci_run() {
 
 	/*
 	 * Handle option for setting support
-	 * labels. Handle prefix too.
+	 * labels. Handle prefix and field too.
 	 */
 
 	vipgoci_option_bool_handle( $options, 'set-support-level-label', 'false' );
@@ -847,6 +849,19 @@ function vipgoci_run() {
 
 	else {
 		$options['set-support-level-label-prefix'] = null;
+	}
+
+	if (
+		( isset( $options['set-support-level-field'] ) ) &&
+		( strlen( $options['set-support-level-field'] ) > 1 )
+	) {
+		$options['set-support-level-field'] = trim(
+			$options['set-support-level-field']
+		);
+	}
+
+	else {
+		$options['set-support-level-field'] = null;
 	}
 
 	/*

--- a/support-level-label.php
+++ b/support-level-label.php
@@ -319,12 +319,21 @@ function vipgoci_support_level_label_set(
 		( empty( $options['repo-meta-api-base-url'] ) )
 	) {
 		vipgoci_log(
-			'Missing configuration for repo-meta API, skipping'
+			'Missing URL for repo-meta API, skipping'
 		);
 
 		return false;
 	}
 
+	if (
+		( empty( $options['set-support-level-field'] ) )
+	) {
+		vipgoci_log(
+			'Missing field for support level in repo-meta API, skipping'
+		);
+
+		return false;
+	}
 
 	/*
 	 * Get information from API about the
@@ -361,7 +370,9 @@ function vipgoci_support_level_label_set(
 		) )
 		&&
 		( ! empty(
-			$repo_meta_data['data'][0]['support_tier']
+			$repo_meta_data['data'][0][
+				$options['set-support-level-field']
+			]
 		) )
 	) {
 		/*
@@ -373,9 +384,17 @@ function vipgoci_support_level_label_set(
 			$support_label_prefix .
 			' ' .
 			ucfirst( strtolower(
-				$repo_meta_data['data'][0]['support_tier']
+				$repo_meta_data['data'][0][
+					$options['set-support-level-field']
+				]
 			) );
 	}
+
+	$support_level_response = (
+		isset( $repo_meta_data['data'][0][ $options['set-support-level-field'] ] ) ?
+		$repo_meta_data['data'][0][ $options['set-support-level-field'] ] :
+		''
+	);
 
 	/*
 	 * No support label found in API, so
@@ -389,11 +408,7 @@ function vipgoci_support_level_label_set(
 				'repo_owner'			=> $options['repo-owner'],
 				'repo_name'			=> $options['repo-name'],
 				'repo_meta_api_base_url'	=> $options['repo-meta-api-base-url'],
-				'support_tier'			=> (
-					isset( $repo_meta_data['data'][0]['support_tier'] ) ?
-					$repo_meta_data['data'][0]['support_tier'] :
-					''
-				),
+				'support_level_response'	=> $support_level_response,
 			)
 		);
 
@@ -407,11 +422,7 @@ function vipgoci_support_level_label_set(
 				'repo_owner'			=> $options['repo-owner'],
 				'repo_name'			=> $options['repo-name'],
 				'repo_meta_api_base_url'	=> $options['repo-meta-api-base-url'],
-				'support_tier'			=> (
-					isset( $repo_meta_data['data'][0]['support_tier'] ) ?
-					$repo_meta_data['data'][0]['support_tier'] :
-					''
-				),
+				'support_level_response'	=> $support_level_response,
 				'support_label_from_api'	=> $support_label_from_api,
 			)
 		);

--- a/tests/SupportLevelLabelMetaApiDataFetchTest.php
+++ b/tests/SupportLevelLabelMetaApiDataFetchTest.php
@@ -13,7 +13,8 @@ final class SupportLevelLabelMetaApiDataFetchTest extends TestCase {
 		'repo-owner'			=> null,
 		'repo-name'			=> null,
 
-		'support-tier-name'		=> null,
+		'support-level'			=> null,
+		'support-level-field-name'	=> null,
 	);
 
 	protected function setUp(): void {
@@ -61,13 +62,17 @@ final class SupportLevelLabelMetaApiDataFetchTest extends TestCase {
 
 		$this->assertTrue(
 			( ! empty(
-				$repo_meta_data['data'][0]['support_tier']
+				$repo_meta_data['data'][0][
+					$this->options['support-level-field-name']
+				]
 			) )
 		);
 
 		$this->assertEquals(
-			$this->options['support-tier-name'],
-			$repo_meta_data['data'][0]['support_tier']
+			$this->options['support-level'],
+			$repo_meta_data['data'][0][
+				$this->options['support-level-field-name']
+			]
 		);
 
 		/*

--- a/tests/SupportLevelLabelRepoMetaApiDataMatchTest.php
+++ b/tests/SupportLevelLabelRepoMetaApiDataMatchTest.php
@@ -13,7 +13,8 @@ final class SupportLevelLabelRepoMetaApiDataMatchTest extends TestCase {
 		'repo-name'			=> null,
 		'repo-owner'			=> null,
 
-		'support-tier-name'		=> null,
+		'support-level'			=> null,
+		'support-level-field-name'	=> null,
 	);
 
 	protected function setUp(): void {
@@ -44,8 +45,8 @@ final class SupportLevelLabelRepoMetaApiDataMatchTest extends TestCase {
 
 		$this->options['data_match2'] = array(
 			2 => array(
-				'support_tier'	=> array(
-					$this->options['support-tier-name']
+				$this->options['support-level-field-name'] => array(
+					$this->options['support-level']
 				),
 			),
 

--- a/tests/SupportLevelLabelSetTest.php
+++ b/tests/SupportLevelLabelSetTest.php
@@ -10,7 +10,8 @@ final class SupportLevelLabelSetTest extends TestCase {
 		'repo-meta-api-user-id'		=> null,
 		'repo-meta-api-access-token'	=> null,
 
-		'support-tier-name'		=> null,
+		'support-level'			=> null,
+		'support-level-field-name'	=> null,
 	);
 
 	var $options_git = array(
@@ -105,7 +106,7 @@ final class SupportLevelLabelSetTest extends TestCase {
 
 			foreach( $pr_item_labels as $label_item ) {
 				if ( 
-					$this->options['set-support-level-label-prefix'] . ' ' . ucfirst( strtolower( $this->options['support-tier-name'] ) )
+					$this->options['set-support-level-label-prefix'] . ' ' . ucfirst( strtolower( $this->options['support-level'] ) )
 					===
 					$label_item->name
 				) {
@@ -128,7 +129,10 @@ final class SupportLevelLabelSetTest extends TestCase {
 		);
 
 		$this->options['set-support-level-label'] = false;
-	
+
+		$this->options['set-support-level-field'] =
+			$this->options['support-level-field-name'];
+
 		$level_label = vipgoci_support_level_label_set(
 			$this->options
 		);
@@ -160,6 +164,9 @@ final class SupportLevelLabelSetTest extends TestCase {
 		}
 
 		$this->options['set-support-level-label'] = true;
+
+		$this->options['set-support-level-field'] =
+			$this->options['support-level-field-name'];
 
 		/*
 		 * Get any PRs attached, verify we got at least one.
@@ -219,7 +226,7 @@ final class SupportLevelLabelSetTest extends TestCase {
 
 			foreach( $pr_item_labels as $label_item ) {
 				if (
-					$this->options['set-support-level-label-prefix'] . ' ' . ucfirst( strtolower( $this->options['support-tier-name'] ) ) ===
+					$this->options['set-support-level-label-prefix'] . ' ' . ucfirst( strtolower( $this->options['support-level'] ) ) ===
 					$label_item->name
 				) {
 					/*


### PR DESCRIPTION
Make the field we extract support-level from configurable on the command-line.

TODO:

- [x] Test `--set-support-level-field` parameter
- [x] Update unit-tests:
  - [x] `SupportLevelLabelMetaApiDataFetchTest`
  - [x] `SupportLevelLabelRepoMetaApiDataMatchTest`
- [x] Update README
- [x] Run full-unit tests 
- [x] Check automated unit-tests
