### PR TITLE
Adding a few unit-tests, replacing assertEquals() with assertSame()

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -155,8 +155,6 @@ function vipgoci_github_rate_limits_check(
  *
  * The results are not cached, as we want fresh data
  * every time.
- *
- * @codeCoverageIgnore
  */
 
 function vipgoci_github_rate_limit_usage(

--- a/github-api.php
+++ b/github-api.php
@@ -94,6 +94,8 @@ function vipgoci_curl_headers( $ch, $header ) {
 
 /*
  * Set a few options for cURL that enhance security.
+ *
+ * @codeCoverageIgnore
  */
 function vipgoci_curl_set_security_options( $ch ) {
 	/*

--- a/tests/A00IrcApiAlertQueueTest.php
+++ b/tests/A00IrcApiAlertQueueTest.php
@@ -22,7 +22,7 @@ final class A00IrcApiAlertQueueTest extends TestCase {
 			true
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'mymessage1',
 				'mymessage2',

--- a/tests/A00StatsCountersTest.php
+++ b/tests/A00StatsCountersTest.php
@@ -9,7 +9,7 @@ final class A00StatsCountersTest extends TestCase {
 	 * @covers ::vipgoci_counter_report
 	 */
 	function testCounterReport1() {
-		$this->assertEquals(
+		$this->assertSame(
 			vipgoci_counter_report(
 				'illegalaction',
 				'mycounter1',
@@ -18,7 +18,7 @@ final class A00StatsCountersTest extends TestCase {
 			false
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(),
 			vipgoci_counter_report(
 				VIPGOCI_COUNTERS_DUMP
@@ -30,7 +30,7 @@ final class A00StatsCountersTest extends TestCase {
 	 * @covers ::vipgoci_counter_report
 	 */
 	function testCounterReport2() {
-		$this->assertEquals(
+		$this->assertSame(
 			true,
 			vipgoci_counter_report(
 				VIPGOCI_COUNTERS_DO,
@@ -39,7 +39,7 @@ final class A00StatsCountersTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			true,
 			vipgoci_counter_report(
 				VIPGOCI_COUNTERS_DO,
@@ -48,7 +48,7 @@ final class A00StatsCountersTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'mycounter2' => 101,
 			),
@@ -92,7 +92,7 @@ final class A00StatsCountersTest extends TestCase {
 		unset( $report['mycounter2'] );
 
 	
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'github_pr_unique_issue_issues' => 3,
 			),

--- a/tests/A09GitHubLabelsTest.php
+++ b/tests/A09GitHubLabelsTest.php
@@ -82,12 +82,12 @@ final class A09GitHubLabelsTest extends TestCase {
 
 		$labels_after = $this->labels_get();
 
-		$this->assertEquals(
+		$this->assertSame(
 			-1,
 			count( $labels_before ) - count( $labels_after )
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'Label for testing',
 			$labels_after[0]->name
 		);
@@ -123,7 +123,7 @@ final class A09GitHubLabelsTest extends TestCase {
 
 		$labels_after = $this->labels_get();
 
-		$this->assertEquals(
+		$this->assertSame(
 			1,
 			count( $labels_before ) - count( $labels_after )
 		);

--- a/tests/A09LintLintScanCommitTest.php
+++ b/tests/A09LintLintScanCommitTest.php
@@ -152,7 +152,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 				$issues_submit[ $pr_item->number][0]['issue']['message']
 			);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				$pr_item->number => array(
 					array(
@@ -170,7 +170,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 			$issues_submit
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				$pr_item->number => array(
 					'error' => 1,
@@ -279,7 +279,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 			);
 
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				$pr_item->number => array(
 					array(
@@ -312,7 +312,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 			$issues_submit
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				$pr_item->number => array(
 					'error' => 2,

--- a/tests/AllUnitTestsInplaceTest.php
+++ b/tests/AllUnitTestsInplaceTest.php
@@ -58,7 +58,7 @@ final class AllUnitTestsInplaceTest extends TestCase {
 		/*
 		 * We should end with an empty array.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			0,
 			count( $files_arr )
 		);

--- a/tests/ApAutoApprovalTest.php
+++ b/tests/ApAutoApprovalTest.php
@@ -73,6 +73,9 @@ final class ApAutoApprovalTest extends TestCase {
 
 		$this->options['local-git-repo'] = false;
 
+		$this->options['pr-test-ap-auto-approval-1'] =
+			(int) $this->options['pr-test-ap-auto-approval-1'];
+
 		$this->cleanup_prs();
 	}
 
@@ -232,13 +235,13 @@ final class ApAutoApprovalTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			1,
 			count( $prs_implicated )
 		);
 
 		foreach ( $prs_implicated as $pr_item ) {
-			$this->assertEquals(
+			$this->assertSame(
 				$this->options['pr-test-ap-auto-approval-1'],
 				$pr_item->number
 			);
@@ -302,7 +305,7 @@ final class ApAutoApprovalTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(),
 			$results
 		);
@@ -319,13 +322,13 @@ final class ApAutoApprovalTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			1,
 			count( $prs_implicated )
 		);
 
 		foreach ( $prs_implicated as $pr_item ) {
-			$this->assertEquals(
+			$this->assertSame(
 				$this->options['pr-test-ap-auto-approval-1'],
 				$pr_item->number
 			);
@@ -346,13 +349,13 @@ final class ApAutoApprovalTest extends TestCase {
 
 			vipgoci_unittests_output_unsuppress();
 
-			$this->assertEquals(
+			$this->assertSame(
 				1,
 				count( $pr_item_reviews )
 			);
 
 			foreach( $pr_item_reviews as $pr_item_review ) {
-				$this->assertEquals(
+				$this->assertSame(
 					'APPROVED',
 					$pr_item_review->state
 				);
@@ -361,7 +364,7 @@ final class ApAutoApprovalTest extends TestCase {
 
 		$labels = $this->pr_get_labels();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$this->options['autoapprove-label'],
 			$labels->name
 		);
@@ -424,7 +427,7 @@ final class ApAutoApprovalTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(),
 			$results
 		);
@@ -441,13 +444,13 @@ final class ApAutoApprovalTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			1,
 			count( $prs_implicated )
 		);
 
 		foreach ( $prs_implicated as $pr_item ) {
-			$this->assertEquals(
+			$this->assertSame(
 				$this->options['pr-test-ap-auto-approval-1'],
 				$pr_item->number
 			);
@@ -468,7 +471,7 @@ final class ApAutoApprovalTest extends TestCase {
 
 			vipgoci_unittests_output_unsuppress();
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				count( $pr_item_reviews )
 			);
@@ -476,7 +479,7 @@ final class ApAutoApprovalTest extends TestCase {
 
 		$label = $this->pr_get_labels();
 
-		$this->assertEquals(
+		$this->assertSame(
 			false,
 			$label
 		);
@@ -558,13 +561,13 @@ final class ApAutoApprovalTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			1,
 			count( $prs_implicated )
 		);
 
 		foreach ( $prs_implicated as $pr_item ) {
-			$this->assertEquals(
+			$this->assertSame(
 				$this->options['pr-test-ap-auto-approval-1'],
 				$pr_item->number
 			);
@@ -585,7 +588,7 @@ final class ApAutoApprovalTest extends TestCase {
 
 			vipgoci_unittests_output_unsuppress();
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				count( $pr_item_reviews )
 			);
@@ -593,12 +596,12 @@ final class ApAutoApprovalTest extends TestCase {
 
 		$label = $this->pr_get_labels();
 
-		$this->assertEquals(
+		$this->assertSame(
 			false,
 			$label
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			1,
 			$results['stats']
 				[ VIPGOCI_STATS_HASHES_API ]
@@ -606,7 +609,7 @@ final class ApAutoApprovalTest extends TestCase {
 				[ 'info' ]
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'file-1.php',
 			$results['issues']
 				[ $this->options['pr-test-ap-auto-approval-1'] ]
@@ -672,7 +675,7 @@ final class ApAutoApprovalTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			0,
 			count( $pr_item_reviews )
 		);
@@ -727,7 +730,7 @@ final class ApAutoApprovalTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			1,
 			count( $pr_item_reviews )
 		);

--- a/tests/ApFileTypesTest.php
+++ b/tests/ApFileTypesTest.php
@@ -105,12 +105,12 @@ final class ApFileTypesTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
+				'README.md'		=> 'autoapprove-filetypes',
 				'auto-approvable-1.txt' => 'autoapprove-filetypes',
 				'auto-approvable-2.txt' => 'autoapprove-filetypes',
 				'auto-approvable-3.jpg' => 'autoapprove-filetypes',
-				'README.md'		=> 'autoapprove-filetypes',
 			),
 			$auto_approved_files_arr
 		);

--- a/tests/ApHashesApiScanCommitTest.php
+++ b/tests/ApHashesApiScanCommitTest.php
@@ -125,7 +125,7 @@ final class ApHashesApiScanCommitTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'auto-approvable-6.php' => 'autoapprove-hashes-to-hashes',
 			),

--- a/tests/ApNonfunctionalChangesTest.php
+++ b/tests/ApNonfunctionalChangesTest.php
@@ -87,7 +87,7 @@ final class ApNonfunctionalChangesTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'file1.php'	=> 'autoapprove-nonfunctional-changes',
 				'file2.php'	=> 'autoapprove-nonfunctional-changes',

--- a/tests/ApSvgFilesTest.php
+++ b/tests/ApSvgFilesTest.php
@@ -127,7 +127,7 @@ final class ApSvgFilesTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'auto-approvable-1.svg' => 'ap-svg-files',
 				'auto-approvable-2.svg' => 'ap-svg-files',
@@ -188,13 +188,13 @@ final class ApSvgFilesTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'auto-approvable-1.svg' => 'ap-svg-files',
 				'auto-approvable-2-renamed.svg' => 'ap-svg-files',
+				'auto-approvable-7.svg' => 'ap-svg-files',
 				'auto-approvable3.svg' => 'ap-svg-files',
 				'auto-approvable4.svg' => 'ap-svg-files',
-				'auto-approvable-7.svg' => 'ap-svg-files',
 			),
 			$auto_approved_files_arr
 		);

--- a/tests/GitHubApiCurlHeadersTest.php
+++ b/tests/GitHubApiCurlHeadersTest.php
@@ -46,12 +46,12 @@ final class GitHubApiCurlHeadersTest extends TestCase {
 			null
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'content-type'	=> array( 'text/plain' ),
 				'date'		=> array( 'Mon, 04 Mar 2019 16:43:35 GMT' ),
 				'location'	=> array( 'https://www.ruv.is/' ),
-				'status'	=> array( 200, 'OK' ),
+				'status'	=> array( '200', 'OK' ),
 			),
 			$actual_results
 		);
@@ -96,11 +96,11 @@ final class GitHubApiCurlHeadersTest extends TestCase {
 			null
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
+				'status'	=> array( '205' ),
 				'date'		=> array( 'Mon, 04 Mar 2020 16:43:35 GMT' ),
 				'location'	=> array( 'https://www.kernel.org/' ),
-				'status'	=> array( 205 ),
 			),
 			$actual_results
 		);

--- a/tests/GitHubAuthenticatedUserGetTest.php
+++ b/tests/GitHubAuthenticatedUserGetTest.php
@@ -49,6 +49,10 @@ final class GitHubAuthenticatedUserGetTest extends TestCase {
 			isset(
 				$gh_result->login
 			)
+			&&
+			( strlen(
+				$gh_result->login
+			) > 0 )
 		);
 	}
 }

--- a/tests/GitHubAuthenticatedUserGetTest.php
+++ b/tests/GitHubAuthenticatedUserGetTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Vipgoci\tests;
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+final class GitHubAuthenticatedUserGetTest extends TestCase {
+	protected function setUp(): void {
+		$this->options = array();
+
+		$this->options[ 'github-token' ] =
+			vipgoci_unittests_get_config_value(
+				'git-secrets',
+				'github-token',
+				true // Fetch from secrets file
+			);
+
+		$this->options['token'] =
+			$this->options['github-token'];
+	}
+
+	protected function tearDown(): void {
+		$this->options = null;
+	}
+
+	/**
+	 * @covers ::vipgoci_github_authenticated_user_get
+	 */
+	public function testGitHubAuthenticatedUserGet1 () {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$gh_result = vipgoci_github_authenticated_user_get(
+			$this->options['github-token']
+		);
+
+		$this->assertTrue(
+			isset(
+				$gh_result->login
+			)
+		);
+	}
+}
+

--- a/tests/GitHubFetchCommitInfoTest.php
+++ b/tests/GitHubFetchCommitInfoTest.php
@@ -101,7 +101,7 @@ final class GitHubFetchCommitInfoTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'2533219d08192025f3209a17ddcf9ff21845a08c',
 			$commit_info->sha
 		);
@@ -112,7 +112,7 @@ final class GitHubFetchCommitInfoTest extends TestCase {
 			$commit_info->files[0]->contents_url
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'sha'		=> '524acfffa760fd0b8c1de7cf001f8dd348b399d8',
 				'filename'	=> 'test1.txt',

--- a/tests/GitHubLabelsFetchTest.php
+++ b/tests/GitHubLabelsFetchTest.php
@@ -72,12 +72,12 @@ final class GitHubLabelsFetchTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'enhancement',
 			$labels[0]->name
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'a2eeef',
 			$labels[0]->color
 		);

--- a/tests/GitHubOauth1HeadersGetTest.php
+++ b/tests/GitHubOauth1HeadersGetTest.php
@@ -52,17 +52,17 @@ final class GitHubOauth1HeadersGetTest extends TestCase {
 			$actual_result_arr_new[ $item[0] ] = $item[1];
 		}
 
-		$this->assertEquals(
+		$this->assertSame(
 			'12',
 			$actual_result_arr_new[ 'OAuth oauth_consumer_key' ]
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'56',
 			$actual_result_arr_new[ 'oauth_token' ]
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$actual_result_arr_new[ 'oauth_signature_method' ],
 			'HMAC-SHA1'
 		);
@@ -106,7 +106,7 @@ final class GitHubOauth1HeadersGetTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$signature_expected,
 			$actual_result_arr_new['oauth_signature']
 		);

--- a/tests/GitHubOauthSignatureGetHmacSha1Test.php
+++ b/tests/GitHubOauthSignatureGetHmacSha1Test.php
@@ -25,7 +25,7 @@ final class GitHubOauthSignatureGetHmacSha1Test extends TestCase {
 			$oauth_keys
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'wzbKZTPTrm5evZ/0ccfJ03pLTLg=',
 			$hmac_sha1
 		);

--- a/tests/GitHubOrgTeamsTest.php
+++ b/tests/GitHubOrgTeamsTest.php
@@ -97,7 +97,7 @@ final class GitHubOrgTeamsTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$teams_res_actual,
 			$teams_res_actual_cached
 		);
@@ -181,7 +181,7 @@ final class GitHubOrgTeamsTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$teams_res_actual,
 			$teams_res_actual_cached
 		);
@@ -254,7 +254,7 @@ final class GitHubOrgTeamsTest extends TestCase {
 			) > 0
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$teams_res_actual_keys[0],
 			$teams_res_actual[
 				$teams_res_actual_keys[0]
@@ -277,7 +277,7 @@ final class GitHubOrgTeamsTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$teams_res_actual,
 			$teams_res_actual_cached
 		);

--- a/tests/GitHubPrGenericCommentsGetTest.php
+++ b/tests/GitHubPrGenericCommentsGetTest.php
@@ -74,17 +74,17 @@ final class GitHubPrGenericCommentsGetTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			1,
 			count( array_keys( $pr_comments ) )
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			471306810,
 			$pr_comments[0]->id
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'Testing of generic comments.',
 			$pr_comments[0]->body
 		);

--- a/tests/GitHubPrGenericSupportCommentTest.php
+++ b/tests/GitHubPrGenericSupportCommentTest.php
@@ -318,7 +318,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				count( $pr_comments ) === 0
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				$this->_countSupportCommentsFromUs(
 					$pr_comments
@@ -376,7 +376,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) === 0
 				);
 
-				$this->assertEquals(
+				$this->assertSame(
 					0,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -389,7 +389,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) > 0
 				);
 
-				$this->assertEquals(
+				$this->assertSame(
 					1,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -423,7 +423,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) === 0
 				);
 
-				$this->assertEquals(
+				$this->assertSame(
 					0,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -436,7 +436,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) > 0
 				);
 
-				$this->assertEquals(
+				$this->assertSame(
 					1,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -491,7 +491,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) === 0
 				);
 
-				$this->assertEquals(
+				$this->assertSame(
 					0,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -504,7 +504,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) > 0
 				);
 
-				$this->assertEquals(
+				$this->assertSame(
 					1,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -538,7 +538,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) === 0
 				);
 	
-				$this->assertEquals(
+				$this->assertSame(
 					0,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -551,7 +551,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) > 0
 				);
 
-				$this->assertEquals(
+				$this->assertSame(
 					1,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -601,7 +601,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				$pr_item->number
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				$this->_countSupportCommentsFromUs(
 					$pr_comments
@@ -629,7 +629,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				$pr_item->number
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				$this->_countSupportCommentsFromUs(
 					$pr_comments
@@ -683,7 +683,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) === 0
 				);
 	
-				$this->assertEquals(
+				$this->assertSame(
 					0,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -696,7 +696,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) > 0
 				);
 
-				$this->assertEquals(
+				$this->assertSame(
 					1,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -730,7 +730,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) === 0
 				);
 	
-				$this->assertEquals(
+				$this->assertSame(
 					0,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -743,7 +743,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					count( $pr_comments ) > 0
 				);
 
-				$this->assertEquals(
+				$this->assertSame(
 					1,
 					$this->_countSupportCommentsFromUs(
 						$pr_comments
@@ -781,7 +781,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				count( $pr_comments ) > 0
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				1,
 				$this->_countSupportCommentsFromUs(
 					$pr_comments
@@ -860,7 +860,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				count( $pr_comments ) === 0
 			);
 	
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				$this->_countSupportCommentsFromUs(
 					$pr_comments
@@ -892,7 +892,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				count( $pr_comments ) === 0
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				$this->_countSupportCommentsFromUs(
 					$pr_comments
@@ -929,7 +929,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				count( $pr_comments ) === 0
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				$this->_countSupportCommentsFromUs(
 					$pr_comments

--- a/tests/GitHubPrReviewEventsGetTest.php
+++ b/tests/GitHubPrReviewEventsGetTest.php
@@ -100,7 +100,7 @@ final class GitHubPrReviewEventsGetTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$issue_events,
 			$issue_events_cached
 		);
@@ -156,12 +156,12 @@ final class GitHubPrReviewEventsGetTest extends TestCase {
 		);
 
 		foreach ( $issue_events as $issue_event ) {
-			$this->assertEquals(
+			$this->assertSame(
 				$this->options['test-github-pr-reviews-event-get-username'],
 				$issue_event->actor->login
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				'labeled',
 				$issue_event->event
 			);
@@ -188,7 +188,7 @@ final class GitHubPrReviewEventsGetTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$issue_events,
 			$issue_events_cached
 		);
@@ -238,7 +238,7 @@ final class GitHubPrReviewEventsGetTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 	
-		$this->assertEquals(
+		$this->assertSame(
 			$issue_events,
 			$issue_events_cached
 		);

--- a/tests/GitHubPrReviewsCommentsGetByPrTest.php
+++ b/tests/GitHubPrReviewsCommentsGetByPrTest.php
@@ -71,28 +71,28 @@ final class GitHubPrReviewsCommentsGetByPrTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			1,
 			count( $comments_actual )
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			264037556,
 			$comments_actual[0]->id
 		);
 
 
-		$this->assertEquals(
+		$this->assertSame(
 			'file1.php',
 			$comments_actual[0]->path
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			3,
 			$comments_actual[0]->position
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'All output should be escaped.',
 			$comments_actual[0]->body
 		);

--- a/tests/GitHubPrReviewsCommentsGetByPrTest.php
+++ b/tests/GitHubPrReviewsCommentsGetByPrTest.php
@@ -97,4 +97,89 @@ final class GitHubPrReviewsCommentsGetByPrTest extends TestCase {
 			$comments_actual[0]->body
 		);
 	}
+
+	/**
+	 * @covers ::vipgoci_github_pr_reviews_comments_get_by_pr
+	 */
+	public function testGitHubPrReviewsCommentsGetByPr2() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'github-token', 'token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		vipgoci_unittests_output_suppress();
+
+		$comments_actual = vipgoci_github_pr_reviews_comments_get_by_pr(
+			$this->options,
+			$this->options['pr-test-github-pr-reviews-get-1'],
+			array(
+				'login'	=> 'gudmdharalds',
+			)
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertSame(
+			1,
+			count( $comments_actual )
+		);
+
+		$this->assertSame(
+			264037556,
+			$comments_actual[0]->id
+		);
+
+
+		$this->assertSame(
+			'file1.php',
+			$comments_actual[0]->path
+		);
+
+		$this->assertSame(
+			3,
+			$comments_actual[0]->position
+		);
+
+		$this->assertSame(
+			'All output should be escaped.',
+			$comments_actual[0]->body
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_github_pr_reviews_comments_get_by_pr
+	 */
+	public function testGitHubPrReviewsCommentsGetByPr3() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'github-token', 'token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		vipgoci_unittests_output_suppress();
+
+		$comments_actual = vipgoci_github_pr_reviews_comments_get_by_pr(
+			$this->options,
+			$this->options['pr-test-github-pr-reviews-get-1'],
+			array(
+				'login'	=> 'random_invalid_user___0x0',
+			)
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertSame(
+			0,
+			count( $comments_actual )
+		);
+	}
 }

--- a/tests/GitHubPrReviewsCommentsGetTest.php
+++ b/tests/GitHubPrReviewsCommentsGetTest.php
@@ -74,32 +74,32 @@ final class GitHubPrReviewsCommentsGetTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			1,
 			count( array_keys( $prs_comments ) )
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			212601504,
 			$prs_comments['file1.php:3'][0]->pull_request_review_id
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			264037556,
 			$prs_comments['file1.php:3'][0]->id
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'file1.php',
 			$prs_comments['file1.php:3'][0]->path
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			3,
 			$prs_comments['file1.php:3'][0]->position
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'All output should be escaped.',
 			$prs_comments['file1.php:3'][0]->body
 		);

--- a/tests/GitHubPrReviewsGetTest.php
+++ b/tests/GitHubPrReviewsGetTest.php
@@ -70,23 +70,23 @@ final class GitHubPrReviewsGetTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			1,
 			count( $reviews_actual )
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			212601504,
 			$reviews_actual[0]->id
 		);
 
 
-		$this->assertEquals(
+		$this->assertSame(
 			'Test review',
 			$reviews_actual[0]->body
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'COMMENTED',
 			$reviews_actual[0]->state
 		);

--- a/tests/GitHubPrsCommitsListTest.php
+++ b/tests/GitHubPrsCommitsListTest.php
@@ -78,7 +78,7 @@ final class GitHubPrsCommitsListTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				$this->options['commit-test-repo-prs-commits-list-1']
 			),

--- a/tests/GitHubPrsImplicatedTest.php
+++ b/tests/GitHubPrsImplicatedTest.php
@@ -82,17 +82,17 @@ final class GitHubPrsImplicatedTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			259078544,
 			$prs_implicated[9]->id
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'80ebd6d65db88e87665b6ff1aa045f68d17ddeb7',
 			$prs_implicated[9]->merge_commit_sha
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'open',
 			$prs_implicated[9]->state
 		);
@@ -142,22 +142,22 @@ final class GitHubPrsImplicatedTest extends TestCase {
 		/*
 		 * Verify non-draft PR.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			'open',
 			$prs_implicated[33]->state
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			463586588,
 			$prs_implicated[33]->id
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'ac10d1f29e64504d7741cd8ca22981c426c26e9a',
 			$prs_implicated[33]->base->sha
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			false,
 			$prs_implicated[33]->draft
 		);
@@ -165,22 +165,22 @@ final class GitHubPrsImplicatedTest extends TestCase {
 		/*
 		 * Verify draft PR.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			'open',
 			$prs_implicated[34]->state
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			463587649,
 			$prs_implicated[34]->id
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'027de6d804e1d40dbe1b13a3ede7cfa758787b85',
 			$prs_implicated[34]->base->sha
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			true,
 			$prs_implicated[34]->draft
 		);
@@ -203,7 +203,7 @@ final class GitHubPrsImplicatedTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$prs_implicated,
 			$prs_implicated_2
 		);
@@ -252,22 +252,22 @@ final class GitHubPrsImplicatedTest extends TestCase {
 		/*
 		 * Verify non-draft PR.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			'open',
 			$prs_implicated[33]->state
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			463586588,
 			$prs_implicated[33]->id
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'ac10d1f29e64504d7741cd8ca22981c426c26e9a',
 			$prs_implicated[33]->base->sha
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			false,
 			$prs_implicated[33]->draft
 		);
@@ -290,7 +290,7 @@ final class GitHubPrsImplicatedTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$prs_implicated,
 			$prs_implicated_2
 		);

--- a/tests/GitHubRateLimitUsageTest.php
+++ b/tests/GitHubRateLimitUsageTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Vipgoci\tests;
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+final class GitHubRateLimitUsageTest extends TestCase {
+	protected function setUp(): void {
+		$this->options = array();
+
+		$this->options[ 'github-token' ] =
+			vipgoci_unittests_get_config_value(
+				'git-secrets',
+				'github-token',
+				true // Fetch from secrets file
+			);
+
+		$this->options['token'] =
+			$this->options['github-token'];
+	}
+
+	protected function tearDown(): void {
+		$this->options = null;
+	}
+
+	/**
+	 * @covers ::vipgoci_github_rate_limit_usage
+	 */
+	public function testGitHubRateLimitUsage1 () {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$gh_result = vipgoci_github_rate_limit_usage(
+			$this->options['github-token']
+		);
+
+		$this->assertTrue(
+			isset(
+				$gh_result->resources->core->used
+			)
+		);
+	
+		$this->assertTrue(
+			isset(
+				$gh_result->resources->core->limit
+			)
+		);
+
+		$this->assertTrue(
+			isset(
+				$gh_result->resources->core->remaining
+			)
+		);
+	}
+}
+

--- a/tests/GitHubRateLimitUsageTest.php
+++ b/tests/GitHubRateLimitUsageTest.php
@@ -49,17 +49,29 @@ final class GitHubRateLimitUsageTest extends TestCase {
 			isset(
 				$gh_result->resources->core->used
 			)
+			&&
+			(
+				is_numeric( $gh_result->resources->core->used )
+			)
 		);
 	
 		$this->assertTrue(
 			isset(
 				$gh_result->resources->core->limit
 			)
+			&&
+			(
+				is_numeric( $gh_result->resources->core->limit )
+			)
 		);
 
 		$this->assertTrue(
 			isset(
 				$gh_result->resources->core->remaining
+			)
+			&&
+			(
+				is_numeric( $gh_result->resources->core->remaining )
 			)
 		);
 	}

--- a/tests/GitHubTeamMembersTest.php
+++ b/tests/GitHubTeamMembersTest.php
@@ -94,7 +94,7 @@ final class GitHubTeamMembersTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$team_members_res1_actual,
 			$team_members_res1_actual_cached
 		);
@@ -168,7 +168,7 @@ final class GitHubTeamMembersTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$team_members_res2_actual,
 			$team_members_res2_actual_cached
 		);

--- a/tests/GitRepoBranchGetTest.php
+++ b/tests/GitRepoBranchGetTest.php
@@ -82,7 +82,7 @@ final class GitRepoBranchGetTest extends TestCase {
 			$this->options['local-git-repo']
 		);
 		
-		$this->assertEquals(
+		$this->assertSame(
 			$this->options['commit-test-repo-branch'],
 			$ret
 		);

--- a/tests/GitRepoRepoFetchCommittedFileTest.php
+++ b/tests/GitRepoRepoFetchCommittedFileTest.php
@@ -94,7 +94,7 @@ final class GitRepoRepoFetchCommittedFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'Test file contents. Some text.' . PHP_EOL,
 			$ret
 		);

--- a/tests/GitRepoRepoFetchTreeTest.php
+++ b/tests/GitRepoRepoFetchTreeTest.php
@@ -94,7 +94,7 @@ final class GitRepoRepoFetchTreeTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'README.md',
 				'file-1.txt',
@@ -148,7 +148,7 @@ final class GitRepoRepoFetchTreeTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'file-1.txt',
 			),

--- a/tests/GitRepoRepoGetFileAtCommitTest.php
+++ b/tests/GitRepoRepoGetFileAtCommitTest.php
@@ -88,7 +88,7 @@ final class GitRepoRepoGetFileAtCommitTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'04f338f924cabbe47994043660304e58a5a3f78f',
 			sha1( $file_content )
 		);
@@ -104,7 +104,7 @@ final class GitRepoRepoGetFileAtCommitTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'c4587f2e42de3ab1ecdf51c993a3135bb1314b68',
 			sha1( $file_content )
 		);
@@ -125,7 +125,7 @@ final class GitRepoRepoGetFileAtCommitTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'04f338f924cabbe47994043660304e58a5a3f78f',
 			sha1( $file_content )
 		);
@@ -141,7 +141,7 @@ final class GitRepoRepoGetFileAtCommitTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			'f8c824b9bc01a5655e77a10a3f2e5fa704a58f9c',
 			sha1( $file_content )
 		);

--- a/tests/GitRepoRepoGetHeadTest.php
+++ b/tests/GitRepoRepoGetHeadTest.php
@@ -85,7 +85,7 @@ final class GitRepoRepoGetHeadTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$this->options['commit-test-repo-get-head-1'],
 			$ret
 		);

--- a/tests/GitRepoSubmoduleFilePathGetTest.php
+++ b/tests/GitRepoSubmoduleFilePathGetTest.php
@@ -90,7 +90,7 @@ final class GitRepoSubmoduleFilePathGetTest extends TestCase {
 			'folder1/vip-go-ci-repo/vip-go-ci.php'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'commit_id'		=> 'a0dba40108fe19f028dbd5970022281cc2cabf81',
 				'submodule_path'	=> 'folder1/vip-go-ci-repo',
@@ -105,7 +105,7 @@ final class GitRepoSubmoduleFilePathGetTest extends TestCase {
 			'vip-go-ci/notexistingfile.php'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			null,
 			$submodule_file_info
 		);
@@ -116,7 +116,7 @@ final class GitRepoSubmoduleFilePathGetTest extends TestCase {
 			'vip-go-INVALID/vip-go-ci.php'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			null,
 			$submodule_file_info
 		);
@@ -127,7 +127,7 @@ final class GitRepoSubmoduleFilePathGetTest extends TestCase {
 			'README.md'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			null,
 			$submodule_file_info
 		);

--- a/tests/GitRepoSubmoduleGetUrlTest.php
+++ b/tests/GitRepoSubmoduleGetUrlTest.php
@@ -83,7 +83,7 @@ final class GitRepoSubmoduleGetUrlTest extends TestCase {
 			'folder1/vip-go-ci-repo'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'https://github.com/automattic/vip-go-ci',
 			$ret
 		);
@@ -93,7 +93,7 @@ final class GitRepoSubmoduleGetUrlTest extends TestCase {
 			'folder1/vip-go-ci-INVALID'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			null,
 			$ret
 		);
@@ -103,7 +103,7 @@ final class GitRepoSubmoduleGetUrlTest extends TestCase {
 			'folder2/vip-go-ci-INVALID'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			null,
 			$ret
 		);

--- a/tests/GitRepoSubmodulesListTest.php
+++ b/tests/GitRepoSubmodulesListTest.php
@@ -89,7 +89,7 @@ final class GitRepoSubmodulesListTest extends TestCase {
 			$this->options['local-git-repo']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				array(
 					'commit_id'		=> 'a0dba40108fe19f028dbd5970022281cc2cabf81',

--- a/tests/LintLintDoScanTest.php
+++ b/tests/LintLintDoScanTest.php
@@ -54,7 +54,7 @@ final class LintLintDoScanTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'No syntax errors detected in ' . $php_file_path
 			),
@@ -101,7 +101,7 @@ final class LintLintDoScanTest extends TestCase {
 			$ret[0]
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				"PHP Parse error:  syntax error, unexpected end of file, expecting ',' or ';' in " . $php_file_path . " on line 3",
 				'Errors parsing ' . $php_file_path

--- a/tests/LintLintGetIssuesTest.php
+++ b/tests/LintLintGetIssuesTest.php
@@ -60,7 +60,7 @@ final class LintLintGetIssuesTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 			),
 			$lint_issues_parsed
@@ -113,7 +113,7 @@ final class LintLintGetIssuesTest extends TestCase {
 				$lint_issues_parsed[3][0]['message']
 			);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				3 => array(
 					array(

--- a/tests/MiscApprovedFilesCommentsRemoveTest.php
+++ b/tests/MiscApprovedFilesCommentsRemoveTest.php
@@ -34,7 +34,7 @@ final class MiscApprovedFilesCommentsRemoveTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$results_desired,
 			json_encode( $results_altered )
 		);

--- a/tests/MiscBlameFilterCommentsTest.php
+++ b/tests/MiscBlameFilterCommentsTest.php
@@ -24,7 +24,7 @@ final class MiscBlameFilterCommentsTest extends TestCase {
 			$relevant_commit_ids
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			json_decode(
 				'[{"commit_id":"0131c2739c1a5d2d03bb2645e1be491a6a182091","file_name":"bla-10.php","line_no":1},{"commit_id":"0131c2739c1a5d2d03bb2645e1be491a6a182091","file_name":"bla-10.php","line_no":2},{"commit_id":"0131c2739c1a5d2d03bb2645e1be491a6a182091","file_name":"bla-10.php","line_no":3},{"commit_id":"0131c2739c1a5d2d03bb2645e1be491a6a182091","file_name":"bla-10.php","line_no":4},{"commit_id":"b591cee061d15b1e0187baf9f13a6ab32661bc1b","file_name":"bla-10.php","line_no":5},{"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","file_name":"bla-10.php","line_no":6},{"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","file_name":"bla-10.php","line_no":7}]',
 				true

--- a/tests/MiscCacheTest.php
+++ b/tests/MiscCacheTest.php
@@ -45,12 +45,12 @@ final class MiscCacheTest extends TestCase {
 			$cache_id2
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$r1,
 			$r1_retrieved
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$r2,
 			$r2_retrieved
 		);
@@ -98,7 +98,7 @@ final class MiscCacheTest extends TestCase {
 			$cache_id
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'mytext',
 			$cached_data
 		);
@@ -115,7 +115,7 @@ final class MiscCacheTest extends TestCase {
 			$cache_id
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			false,
 			$cached_data
 		);

--- a/tests/MiscCachedIndicationStrTest.php
+++ b/tests/MiscCachedIndicationStrTest.php
@@ -13,21 +13,21 @@ final class MiscCachedIndicationStrTest extends TestCase {
 	 * @covers ::vipgoci_cached_indication_str
 	 */
 	public function testCachedIndicationStr1() {
-		$this->assertsame(
+		$this->assertSame(
 			' (cached)',
 			vipgoci_cached_indication_str(
 				true
 			)
 		);
 
-		$this->assertsame(
+		$this->assertSame(
 			' (cached)',
 			vipgoci_cached_indication_str(
 				array( 1, 2, 3 ),
 			)
 		);
 
-		$this->assertsame(
+		$this->assertSame(
 			'',
 			vipgoci_cached_indication_str(
 				false,

--- a/tests/MiscCachedIndicationStrTest.php
+++ b/tests/MiscCachedIndicationStrTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Vipgoci\tests;
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class MiscCachedIndicationStrTest extends TestCase {
+	/**
+	 * @covers ::vipgoci_cached_indication_str
+	 */
+	public function testCachedIndicationStr1() {
+		$this->assertsame(
+			' (cached)',
+			vipgoci_cached_indication_str(
+				true
+			)
+		);
+
+		$this->assertsame(
+			' (cached)',
+			vipgoci_cached_indication_str(
+				array( 1, 2, 3 ),
+			)
+		);
+
+		$this->assertsame(
+			'',
+			vipgoci_cached_indication_str(
+				false,
+			)
+		);
+	}
+}

--- a/tests/MiscCachedIndicationStrTest.php
+++ b/tests/MiscCachedIndicationStrTest.php
@@ -6,6 +6,8 @@ require_once( __DIR__ . '/IncludesForTests.php' );
 
 use PHPUnit\Framework\TestCase;
 
+// phpcs:disable PSR1.Files.SideEffects
+
 final class MiscCachedIndicationStrTest extends TestCase {
 	/**
 	 * @covers ::vipgoci_cached_indication_str

--- a/tests/MiscConvertStringToTypeTest.php
+++ b/tests/MiscConvertStringToTypeTest.php
@@ -9,22 +9,22 @@ final class MiscConvertStringToTypeTest extends TestCase {
 	 * @covers ::vipgoci_convert_string_to_type
 	 */
 	public function testConvert1() {
-		$this->assertEquals(
+		$this->assertSame(
 			true,
 			vipgoci_convert_string_to_type('true')
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			false,
 			vipgoci_convert_string_to_type('false')
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			null,
 			vipgoci_convert_string_to_type('null')
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'somestring',
 			vipgoci_convert_string_to_type('somestring')
 		);

--- a/tests/MiscFileExtensionTest.php
+++ b/tests/MiscFileExtensionTest.php
@@ -15,7 +15,7 @@ final class MiscFileExtensionTest extends TestCase {
 			$file_name
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'exe',
 			$file_extension
 		);
@@ -31,7 +31,7 @@ final class MiscFileExtensionTest extends TestCase {
 			$file_name
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'exe',
 			$file_extension
 		);
@@ -47,7 +47,7 @@ final class MiscFileExtensionTest extends TestCase {
 			$file_name
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			null,
 			$file_extension
 		);

--- a/tests/MiscFindFieldsInArrayTest.php
+++ b/tests/MiscFindFieldsInArrayTest.php
@@ -9,7 +9,7 @@ final class MiscFindFieldsInArrayTest extends TestCase {
 	 * @covers ::vipgoci_find_fields_in_array
 	 */
 	public function testFindFields1() {
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				0 => false,
 				1 => true,

--- a/tests/MiscGitHubEmojisTest.php
+++ b/tests/MiscGitHubEmojisTest.php
@@ -9,14 +9,14 @@ final class MiscGitHubEmojisTest extends TestCase {
 	 * @covers ::vipgoci_github_transform_to_emojis
 	 */
 	public function testGitHubEmojis1() {
-		$this->assertEquals(
+		$this->assertSame(
 			'',
 			vipgoci_github_transform_to_emojis(
 				'exclamation'
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			':warning:',
 			vipgoci_github_transform_to_emojis(
 				'warning'

--- a/tests/MiscGitHubPrRemoveDraftsTest.php
+++ b/tests/MiscGitHubPrRemoveDraftsTest.php
@@ -31,9 +31,13 @@ final class MiscGitHubPrRemoveDraftsTest extends TestCase {
 			$prs_array
 		);
 
-		$this->assertEquals(
+		if ( isset( $prs_array[ 1 ] ) ) {
+			$prs_array[ 1 ] = (array) $prs_array[ 1 ];
+		}
+
+		$this->assertSame(
 			array(
-				1 => (object) array(
+				1 => array(
 	 				'url'		=> 'https://myapi2.mydomain.is',
 					'id'		=> 999,
 					'node_id'	=> 'testing2',

--- a/tests/MiscMarkdownCommentAddPagebreakTest.php
+++ b/tests/MiscMarkdownCommentAddPagebreakTest.php
@@ -16,7 +16,7 @@ final class MiscMarkdownCommentAddPagebreakTest extends TestCase {
 			'***'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'Here is my text. ' . "\n\r" . '***' . "\n\r",
 			$mycomment 
 		);

--- a/tests/MiscResultsFilterIgnorableTest.php
+++ b/tests/MiscResultsFilterIgnorableTest.php
@@ -39,7 +39,7 @@ final class MiscResultsFilterIgnorableTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			$results_desired,
 			json_encode(
 				$results_altered

--- a/tests/MiscSanitizeStringTest.php
+++ b/tests/MiscSanitizeStringTest.php
@@ -9,14 +9,14 @@ final class MiscSanitizeStringTest extends TestCase {
 	 * @covers ::vipgoci_sanitize_string
 	 */
 	public function testSanitizeString1() {
-		$this->assertEquals(
+		$this->assertSame(
 			'foobar',
 			vipgoci_sanitize_string(
 				'FooBar'
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'foobar',
 			vipgoci_sanitize_string(
 				'   FooBar   '

--- a/tests/MiscScandirGitRepoTest.php
+++ b/tests/MiscScandirGitRepoTest.php
@@ -96,7 +96,7 @@ final class MiscScandirGitRepoTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'README.md',
  				'myfile1.txt',	
@@ -150,7 +150,7 @@ final class MiscScandirGitRepoTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'README.md'
 			),

--- a/tests/MiscTempTest.php
+++ b/tests/MiscTempTest.php
@@ -34,12 +34,12 @@ final class MiscTempTest extends TestCase {
 			$temp_file_name
 		);
 
-		$this->assertEquals(
-			$file_name_extension,
+		$this->assertSame(
+			'',
 			$temp_file_extension
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$file_contents,
 			$temp_file_contents
 		);
@@ -52,7 +52,7 @@ final class MiscTempTest extends TestCase {
 	 */
 	public function testTempFile2() {
 		$file_name_prefix = 'myfilename2';
-		$file_name_extension = 'txt';
+		$file_name_extension = '';
 		$file_contents = 'mycontentsofthefile2' . PHP_EOL;
 
 		$temp_file_name = vipgoci_save_temp_file(
@@ -76,12 +76,55 @@ final class MiscTempTest extends TestCase {
 			$temp_file_name
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$file_name_extension,
 			$temp_file_extension
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
+			$file_contents,
+			$temp_file_contents
+		);
+
+		unlink( $temp_file_name );
+	}
+
+
+	/**
+	 * @covers ::vipgoci_save_temp_file
+	 */
+	public function testTempFile3() {
+		$file_name_prefix = 'myfilename3';
+		$file_name_extension = 'txt';
+		$file_contents = 'mycontentsofthefile3' . PHP_EOL;
+
+		$temp_file_name = vipgoci_save_temp_file(
+			$file_name_prefix,
+			$file_name_extension,
+			$file_contents
+		);
+
+		$this->assertNotEquals(
+			false,
+			$temp_file_name
+		);
+
+		
+		$temp_file_extension = pathinfo(
+			$temp_file_name,
+			PATHINFO_EXTENSION
+		);
+
+		$temp_file_contents = file_get_contents(
+			$temp_file_name
+		);
+
+		$this->assertSame(
+			$file_name_extension,
+			$temp_file_extension
+		);
+
+		$this->assertSame(
 			$file_contents,
 			$temp_file_contents
 		);

--- a/tests/OptionsGenericSupportCommentsMatchTest.php
+++ b/tests/OptionsGenericSupportCommentsMatchTest.php
@@ -25,7 +25,7 @@ final class OptionsGenericSupportCommentsMatchTest extends TestCase {
 			'myoption1'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'1' => array(
 					'key1' => array( 'value1' ),

--- a/tests/OptionsGenericSupportCommentsProcessTest.php
+++ b/tests/OptionsGenericSupportCommentsProcessTest.php
@@ -26,7 +26,7 @@ final class OptionsGenericSupportCommentsProcessTest extends TestCase {
 			'boolean'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				1	=> false,
 				5	=> true,
@@ -51,7 +51,7 @@ final class OptionsGenericSupportCommentsProcessTest extends TestCase {
 			false
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				3	=> 'bar',
 				6	=> 'foo',
@@ -78,7 +78,7 @@ final class OptionsGenericSupportCommentsProcessTest extends TestCase {
 			true
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				3	=> 'bar',
 				6	=> 'foo',
@@ -105,7 +105,7 @@ final class OptionsGenericSupportCommentsProcessTest extends TestCase {
 			false
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				3	=> array(
 					'foo', 'bar', 'test'
@@ -143,7 +143,7 @@ final class OptionsGenericSupportCommentsProcessTest extends TestCase {
 			true
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				3	=> array(
 					'foo', 'bar', 'test'

--- a/tests/OptionsReadRepoFileTest.php
+++ b/tests/OptionsReadRepoFileTest.php
@@ -121,7 +121,7 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			-100, // Should remain unchanged, no option file exists.
 			$this->options['phpcs-severity']
 		);
@@ -169,7 +169,7 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			1, // Options file should change this to 1
 			$this->options['phpcs-severity']
 		);
@@ -220,7 +220,7 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			-100, // Should remain unchanged, feature is turned off.
 			$this->options['phpcs-severity']
 		);
@@ -274,7 +274,7 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			-100, // Should remain unchanged, as checks failed
 			$this->options['phpcs-severity']
 		);
@@ -322,7 +322,7 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			-100, // Should remain unchanged
 			$this->options['phpcs-severity']
 		);
@@ -371,7 +371,7 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			-100, // Should remain unchanged
 			$this->options['phpcs-severity']
 		);
@@ -420,7 +420,7 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			false, // Should remain unchanged
 			$this->options['post-generic-pr-support-comments']
 		);
@@ -471,7 +471,7 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			false, // Should not have changed
 			$this->options['post-generic-pr-support-comments']
 		);
@@ -521,7 +521,7 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			true, // Should have changed, repo setting is true
 			$this->options['post-generic-pr-support-comments']
 		);
@@ -573,7 +573,7 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'MySniff1',
 				'MySniff2',
@@ -630,7 +630,7 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'OtherSniff1',
 				'OtherSniff2',
@@ -694,17 +694,17 @@ final class OptionsReadRepoFileTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			true, // Should have changed, repo setting is true
 			$this->options['post-generic-pr-support-comments']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			-100, // Should not have changed, repo setting is set, but cannot be set
 			$this->options['phpcs-severity']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array( 'MySniff.MySniffName' ), // Should not have changed, is not configured
 			$this->options['phpcs-sniffs-exclude']
 		);

--- a/tests/OptionsReadRepoSkipFilesTest.php
+++ b/tests/OptionsReadRepoSkipFilesTest.php
@@ -87,14 +87,14 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 			$this->options
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'qqq-75x-n/plugins',
 			),
 			$this->options['phpcs-skip-folders']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'mmm-300/800',
 			),
@@ -120,14 +120,14 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 			$this->options
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'qqq-75x-n/plugins',
 			),
 			$this->options['phpcs-skip-folders']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'mmm-300/800',
 			),
@@ -153,7 +153,7 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 			$this->options
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'qqq-75x-n/plugins',
 				'bar-34/751-508x',
@@ -164,7 +164,7 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 			$this->options['phpcs-skip-folders']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'mmm-300/800',
 			),
@@ -188,14 +188,14 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 			$this->options
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'qqq-75x-n/plugins',
 			),
 			$this->options['phpcs-skip-folders']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'mmm-300/800',
 			),
@@ -221,14 +221,14 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 			$this->options
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'qqq-75x-n/plugins',
 			),
 			$this->options['phpcs-skip-folders']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'mmm-300/800',
 			),
@@ -254,14 +254,14 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 			$this->options
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'qqq-75x-n/plugins',
 			),
 			$this->options['phpcs-skip-folders']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'mmm-300/800',
 				'foo-bar-1/750-500x',

--- a/tests/OptionsSensitiveCleanTest.php
+++ b/tests/OptionsSensitiveCleanTest.php
@@ -27,7 +27,7 @@ final class OptionsSensitiveCleanTest extends TestCase {
 		 * cleaning, should remain unchanged.
 		 */		
 
-		$this->assertEquals(
+		$this->assertSame(
 			$options,
 			$options_clean
 		);
@@ -49,7 +49,7 @@ final class OptionsSensitiveCleanTest extends TestCase {
 			$options
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'a1'	=> '***',
 				'b1'	=> 'notsecret',
@@ -77,7 +77,7 @@ final class OptionsSensitiveCleanTest extends TestCase {
 			$options
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'a1'	=> '***',
 				'b1'	=> 'notsecret',

--- a/tests/OptionsSkipFolderHandleTest.php
+++ b/tests/OptionsSkipFolderHandleTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Vipgoci\tests;
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+final class OptionsSkipFolderHandleTest extends TestCase {
+	protected function setUp(): void {
+		$this->options = array();
+	}
+
+	protected function tearDown(): void {
+		$this->options = null;
+	}
+
+	/**
+	 * @covers ::vipgoci_option_skip_folder_handle
+	 */
+	public function testOptionSkipFolderHandle1() {
+		$this->options['phpcs-skip-folders'] =
+			'var/tmp/,/client-mu-plugins/myplugin/,/plugins/myplugin/,/tmp/1,tmp/3';
+
+		$this->options['lint-skip-folders'] =
+			'var/tmp2/,/client-mu-plugins/otherplugin/,/plugins/otherplugin/,/tmp/2,tmp/4';
+
+		vipgoci_option_skip_folder_handle(
+			$this->options,
+			'phpcs-skip-folders'
+		);
+
+		vipgoci_option_skip_folder_handle(
+			$this->options,
+			'lint-skip-folders'
+		);
+
+		$this->assertSame(
+			array(
+				'phpcs-skip-folders'	=> array(
+					'var/tmp',
+					'client-mu-plugins/myplugin',
+					'plugins/myplugin',
+					'tmp/1',
+					'tmp/3',
+				),
+
+				'lint-skip-folders'	=> array(
+					'var/tmp2',
+					'client-mu-plugins/otherplugin',
+					'plugins/otherplugin',
+					'tmp/2',
+					'tmp/4',
+				),
+			),
+			$this->options
+		);
+	}
+}

--- a/tests/PhpcsScanDoScanTest.php
+++ b/tests/PhpcsScanDoScanTest.php
@@ -91,7 +91,7 @@ final class PhpcsScanDoScanTest extends TestCase {
 
 		unlink( $temp_file_path );
 
-		$this->assertEquals(
+		$this->assertSame(
 			'{"totals":{"errors":1,"warnings":1,"fixable":0},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":1,"warnings":1,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6},{"message":"`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.","source":"WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter","severity":5,"fixable":false,"type":"WARNING","line":4,"column":16}]}}}',
 			$phpcs_res
 		);
@@ -181,7 +181,7 @@ final class PhpcsScanDoScanTest extends TestCase {
 
 		unlink( $temp_file_path );
 
-		$this->assertEquals(
+		$this->assertSame(
 			'{"totals":{"errors":2,"warnings":1,"fixable":1},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":2,"warnings":1,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6},{"message":"`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.","source":"WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter","severity":5,"fixable":false,"type":"WARNING","line":4,"column":16},{"message":"Expected 1 space before array closer, found 5.","source":"WordPress.Arrays.ArrayDeclarationSpacing.SpaceBeforeArrayCloser","severity":5,"fixable":true,"type":"ERROR","line":5,"column":25}]}}}',
 			$phpcs_res
 		);
@@ -236,7 +236,7 @@ final class PhpcsScanDoScanTest extends TestCase {
 
 		unlink( $temp_file_path );
 
-		$this->assertEquals(
+		$this->assertSame(
 			'{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":1,"warnings":0,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6}]}}}',
 			$phpcs_res
 		);
@@ -310,7 +310,7 @@ final class PhpcsScanDoScanTest extends TestCase {
 
 		unlink( $temp_file_path );
 
-		$this->assertEquals(
+		$this->assertSame(
 			'{"totals":{"errors":2,"warnings":0,"fixable":1},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":2,"warnings":0,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6},{"message":"Expected 1 space before array closer, found 5.","source":"WordPress.Arrays.ArrayDeclarationSpacing.SpaceBeforeArrayCloser","severity":5,"fixable":true,"type":"ERROR","line":5,"column":25}]}}}',
 			$phpcs_res
 		);

--- a/tests/PhpcsScanIssuesFilterDuplicateTest.php
+++ b/tests/PhpcsScanIssuesFilterDuplicateTest.php
@@ -46,7 +46,7 @@ final class PhpcsScanIssuesFilterDuplicateTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				array(
 					'message' => 'json_encode() is discouraged. Use wp_json_encode() instead.',
@@ -117,7 +117,7 @@ final class PhpcsScanIssuesFilterDuplicateTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				array(
 					'message' => 'json_encode() is discouraged. Use wp_json_encode() instead.',

--- a/tests/PhpcsScanIssuesFilterIrrellevantTest.php
+++ b/tests/PhpcsScanIssuesFilterIrrellevantTest.php
@@ -38,7 +38,7 @@ final class PhpcsScanIssuesFilterIrrellevantTest extends TestCase {
 			$file_relative_lines
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				array(
 					'message' => 'json_encode() is discouraged. Use wp_json_encode() instead.',

--- a/tests/PhpcsScanPossiblyUseNewStandardFileTest.php
+++ b/tests/PhpcsScanPossiblyUseNewStandardFileTest.php
@@ -46,7 +46,7 @@ final class PhpcsScanPossiblyUseNewStandardFileTest extends TestCase {
 			$this->options['phpcs-standard-file']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$this->original_standard,
 			$this->options['phpcs-standard']
 		);

--- a/tests/PhpcsScanScanCommitTest.php
+++ b/tests/PhpcsScanScanCommitTest.php
@@ -138,7 +138,7 @@ final class PhpcsScanScanCommitTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				8 => array(
 					array(
@@ -194,7 +194,7 @@ final class PhpcsScanScanCommitTest extends TestCase {
 			$issues_submit
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				8 => array(
 					'error' => 3,
@@ -258,13 +258,13 @@ final class PhpcsScanScanCommitTest extends TestCase {
 		 * we should have initialised statistics
 		 * for both. Make sure it is so.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			array(
-				21 => array(
+				22 => array(
 					'error' => 0,
 				),
 
-				22 => array(
+				21 => array(
 					'error' => 0,
 				),
 			),
@@ -295,7 +295,7 @@ final class PhpcsScanScanCommitTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				21 => array(
 					array(
@@ -340,7 +340,7 @@ final class PhpcsScanScanCommitTest extends TestCase {
 			$issues_submit
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				21 => array(
 					'error' => 2,
@@ -435,7 +435,7 @@ final class PhpcsScanScanCommitTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				30 => array(
 					array(
@@ -512,7 +512,7 @@ final class PhpcsScanScanCommitTest extends TestCase {
 			$issues_submit
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				30 => array(
 					'error' => 3,
@@ -614,7 +614,7 @@ final class PhpcsScanScanCommitTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				30 => array(
 					/*
@@ -642,11 +642,11 @@ final class PhpcsScanScanCommitTest extends TestCase {
 			$issues_submit
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				30 => array(
-					'error' => 0,
 					'warning' => 1,
+					'error' => 0,
 				)
 			),
 			$issues_stats
@@ -794,7 +794,7 @@ final class PhpcsScanScanCommitTest extends TestCase {
 			$tmp_standard_dir
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				30 => array(
 					array(
@@ -882,7 +882,7 @@ final class PhpcsScanScanCommitTest extends TestCase {
 			$issues_submit
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				30 => array(
 					'error' => 4,

--- a/tests/PhpcsScanSingleFileTest.php
+++ b/tests/PhpcsScanSingleFileTest.php
@@ -166,7 +166,7 @@ final class PhpcsScanSingleFileTest extends TestCase {
 			$expected_results['file_issues_arr_master']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$expected_results,
 			$scan_results
 		);

--- a/tests/PhpcsScanValidateSniffsInOptionAndReportTest.php
+++ b/tests/PhpcsScanValidateSniffsInOptionAndReportTest.php
@@ -168,7 +168,7 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 				$pr_item->number
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				count( array_keys( $pr_comments ) )
 			);
@@ -250,13 +250,13 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			}
 
 			// Make sure we removed one comment
-			$this->assertEquals(
+			$this->assertSame(
 				1,
 				$removed_comments
 			);
 		}
 
-		$this->assertEquals(
+		$this->assertSame(
 			$this->options['phpcs-validate-sniffs-and-report-include-valid'],
 			$this->options['phpcs-sniffs-include']
 		);
@@ -312,7 +312,7 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 				$pr_item->number
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				count( array_keys( $pr_comments ) )
 			);
@@ -347,13 +347,13 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 				$pr_item->number
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				count( array_keys( $pr_comments ) )
 			);
 		}
 
-		$this->assertEquals(
+		$this->assertSame(
 			$this->options['phpcs-validate-sniffs-and-report-include-valid'],
 			$this->options['phpcs-sniffs-include']
 		);
@@ -409,7 +409,7 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 				$pr_item->number
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				count( array_keys( $pr_comments ) )
 			);
@@ -491,13 +491,13 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			}
 
 			// Make sure we removed one comment
-			$this->assertEquals(
+			$this->assertSame(
 				1,
 				$removed_comments
 			);
 		}
 
-		$this->assertEquals(
+		$this->assertSame(
 			$this->options['phpcs-validate-sniffs-and-report-exclude-valid'],
 			$this->options['phpcs-sniffs-exclude']
 		);
@@ -553,7 +553,7 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 				$pr_item->number
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				count( array_keys( $pr_comments ) )
 			);
@@ -588,13 +588,13 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 				$pr_item->number
 			);
 
-			$this->assertEquals(
+			$this->assertSame(
 				0,
 				count( array_keys( $pr_comments ) )
 			);
 		}
 
-		$this->assertEquals(
+		$this->assertSame(
 			$this->options['phpcs-validate-sniffs-and-report-exclude-valid'],
 			$this->options['phpcs-sniffs-exclude']
 		);

--- a/tests/PhpcsScanWriteXmlStandardFileTest.php
+++ b/tests/PhpcsScanWriteXmlStandardFileTest.php
@@ -48,7 +48,7 @@ final class PhpcsScanWriteXmlStandardFileTest extends TestCase {
 			$xml_content
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'<?xml version="1.0" encoding="UTF-8"?>' .
 				'<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">' .
 				'<description>Custom coding standard</description>' .

--- a/tests/ResultsFilterCommentsToMaxTest.php
+++ b/tests/ResultsFilterCommentsToMaxTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Vipgoci\tests;
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+final class ResultsFilterCommentsToMaxTest extends TestCase {
+	var $options_git = array(
+		'repo-owner'	=> null,
+		'repo-name'	=> null,
+	);
+
+	var $options_git_repo_tests = array(
+		'pr-test-github-pr-results-max'	=> null,
+	);
+
+	protected function setUp(): void {
+		vipgoci_unittests_get_config_values(
+			'git',
+			$this->options_git
+		);
+
+		vipgoci_unittests_get_config_values(
+			'git-repo-tests',
+			$this->options_git_repo_tests
+		);
+
+		$this->options = array_merge(
+			$this->options_git,
+			$this->options_git_repo_tests
+		);
+
+		$this->options['token'] =
+			vipgoci_unittests_get_config_value(
+				'git-secrets',
+				'github-token',
+				true // Fetch from secrets file
+			);
+
+		$this->results = array(
+			'issues'	=> array(
+				$this->options['pr-test-github-pr-results-max']	=> array(
+					array(
+						'type'		=> 'phpcs',
+						'file_name'	=> 'bla-8.php',
+						'file_line'	=> 9,
+						'issue'		=> array(
+							'message'	=> 'This comment is 36% valid code; is this commented out code?',
+							'source'	=> 'Squiz.PHP.CommentedOutCode.Found',
+							'severity'	=> 1,
+							'fixable'	=> false,
+							'type'		=> 'WARNING',
+							'line'		=> 9,
+							'column'	=> 1,
+							'level'	=> 'WARNING'
+						),
+					),
+
+					array(
+						'type'		=> 'phpcs',
+						'file_name'	=> 'bla-9.php',
+						'file_line'	=> 10,
+						'issue'		=> array(
+							'message'	=> 'This comment is 100% valid code; is this commented out code?',
+							'source'	=> 'Squiz.PHP.CommentedOutCode.Found',
+							'severity'	=> 10,
+							'fixable'	=> false,
+							'type'		=> 'WARNING',
+							'line'		=> 10,
+							'column'	=> 1,
+							'level'	=> 'WARNING'
+						),
+					),
+				)
+			),
+
+			'stats'		=> array(
+				'phpcs'		=> array(
+					$this->options['pr-test-github-pr-results-max'] => array(
+						'error'		=> 0,
+						'warning'	=> 2,
+						'info'		=> 0,
+					)
+				)
+			),
+		);
+
+		$this->results_orig = $this->results;
+	}
+
+	protected function tearDown(): void {
+		$this->options = null;
+		$this->options_git = null;
+		$this->options_git_repo_tests = null;
+		$this->results = null;
+		$this->results_orig = null;
+	}
+
+	/**
+	 * @covers ::vipgoci_results_filter_comments_to_max
+	 */
+	public function testResultsFilterCommentsToMax1() {
+		/*
+		 * Test with max 1 comments allowed.
+		 */
+		$this->options['review-comments-total-max'] = 1;
+
+		$prs_comments_maxed = array();
+
+		vipgoci_results_filter_comments_to_max(
+			$this->options,
+			$this->results,
+			$prs_comments_maxed
+		);
+
+		$this->assertSame(
+			array(
+				$this->options['pr-test-github-pr-results-max']	=> true,
+			),
+			$prs_comments_maxed
+		);
+
+		$this->assertSame(
+			array(
+				'issues' => array(
+					$this->options['pr-test-github-pr-results-max'] => array(
+					)
+				),
+
+				'stats'		=> array(
+					'phpcs'		=> array(
+						$this->options['pr-test-github-pr-results-max'] => array(
+							'error'		=> 0,
+							'warning'	=> 0,
+							'info'		=> 0,
+						)
+					)
+				)
+			),
+			$this->results
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_results_filter_comments_to_max
+	 */
+	public function testResultsFilterCommentsToMax2() {
+		/*
+		 * Exactly one more comment allowed.
+		 */
+		$comments_count = count(
+			vipgoci_github_pr_reviews_comments_get_by_pr(
+				$this->options,
+				$this->options['pr-test-github-pr-results-max'],
+				array(
+					'login'                 => 'myself',
+					'comments_active'       => true,
+				)
+			)
+		);
+
+		$this->options['review-comments-total-max'] = $comments_count + 1;
+
+		$prs_comments_maxed = array();
+
+		vipgoci_results_filter_comments_to_max(
+			$this->options,
+			$this->results,
+			$prs_comments_maxed
+		);
+
+		$this->assertSame(
+			array(
+				$this->options['pr-test-github-pr-results-max']	=> true,
+			),
+			$prs_comments_maxed
+		);
+
+		$this->assertSame(
+			array(
+				'issues' => array(
+					$this->options['pr-test-github-pr-results-max'] => array(
+						array(
+							'type'		=> 'phpcs',
+							'file_name'	=> 'bla-9.php',
+							'file_line'	=> 10,
+								'issue'		=> array(
+								'message'	=> 'This comment is 100% valid code; is this commented out code?',
+								'source'	=> 'Squiz.PHP.CommentedOutCode.Found',
+								'severity'	=> 10,
+								'fixable'	=> false,
+								'type'		=> 'WARNING',
+								'line'		=> 10,
+								'column'	=> 1,
+								'level'	=> 'WARNING'
+							),
+						),
+					)
+				),
+
+				'stats'		=> array(
+					'phpcs'		=> array(
+						$this->options['pr-test-github-pr-results-max'] => array(
+							'error'		=> 0,
+							'warning'	=> 1,
+							'info'		=> 0,
+						)
+					)
+				)
+			),
+			$this->results
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_results_filter_comments_to_max
+	 */
+	public function testResultsFilterCommentsToMax3() {
+		/*
+		 * Max 100 allowed
+		 */
+		$this->options['review-comments-total-max'] = 100;
+
+		$prs_comments_maxed = array();
+
+		vipgoci_results_filter_comments_to_max(
+			$this->options,
+			$this->results,
+			$prs_comments_maxed
+		);
+
+		$this->assertSame(
+			array(
+			),
+			$prs_comments_maxed
+		);
+
+		$this->assertSame(
+			$this->results_orig,
+			$this->results
+		);
+	}
+}

--- a/tests/ResultsFilterCommentsToMaxTest.php
+++ b/tests/ResultsFilterCommentsToMaxTest.php
@@ -104,6 +104,16 @@ final class ResultsFilterCommentsToMaxTest extends TestCase {
 	 * @covers ::vipgoci_results_filter_comments_to_max
 	 */
 	public function testResultsFilterCommentsToMax1() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
 		/*
 		 * Test with max 1 comments allowed.
 		 */
@@ -149,6 +159,16 @@ final class ResultsFilterCommentsToMaxTest extends TestCase {
 	 * @covers ::vipgoci_results_filter_comments_to_max
 	 */
 	public function testResultsFilterCommentsToMax2() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
 		/*
 		 * Exactly one more comment allowed.
 		 */
@@ -157,8 +177,8 @@ final class ResultsFilterCommentsToMaxTest extends TestCase {
 				$this->options,
 				$this->options['pr-test-github-pr-results-max'],
 				array(
-					'login'                 => 'myself',
-					'comments_active'       => true,
+					'login'			=> 'myself',
+					'comments_active'	=> true,
 				)
 			)
 		);
@@ -220,6 +240,16 @@ final class ResultsFilterCommentsToMaxTest extends TestCase {
 	 * @covers ::vipgoci_results_filter_comments_to_max
 	 */
 	public function testResultsFilterCommentsToMax3() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
 		/*
 		 * Max 100 allowed
 		 */

--- a/tests/ResultsSortBySeverityTest.php
+++ b/tests/ResultsSortBySeverityTest.php
@@ -163,7 +163,7 @@ final class ResultsSortBySeverityTest extends TestCase {
 		);
 
 		// Not configured to sort, should remain unchanged
-		$this->assertEquals(
+		$this->assertSame(
 			$this->results_before,
 			$this->results
 		);
@@ -185,7 +185,7 @@ final class ResultsSortBySeverityTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		// Configured to sort, should be changed
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'issues' => array(
 					24 => array(

--- a/tests/Skeleton.php
+++ b/tests/Skeleton.php
@@ -1,8 +1,12 @@
 <?php
 
+namespace Vipgoci\tests;
+
 require_once( __DIR__ . '/IncludesForTests.php' );
 
 use PHPUnit\Framework\TestCase;
+
+// phpcs:disable PSR1.Files.SideEffects
 
 final class Skeleton extends TestCase {
 	/**

--- a/tests/StatsRunTimeMeasureTest.php
+++ b/tests/StatsRunTimeMeasureTest.php
@@ -9,7 +9,7 @@ final class StatsRunTimeMeasureTest extends TestCase {
 	 * @covers ::vipgoci_runtime_measure
 	 */
 	function testRuntimeMeasure1() {
-		return $this->assertEquals(
+		return $this->assertSame(
 			false,
 			vipgoci_runtime_measure( 'illegalaction', 'mytimer1' )
 		);
@@ -19,7 +19,7 @@ final class StatsRunTimeMeasureTest extends TestCase {
 	 * @covers ::vipgoci_runtime_measure
 	 */
 	function testRuntimeMeasure2() {
-		return $this->assertEquals(
+		return $this->assertSame(
 			false,
 			vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'mytimer2' )
 		);
@@ -29,7 +29,7 @@ final class StatsRunTimeMeasureTest extends TestCase {
 	 * @covers ::vipgoci_runtime_measure
 	 */
 	function testRuntimeMeasure3() {
-		$this->assertEquals(
+		$this->assertSame(
 			true,
 			vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'mytimer3' )
 		);
@@ -55,7 +55,7 @@ final class StatsRunTimeMeasureTest extends TestCase {
 	 * @covers ::vipgoci_runtime_measure
 	 */
 	function testRuntimeMeasure4() {
-		$this->assertEquals(
+		$this->assertSame(
 			true,
 			vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'mytimer4' )
 		);

--- a/tests/StatsStatsInitTest.php
+++ b/tests/StatsStatsInitTest.php
@@ -30,7 +30,7 @@ final class StatsStatsInitTest extends TestCase {
 			$stats_arr
 		);
 
-		return $this->assertEquals(
+		return $this->assertSame(
 			array(
 				'issues' => array(
 					100 =>

--- a/tests/SupportLevelLabelMetaApiDataFetchTest.php
+++ b/tests/SupportLevelLabelMetaApiDataFetchTest.php
@@ -68,7 +68,7 @@ final class SupportLevelLabelMetaApiDataFetchTest extends TestCase {
 			) )
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$this->options['support-level'],
 			$repo_meta_data['data'][0][
 				$this->options['support-level-field-name']
@@ -86,7 +86,7 @@ final class SupportLevelLabelMetaApiDataFetchTest extends TestCase {
 			$this->options['repo-name']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$repo_meta_data,
 			$repo_meta_data_2
 		);

--- a/tests/SupportLevelLabelRepoMetaApiDataMatchTest.php
+++ b/tests/SupportLevelLabelRepoMetaApiDataMatchTest.php
@@ -81,7 +81,7 @@ final class SupportLevelLabelRepoMetaApiDataMatchTest extends TestCase {
 
 		$option_key_no = null;
 
-		$this->assertEquals(
+		$this->assertSame(
 			false,
 
 			vipgoci_repo_meta_api_data_match(
@@ -91,7 +91,7 @@ final class SupportLevelLabelRepoMetaApiDataMatchTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			null,
 			$option_key_no
 		);
@@ -113,7 +113,7 @@ final class SupportLevelLabelRepoMetaApiDataMatchTest extends TestCase {
 
 		$option_key_no = null;
 
-		$this->assertEquals(
+		$this->assertSame(
 			false,
 
 			vipgoci_repo_meta_api_data_match(
@@ -123,7 +123,7 @@ final class SupportLevelLabelRepoMetaApiDataMatchTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			null,
 			$option_key_no
 		);
@@ -145,7 +145,7 @@ final class SupportLevelLabelRepoMetaApiDataMatchTest extends TestCase {
 
 		$option_key_no = null;
 
-		$this->assertEquals(
+		$this->assertSame(
 			false,
 
 			vipgoci_repo_meta_api_data_match(
@@ -155,7 +155,7 @@ final class SupportLevelLabelRepoMetaApiDataMatchTest extends TestCase {
 			)
 		);
 	
-		$this->assertEquals(
+		$this->assertSame(
 			null,
 			$option_key_no
 		);
@@ -177,7 +177,7 @@ final class SupportLevelLabelRepoMetaApiDataMatchTest extends TestCase {
 
 		$option_key_no = null;
 
-		$this->assertEquals(
+		$this->assertSame(
 			true,
 
 			vipgoci_repo_meta_api_data_match(
@@ -187,7 +187,7 @@ final class SupportLevelLabelRepoMetaApiDataMatchTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			2,
 			$option_key_no
 		);

--- a/tests/SupportLevelLabelSetTest.php
+++ b/tests/SupportLevelLabelSetTest.php
@@ -143,7 +143,7 @@ final class SupportLevelLabelSetTest extends TestCase {
 
 		$support_labels_cnt = $this->_findSupportLabelstoPrs();
 
-		$this->assertEquals(
+		$this->assertSame(
 			0,
 			$support_labels_cnt
 		);
@@ -182,7 +182,7 @@ final class SupportLevelLabelSetTest extends TestCase {
 		 */
 		$support_labels_cnt = $this->_findSupportLabelstoPrs();
 
-		$this->assertEquals(
+		$this->assertSame(
 			0,
 			$support_labels_cnt
 		);

--- a/tests/SvgScanLookForSpecificTokensTest.php
+++ b/tests/SvgScanLookForSpecificTokensTest.php
@@ -59,7 +59,7 @@ final class SvgScanLookForSpecificTokensTest extends TestCase {
 			$temp_file_name
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$results_expected,
 			$results
 		);

--- a/tests/SvgScanScanSingleFileTest.php
+++ b/tests/SvgScanScanSingleFileTest.php
@@ -136,7 +136,8 @@ final class SvgScanScanSingleFileTest extends TestCase {
 					)
 				),
 			),
-			
+
+			'file_issues_str'	=> '',
 			'temp_file_name'	=> $temp_file_name,
 		);
 
@@ -144,7 +145,7 @@ final class SvgScanScanSingleFileTest extends TestCase {
 			$expected_result['file_issues_arr_master']
 		);
 	
-		$this->assertEquals(
+		$this->assertSame(
 			$expected_result,
 			$ret
 		);

--- a/tests/SvgScanWithScannerTest.php
+++ b/tests/SvgScanWithScannerTest.php
@@ -75,7 +75,7 @@ final class SvgScanWithScannerTest extends TestCase {
 			$temp_file_name
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$scanner_results_expected,
 			$scanner_results
 		);
@@ -136,7 +136,7 @@ final class SvgScanWithScannerTest extends TestCase {
 			$temp_file_name
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$scanner_results_expected,
 			$scanner_results
 		);

--- a/tests/VipgociExitStatusTest.php
+++ b/tests/VipgociExitStatusTest.php
@@ -21,7 +21,7 @@ final class VipgociExitStatusTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			0,
 			$exit_status
 		);
@@ -43,7 +43,7 @@ final class VipgociExitStatusTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			250,
 			$exit_status
 		);

--- a/tests/VipgociOptionsArrayHandleTest.php
+++ b/tests/VipgociOptionsArrayHandleTest.php
@@ -20,7 +20,7 @@ final class VipgociOptionsArrayHandleTest extends TestCase {
 			','
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'myvalue',
 			),
@@ -44,7 +44,7 @@ final class VipgociOptionsArrayHandleTest extends TestCase {
 			','
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'myvalue1',
 				'myvalue2',
@@ -70,7 +70,7 @@ final class VipgociOptionsArrayHandleTest extends TestCase {
 			','
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'myvalue1',
 				'myvalue2',
@@ -97,7 +97,7 @@ final class VipgociOptionsArrayHandleTest extends TestCase {
 			false // do not strtolower()
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'myvalue1',
 				'myvalue2',

--- a/tests/VipgociOptionsBoolHandleTest.php
+++ b/tests/VipgociOptionsBoolHandleTest.php
@@ -18,7 +18,7 @@ final class VipgociOptionsBoolHandleTest extends TestCase {
 			'false'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			false,
 			$options['mytestoption']
 		);
@@ -37,7 +37,7 @@ final class VipgociOptionsBoolHandleTest extends TestCase {
 			false
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			false,
 			$options['mytestoption']
 		);
@@ -57,7 +57,7 @@ final class VipgociOptionsBoolHandleTest extends TestCase {
 			true
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			true,
 			$options['mytestoption']
 		);

--- a/tests/VipgociOptionsFileHandleTest.php
+++ b/tests/VipgociOptionsFileHandleTest.php
@@ -24,7 +24,7 @@ final class VipgociOptionsFileHandleTest extends TestCase {
 			$temp_file_name
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			$options['mytestoption'],
 			$temp_file_name
 		);

--- a/tests/VipgociOptionsIntegerHandleTest.php
+++ b/tests/VipgociOptionsIntegerHandleTest.php
@@ -18,7 +18,7 @@ final class VipgociOptionsIntegerHandleTest extends TestCase {
 			5
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'mytestoption'	=> 5
 			),

--- a/tests/VipgociOptionsPhpcsRuntimeSetTest.php
+++ b/tests/VipgociOptionsPhpcsRuntimeSetTest.php
@@ -23,7 +23,7 @@ final class VipgociOptionsPhpcsRuntimeSetTest extends TestCase {
 			'myphpcsruntimeoption',
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'myphpcsruntimeoption' => array(
 					array(

--- a/tests/VipgociOptionsReadEnvTest.php
+++ b/tests/VipgociOptionsReadEnvTest.php
@@ -63,13 +63,13 @@ final class VipgociOptionsReadEnvTest extends TestCase {
 		/*
 		 * Should successfully read from environment.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			array(
-				'repo-owner' => 'repo-test-owner',
 				'repo-name' => 'repo-test-name',
 				'env-options' => array(
 					0 => 'repo-owner=PHP_ROWNER',
 				),
+				'repo-owner' => 'repo-test-owner',
 			),
 			$options
 		);
@@ -111,7 +111,7 @@ final class VipgociOptionsReadEnvTest extends TestCase {
 		/*
 		 * Should not have read from environment.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'repo-name' => 'repo-test-name',
 				'env-options' => array(
@@ -159,7 +159,7 @@ final class VipgociOptionsReadEnvTest extends TestCase {
 		/*
 		 * Should not have read from environment.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'repo-name' => 'repo-test-name',
 				'env-options' => array(
@@ -205,7 +205,7 @@ final class VipgociOptionsReadEnvTest extends TestCase {
 		/*
 		 * Should not have read from environment.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'repo-name' => 'repo-test-name',
 				'env-options' => array(
@@ -252,7 +252,7 @@ final class VipgociOptionsReadEnvTest extends TestCase {
 		/*
 		 * Should not have read from environment.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'repo-name' => 'repo-test-name',
 				'env-options' => array(
@@ -299,7 +299,7 @@ final class VipgociOptionsReadEnvTest extends TestCase {
 		/*
 		 * Should not have read from environment.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'repo-name' => 'repo-test-name',
 				'env-options' => array(
@@ -346,14 +346,14 @@ final class VipgociOptionsReadEnvTest extends TestCase {
 		/*
 		 * Should not have read from environment.
 		 */
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'repo-name' => 'repo-test-name',
-				'repo-owner' => 'repo-test-owner2',
 				'env-options' => array(
 					0 => 'repo-owner=PHP_ROWNER',
 					1 => 'repo-owner=PHP_ROWNER2',
 				),
+				'repo-owner' => 'repo-test-owner2',
 			),
 			$options
 		);

--- a/unittests.ini
+++ b/unittests.ini
@@ -88,6 +88,7 @@ commit-test-options-read-repo-skip-files-2=ac10d1f29e64504d7741cd8ca22981c426c26
 commit-test-repo-branch=ap-file-types-test-1
 commit-test-submodule-list-get-1=f2008d8519d998d9e38f5688aaa2c5322179a266
 commit-test-submodule-list-get-2=dd18779e980f0302ab4acf7e871d2062d86b5f58
+pr-test-github-pr-results-max=28
 
 [labels]
 labels-pr-to-modify=12


### PR DESCRIPTION
Add a few unit-tests, as per #164. 

TODO:
- [x] Add unit-test for `vipgoci_cached_indication_str()`
- [x] Add unit-test for `vipgoci_github_rate_limit_usage()`
- [x] Add unit-test for `vipgoci_github_authenticated_user_get()`
- [x] Add unit-test for `vipgoci_option_skip_folder_handle()`
- [x] Add unit-test for `vipgoci_results_filter_comments_to_max()`
- [x] Improved unit-test for `vipgoci_github_pr_reviews_comments_get_by_pr()`
- [ ] Changelog entry

Also replaces all instances of `assertEquals()` with `assertSame()` in tests, except those that get replaced in #166. Fixes #156.