### PR TITLE
Update VIP-Coding-Standards to version 2.3.2

### DIFF
--- a/tools-init.sh
+++ b/tools-init.sh
@@ -11,8 +11,8 @@ export PHP_CODESNIFFER_VER="3.5.5"
 export PHP_CODESNIFFER_SHA1SUM="0f51879e5caa7147ef47f61f7b3ecdc2d088422a"
 
 # https://github.com/WordPress/WordPress-Coding-Standards/releases
-export WP_CODING_STANDARDS_VER="2.3.0"
-export WP_CODING_STANDARDS_SHA1SUM="c8161d77fcf63bdeaa3e8e6aa36bc1936b469070";
+export WP_CODING_STANDARDS_VER="2.3.1"
+export WP_CODING_STANDARDS_SHA1SUM="e453ebe79917af242de572edccffb2933fc83364";
 
 # https://github.com/automattic/vip-coding-standards/releases
 export VIP_CODING_STANDARDS_VER="2.3.0"

--- a/tools-init.sh
+++ b/tools-init.sh
@@ -15,8 +15,8 @@ export WP_CODING_STANDARDS_VER="2.3.0"
 export WP_CODING_STANDARDS_SHA1SUM="c8161d77fcf63bdeaa3e8e6aa36bc1936b469070";
 
 # https://github.com/automattic/vip-coding-standards/releases
-export VIP_CODING_STANDARDS_VER="2.2.0"
-export VIP_CODING_STANDARDS_SHA1SUM="65e14a1e95288cb4cf29b216c89a338e6523ec52";
+export VIP_CODING_STANDARDS_VER="2.3.0"
+export VIP_CODING_STANDARDS_SHA1SUM="2b4259564f3fcc0b432ef30378d24907e856cde3";
 
 # https://github.com/sirbrillig/phpcs-variable-analysis/releases
 export PHPCS_VARIABLE_ANALYSIS_VER="2.9.0"

--- a/tools-init.sh
+++ b/tools-init.sh
@@ -11,12 +11,12 @@ export PHP_CODESNIFFER_VER="3.5.5"
 export PHP_CODESNIFFER_SHA1SUM="0f51879e5caa7147ef47f61f7b3ecdc2d088422a"
 
 # https://github.com/WordPress/WordPress-Coding-Standards/releases
-export WP_CODING_STANDARDS_VER="2.3.1"
-export WP_CODING_STANDARDS_SHA1SUM="e453ebe79917af242de572edccffb2933fc83364";
+export WP_CODING_STANDARDS_VER="2.3.0"
+export WP_CODING_STANDARDS_SHA1SUM="c8161d77fcf63bdeaa3e8e6aa36bc1936b469070";
 
 # https://github.com/automattic/vip-coding-standards/releases
-export VIP_CODING_STANDARDS_VER="2.3.0"
-export VIP_CODING_STANDARDS_SHA1SUM="2b4259564f3fcc0b432ef30378d24907e856cde3";
+export VIP_CODING_STANDARDS_VER="2.3.1"
+export VIP_CODING_STANDARDS_SHA1SUM="e453ebe79917af242de572edccffb2933fc83364";
 
 # https://github.com/sirbrillig/phpcs-variable-analysis/releases
 export PHPCS_VARIABLE_ANALYSIS_VER="2.9.0"

--- a/tools-init.sh
+++ b/tools-init.sh
@@ -15,8 +15,8 @@ export WP_CODING_STANDARDS_VER="2.3.0"
 export WP_CODING_STANDARDS_SHA1SUM="c8161d77fcf63bdeaa3e8e6aa36bc1936b469070";
 
 # https://github.com/automattic/vip-coding-standards/releases
-export VIP_CODING_STANDARDS_VER="2.3.1"
-export VIP_CODING_STANDARDS_SHA1SUM="e453ebe79917af242de572edccffb2933fc83364";
+export VIP_CODING_STANDARDS_VER="2.3.2"
+export VIP_CODING_STANDARDS_SHA1SUM="fd3833fa69feb8ab3f02c894c00790ea45e7103d";
 
 # https://github.com/sirbrillig/phpcs-variable-analysis/releases
 export PHPCS_VARIABLE_ANALYSIS_VER="2.9.0"


### PR DESCRIPTION
Update VIP-Coding-Standards to version 2.3.2, see [announcement](https://lobby.vip.wordpress.com/2021/04/19/new-release-vip-coding-standards-2-3-0/). 

TODO:
- [x] Check automated unit-tests
