### PR TITLE
Fix bug with vipgoci_gitrepo_blame_for_file()

### DIFF
--- a/git-repo.php
+++ b/git-repo.php
@@ -305,10 +305,10 @@ function vipgoci_gitrepo_fetch_committed_file(
  */
 
 function vipgoci_gitrepo_blame_for_file(
-	$commit_id,
-	$file_name,
-	$local_git_repo
-) {
+	string $commit_id,
+	string $file_name,
+	string $local_git_repo
+): array {
 	vipgoci_gitrepo_ok(
 		$commit_id, $local_git_repo
 	);

--- a/git-repo.php
+++ b/git-repo.php
@@ -409,21 +409,57 @@ function vipgoci_gitrepo_blame_for_file(
 			unset( $tmp_file_arr );
 		}
 
+		/*
+		 * If we see any of these keywords,
+		 * ignore them.
+		 */
+		else if (
+			( count( $result_line_arr ) >= 1 ) &&
+			( in_array(
+				$result_line_arr[0],
+				array(
+					'author', 'author-mail', 'author-time',
+					'author-tz', 'boundary', 'committer',
+					'committer-mail', 'committer-time',
+					'committer-tz', 'summary', 'previous',
+				)
+			) )
+		) {
+			continue;
+		}
 
 		/*
-		 * If we have got commit-ID, line-number
+		 * If line starts with a tab,
+		 * this is our code -- save that.
+		 */
+		else if (
+			( isset( $result_line[0] ) ) &&
+			( ord( $result_line[0] ) === 9 )
+		) {
+			$tmp_content = substr(
+				$result_line,
+				1
+			);
+
+			$current_commit['content'] = $tmp_content;
+		}
+
+		/*
+		 * If we have got commit-ID, line-number, content
 		 * and filename, we can construct a return array
 		 */
 
 		if (
-			( ! empty( $current_commit['commit_id'] ) ) &&
-			( ! empty( $current_commit['number'] ) ) &&
-			( ! empty( $current_commit['filename'] ) )
+			( isset( $current_commit['commit_id'] ) ) &&
+			( isset( $current_commit['number'] ) ) &&
+			( isset( $current_commit['filename'] ) ) &&
+			( isset( $current_commit['content'] ) )
 		) {
 			$blame_log[] = array(
-				'commit_id' => $current_commit['commit_id'],
-				'file_name' => $current_commit['filename'],
-				'line_no' => (int) $current_commit['number'],
+				'commit_id'	=> $current_commit['commit_id'],
+				'file_name'	=> $current_commit['filename'],
+				'line_no'	=> (int) $current_commit['number'],
+				'content'	=> $current_commit['content'],
 			);
 
 			$current_commit = array();

--- a/git-repo.php
+++ b/git-repo.php
@@ -385,8 +385,8 @@ function vipgoci_gitrepo_blame_for_file(
 			( ctype_xdigit( $result_line_arr[0] ) === true )
 		) {
 			$current_commit = array(
-				'commit_id'	=> $result_line_arr[0],
-				'number'	=> $result_line_arr[1],
+				'commit_id'	=> $result_line_arr[0], // Get commit-ID
+				'number'	=> $result_line_arr[2], // Line number in final file
 			);
 		}
 

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -564,7 +564,7 @@ function vipgoci_phpcs_scan_commit(
 				['files']
 				[ $temp_file_name ]
 		) ) {
-			$file_issues_arr_index = 
+			$file_issues_arr_index =
 				$temp_file_name;
 		}
 
@@ -574,7 +574,7 @@ function vipgoci_phpcs_scan_commit(
 				['files']
 				[ ltrim( $temp_file_name, '/' ) ]
 		) ) {
-			$file_issues_arr_index = 
+			$file_issues_arr_index =
 				ltrim( $temp_file_name, '/' );
 		}
 

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -778,6 +778,9 @@ function vipgoci_phpcs_scan_commit(
 				$options['local-git-repo']
 			);
 
+			/*
+			 * Get patch for the file
+			 */
 			$file_changed_lines = vipgoci_patch_changed_lines(
 				$repo_owner,
 				$repo_name,

--- a/tests/GitRepoRepoBlameForFileTest.php
+++ b/tests/GitRepoRepoBlameForFileTest.php
@@ -14,6 +14,7 @@ final class GitRepoRepoBlameForFileTest extends TestCase {
 
 	var $options_git_repo_tests = array(
 		'commit-test-repo-blame-for-file-1'	=> null,
+		'commit-test-repo-blame-for-file-2'	=> null,
 	);
 
 	protected function setUp(): void {
@@ -46,12 +47,16 @@ final class GitRepoRepoBlameForFileTest extends TestCase {
 				$this->options['local-git-repo']
 			);
 		}
+
+		unset( $this->options );
+		unset( $this->options_git );
+		unset( $this->options_git_repo_tests );
 	}
 
 	/**
 	 * @covers ::vipgoci_gitrepo_blame_for_file
 	 */
-	public function testRepoFetchTree1() {
+	public function testGitRepoBlameForFile1() {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array( 'github-token', 'token' ),
@@ -93,8 +98,264 @@ final class GitRepoRepoBlameForFileTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$this->assertEquals(
-			'[{"commit_id":"4869335189752462325aaef4838c9761d56195ce","file_name":"README.md","line_no":1},{"commit_id":"45b9e6479dfba4d54b584d53ace1814ce155d35e","file_name":"README.md","line_no":2}]',
-			json_encode( $ret )
+			array(
+				array(
+					'commit_id'	=> '4869335189752462325aaef4838c9761d56195ce',
+					'file_name'	=> 'README.md',
+					'line_no'	=> 1,
+					'content'	=> '# vip-go-ci-testing',
+				),
+				array(
+					'commit_id'	=> '45b9e6479dfba4d54b584d53ace1814ce155d35e',
+					'file_name'	=> 'README.md',
+					'line_no'	=> 2,
+					'content'	=> 'Pull-Requests, commits and data to test <a href="https://github.com/automattic/vip-go-ci/">vip-go-ci</a>\'s functionality. Please do not remove or alter unless you\'ve contacted the VIP Team first. ',
+				)
+			),
+			$ret
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_gitrepo_blame_for_file
+	 */
+	public function testGitRepoBlameForFile2() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'github-token', 'token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$this->options['commit'] =
+			$this->options['commit-test-repo-blame-for-file-2'];
+
+		vipgoci_unittests_output_suppress();
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
+
+	
+		if ( false === $this->options['local-git-repo'] ) {
+			$this->markTestSkipped(
+				'Could not set up git repository: ' .
+					vipgoci_unittests_output_get()
+			);
+		}
+
+		$this->options['token'] =
+			$this->options['github-token'];
+
+
+		$ret = vipgoci_gitrepo_blame_for_file(
+			$this->options['commit'],
+			'file1.txt',
+			$this->options['local-git-repo']
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertSame(
+			array(
+				array(
+					'commit_id'	=> 'bb001b24bf6bbdd98004ea49511a4290e173a965',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 1,
+					'content'	=> 'Line 1',
+				),
+				array(
+					'commit_id'	=> 'bb001b24bf6bbdd98004ea49511a4290e173a965',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 2,
+					'content'	=> '',
+				),
+				array(
+					'commit_id'	=> '179ed3fa92f15c65b127adb459974d65ff8df053',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 3,
+					'content'	=> 'Line 3',
+				),
+				array(
+					'commit_id'	=> '179ed3fa92f15c65b127adb459974d65ff8df053',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 4,
+					'content'	=> '',
+				),
+				array(
+					'commit_id'	=> '5292767197e77cbd1259671913bd2912b24d7e10',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 5,
+					'content'	=> 'Line 5',
+				),
+				array(
+					'commit_id'	=> '5292767197e77cbd1259671913bd2912b24d7e10',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 6,
+					'content'	=> '',
+				),
+				array(
+					'commit_id'	=> '179ed3fa92f15c65b127adb459974d65ff8df053',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 7,
+					'content'	=> 'Line 7',
+				),
+				array(
+					'commit_id'	=> '179ed3fa92f15c65b127adb459974d65ff8df053',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 8,
+					'content'	=> '',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 9,
+					'content'	=> 'echo "1";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 10,
+					'content'	=> 'echo "2";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 11,
+					'content'	=> 'echo "3";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 12,
+					'content'	=> 'echo "4";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 13,
+					'content'	=> 'echo "5";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 14,
+					'content'	=> 'echo "6";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 15,
+					'content'	=> 'echo "7";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 16,
+					'content'	=> 'echo "8";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 17,
+					'content'	=> 'echo "9";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 18,
+					'content'	=> 'echo "10";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 19,
+					'content'	=> 'echo "11";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 20,
+					'content'	=> 'echo "12";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 21,
+					'content'	=> 'echo "13";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 22,
+					'content'	=> 'echo "14";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 23,
+					'content'	=> 'echo "15";',
+				),
+				array(
+					'commit_id'	=> 'ac5aa2f4199906a2dcb335f97ec053995a59c546',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 24,
+					'content'	=> '',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 25,
+					'content'	=> 'echo "495";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 26,
+					'content'	=> 'echo "496";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 27,
+					'content'	=> 'echo "497";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 28,
+					'content'	=> 'echo "498";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 29,
+					'content'	=> 'echo "499";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 30,
+					'content'	=> 'echo "500";',
+				),
+				array(
+					'commit_id'	=> 'bf3d2edfa286b3531d4f0d491fbb2ce27a75af9e',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 31,
+					'content'	=> '',
+				),
+				array(
+					'commit_id'	=> 'bb001b24bf6bbdd98004ea49511a4290e173a965',
+					'file_name'	=> 'file1.txt',
+					'line_no'	=> 32,
+					'content'	=> 'Last line of file',
+				),
+			),
+			$ret
 		);
 	}
 }

--- a/tests/GitRepoRepoBlameForFileTest.php
+++ b/tests/GitRepoRepoBlameForFileTest.php
@@ -68,7 +68,7 @@ final class GitRepoRepoBlameForFileTest extends TestCase {
 		}
 
 		$this->options['commit'] =
-			$this->options['commit-test-repo-blame-for-file-1'];
+			$this->options['commit-test-repo-blame-for-file-2'];
 
 		vipgoci_unittests_output_suppress();
 
@@ -97,7 +97,7 @@ final class GitRepoRepoBlameForFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				array(
 					'commit_id'	=> '4869335189752462325aaef4838c9761d56195ce',
@@ -114,43 +114,8 @@ final class GitRepoRepoBlameForFileTest extends TestCase {
 			),
 			$ret
 		);
-	}
-
-	/**
-	 * @covers ::vipgoci_gitrepo_blame_for_file
-	 */
-	public function testGitRepoBlameForFile2() {
-		$options_test = vipgoci_unittests_options_test(
-			$this->options,
-			array( 'github-token', 'token' ),
-			$this
-		);
-
-		if ( -1 === $options_test ) {
-			return;
-		}
-
-		$this->options['commit'] =
-			$this->options['commit-test-repo-blame-for-file-2'];
 
 		vipgoci_unittests_output_suppress();
-
-		$this->options['local-git-repo'] =
-			vipgoci_unittests_setup_git_repo(
-				$this->options
-			);
-
-	
-		if ( false === $this->options['local-git-repo'] ) {
-			$this->markTestSkipped(
-				'Could not set up git repository: ' .
-					vipgoci_unittests_output_get()
-			);
-		}
-
-		$this->options['token'] =
-			$this->options['github-token'];
-
 
 		$ret = vipgoci_gitrepo_blame_for_file(
 			$this->options['commit'],

--- a/tests/GitRepoRepoBlameForFileTest.php
+++ b/tests/GitRepoRepoBlameForFileTest.php
@@ -13,7 +13,6 @@ final class GitRepoRepoBlameForFileTest extends TestCase {
 	);
 
 	var $options_git_repo_tests = array(
-		'commit-test-repo-blame-for-file-1'	=> null,
 		'commit-test-repo-blame-for-file-2'	=> null,
 	);
 

--- a/unittests.ini
+++ b/unittests.ini
@@ -62,7 +62,6 @@ commit-test-repo-get-head-1=14f69e021aa814eeaa62566cc8cfa2b426d25b5c
 commit-test-repo-fetch-tree-1=14f69e021aa814eeaa62566cc8cfa2b426d25b5c
 commit-test-repo-fetch-tree-2=14f69e021aa814eeaa62566cc8cfa2b426d25b5c
 commit-test-repo-fetch-committed-file-1=14f69e021aa814eeaa62566cc8cfa2b426d25b5c
-commit-test-repo-blame-for-file-1=14f69e021aa814eeaa62566cc8cfa2b426d25b5c
 commit-test-repo-blame-for-file-2=ac5aa2f4199906a2dcb335f97ec053995a59c546
 commit-test-scandir-repo-test-1=ec9baf6e10a617f67ae1d8414634092b40b16faf
 commit-test-scandir-repo-test-2=ec9baf6e10a617f67ae1d8414634092b40b16faf

--- a/unittests.ini
+++ b/unittests.ini
@@ -63,6 +63,7 @@ commit-test-repo-fetch-tree-1=14f69e021aa814eeaa62566cc8cfa2b426d25b5c
 commit-test-repo-fetch-tree-2=14f69e021aa814eeaa62566cc8cfa2b426d25b5c
 commit-test-repo-fetch-committed-file-1=14f69e021aa814eeaa62566cc8cfa2b426d25b5c
 commit-test-repo-blame-for-file-1=14f69e021aa814eeaa62566cc8cfa2b426d25b5c
+commit-test-repo-blame-for-file-2=ac5aa2f4199906a2dcb335f97ec053995a59c546
 commit-test-scandir-repo-test-1=ec9baf6e10a617f67ae1d8414634092b40b16faf
 commit-test-scandir-repo-test-2=ec9baf6e10a617f67ae1d8414634092b40b16faf
 pr-test-labels-fetch-test-1=7


### PR DESCRIPTION
Fix bug with `vipgoci_gitrepo_blame_for_file()` which can lead to changes being excluded from reporting.

TODO:
- [x] Fix bug in `vipgoci_gitrepo_blame_for_file()` so that the correct line number is used from the `git blame` log
- [x] Review the code to ensure the fix does not lead to unexpected behaviour
- [x] Add unit-test to test bugfix
- [x] Run full-unit tests 
- [x] Check automated unit-tests
- [x] More testing

This was discovered while working on #153.