### PR TITLE
Bump PHP version from 7.3 to 7.4 in circle ci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
       # Run unit-tests
       - run: ./vendor/bin/phpunit -vv ~/project/tests
       # Run PHPCS, check for PHP compatibility issues
-      - run: ~/vip-go-ci-tools/phpcs/bin/phpcs --runtime-set 'testVersion' '7.3-'  --standard=PHPCompatibility,PHPCompatibilityParagonieRandomCompat,PHPCompatibilityParagonieSodiumCompat --ignore="vendor/*"  ~/project
+      - run: ~/vip-go-ci-tools/phpcs/bin/phpcs --runtime-set 'testVersion' '7.4-'  --standard=PHPCompatibility,PHPCompatibilityParagonieRandomCompat,PHPCompatibilityParagonieSodiumCompat --ignore="vendor/*"  ~/project
 
 # List of images at: https://circleci.com/docs/2.0/circleci-images/
 jobs:


### PR DESCRIPTION
Update circle ci configuration file to use PHP 7.4 as default when executing ``phpcs`` command.