### PR TITLE
Add status code 100 as valid GitHub post response

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -522,7 +522,8 @@ function vipgoci_github_post_url(
 			(
 				( false === $http_delete ) &&
 				( intval( $resp_headers['status'][0] ) !== 200 ) &&
-				( intval( $resp_headers['status'][0] ) !== 201 )
+				( intval( $resp_headers['status'][0] ) !== 201 ) &&
+				( intval( $resp_headers['status'][0] ) !== 100 )
 			)
 
 			||


### PR DESCRIPTION
While using `vip-go-ci` in GitHub actions via [action-phpcs-code-review](https://github.com/rtCamp/action-phpcs-code-review/), recently we started getting an additional comment along with the requested changes from phpcs scan done by vip-go-ci: 
```
GitHub API communication error. Please contact a human. (commit-ID: <id>).
```

On debugging [`$resp_headers`](https://github.com/Automattic/vip-go-ci/blob/221266881d9d96b8b376082e3fd32604bbdf262b/github-api.php#L512) when the post request to submit review comments was done,
<details>
<summary>
the following dump was obtained.
</summary>

```php
array(24) {
  ["status"]=>
  array(1) {
    [0]=>
    string(3) "100"
  }
  ["server"]=>
  array(1) {
    [0]=>
    string(10) "GitHub.com"
  }
  ["date"]=>
  array(1) {
    [0]=>
    string(29) "Thu, 11 Mar 2021 11:33:16 GMT"
  }
  ["content-type"]=>
  array(1) {
    [0]=>
    string(31) "application/json; charset=utf-8"
  }
  ["content-length"]=>
  array(1) {
    [0]=>
    string(4) "1766"
  }
  ["cache-control"]=>
  array(1) {
    [0]=>
    string(32) "private, max-age=60, s-maxage=60"
  }
  ["vary"]=>
  array(2) {
    [0]=>
    string(43) "Accept, Authorization, Cookie, X-GitHub-OTP"
    [1]=>
    string(41) "Accept-Encoding, Accept, X-Requested-With"
  }
  ["etag"]=>
  array(1) {
    [0]=>
    string(66) ""<redacted>""
  }
  ["x-oauth-scopes"]=>
  array(1) {
    [0]=>
    string(32) "repo, workflow, write:discussion"
  }
  ["x-accepted-oauth-scopes"]=>
  array(1) {
    [0]=>
    string(0) ""
  }
  ["x-github-media-type"]=>
  array(1) {
    [0]=>
    string(22) "github.v3; format=json"
  }
  ["x-ratelimit-limit"]=>
  array(1) {
    [0]=>
    string(4) "5000"
  }
  ["x-ratelimit-remaining"]=>
  array(1) {
    [0]=>
    string(4) "4924"
  }
  ["x-ratelimit-reset"]=>
  array(1) {
    [0]=>
    string(10) "1615464816"
  }
  ["x-ratelimit-used"]=>
  array(1) {
    [0]=>
    string(2) "76"
  }
  ["access-control-expose-headers"]=>
  array(1) {
    [0]=>
    string(226) "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
  }
  ["access-control-allow-origin"]=>
  array(1) {
    [0]=>
    string(1) "*"
  }
  ["strict-transport-security"]=>
  array(1) {
    [0]=>
    string(44) "max-age=31536000; includeSubdomains; preload"
  }
  ["x-frame-options"]=>
  array(1) {
    [0]=>
    string(4) "deny"
  }
  ["x-content-type-options"]=>
  array(1) {
    [0]=>
    string(7) "nosniff"
  }
  ["x-xss-protection"]=>
  array(1) {
    [0]=>
    string(13) "1; mode=block"
  }
  ["referrer-policy"]=>
  array(1) {
    [0]=>
    string(57) "origin-when-cross-origin, strict-origin-when-cross-origin"
  }
  ["content-security-policy"]=>
  array(1) {
    [0]=>
    string(18) "default-src 'none'"
  }
  ["x-github-request-id"]=>
  array(1) {
    [0]=>
    string(32) "<redacted>"
  }
}
```
</details>

The received status code was 100, leading to failure in [this condition](https://github.com/Automattic/vip-go-ci/blob/221266881d9d96b8b376082e3fd32604bbdf262b/github-api.php#L523-L525) and that is why the comment with the error was getting posted.

>The HTTP 100 Continue informational status response code indicates that everything so far is OK and that the client should continue with the request or ignore it if it is already finished.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/100

With this patch, `vip-go-ci` started working normally as before in GitHub actions. Please let me know if this is the right way forward or if any other changes are needed.