### PR TITLE
Make messages in IRC queue unique before sending

### DIFF
--- a/other-web-services.php
+++ b/other-web-services.php
@@ -22,6 +22,52 @@ function vipgoci_irc_api_alert_queue(
 	$msg_queue[] = $message;
 }
 
+/*
+ * Make messages in IRC queue unique, but add
+ * a prefix to those messages that were not unique
+ * indicating how many they were.
+ */
+function vipgoci_irc_api_alert_queue_unique( array $msg_queue ) {
+	$msg_queue_unique = array_unique(
+		$msg_queue
+	);
+
+	/*
+	 * If all messages were unique,
+	 * nothing more to do.
+	 */
+	if (
+		count( $msg_queue ) ===
+		count( $msg_queue_unique )
+	) {
+		return $msg_queue;
+	}
+
+	/*
+	 * Not all unique, count values
+	 */
+	$msg_queue_count = array_count_values(
+		$msg_queue
+	);
+
+	$msg_queue_new = array();
+
+	/*
+	 * Add prefix where needed.
+	 */
+	foreach( $msg_queue_count as $msg => $cnt ) {
+		$msg_prefix = '';
+
+		if ( $cnt > 1 ) {
+			$msg_prefix = '(' . $cnt . 'x) ';
+		}
+
+		$msg_queue_new[] = $msg_prefix . $msg;
+	}
+
+	return $msg_queue_new;
+}
+
 /**
  * Empty IRC message queue and send off
  * to the IRC API.
@@ -36,6 +82,10 @@ function vipgoci_irc_api_alerts_send(
 ) {
 	$msg_queue = vipgoci_irc_api_alert_queue(
 		null, true
+	);
+
+	$msg_queue = vipgoci_irc_api_alert_queue_unique(
+		$msg_queue
 	);
 
 	vipgoci_log(

--- a/tests/A00IrcApiAlertQueueUniqueTest.php
+++ b/tests/A00IrcApiAlertQueueUniqueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Vipgoci\tests;
+
 require_once( __DIR__ . '/IncludesForTests.php' );
 
 use PHPUnit\Framework\TestCase;

--- a/tests/A00IrcApiAlertQueueUniqueTest.php
+++ b/tests/A00IrcApiAlertQueueUniqueTest.php
@@ -1,0 +1,88 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+final class A00IrcApiAlertQueueUniqueTest extends TestCase {
+	/**
+	 * @covers: vipgoci_irc_api_alert_queue_unique
+	 */
+	public function testIrcQueueUnique1() {
+		$msg_queue = array(
+			'Msg 1',
+			'Msg 2',
+			'Msg 3'
+		);
+
+		$msg_queue_new = vipgoci_irc_api_alert_queue_unique(
+			$msg_queue
+		);
+
+		$this->assertSame(
+			array(
+				'Msg 1',
+				'Msg 2',
+				'Msg 3',
+			),
+			$msg_queue_new
+		);
+	}
+
+	/**
+	 * @covers: vipgoci_irc_api_alert_queue_unique
+	 */
+	public function testIrcQueueUnique2() {
+		$msg_queue = array(
+			'Msg 1',
+			'Msg 2',
+			'Msg 3',
+			'Msg 3',
+			'Msg 3',
+			'Msg 3',
+		);
+
+		$msg_queue_new = vipgoci_irc_api_alert_queue_unique(
+			$msg_queue
+		);
+
+		$this->assertSame(
+			array(
+				'Msg 1',
+				'Msg 2',
+				'(4x) Msg 3',
+			),
+			$msg_queue_new
+		);
+	}
+
+	/**
+	 * @covers: vipgoci_irc_api_alert_queue_unique
+	 */
+	public function testIrcQueueUnique3() {
+		$msg_queue = array(
+			'Msg 1',
+			'Msg 2',
+			'Msg 2',
+			'Msg 2',
+			'Msg 2',
+			'Msg 3',
+			'Msg 3',
+		);
+
+		$msg_queue_new = vipgoci_irc_api_alert_queue_unique(
+			$msg_queue
+		);
+
+		$this->assertSame(
+			array(
+				'Msg 1',
+				'(4x) Msg 2',
+				'(2x) Msg 3',
+			),
+			$msg_queue_new
+		);
+	}
+}


### PR DESCRIPTION
Sometimes messages to IRC are in duplicate. Here we ensure this does not happen by making all the messages unique before sending.

TODO:
- [x] Make messages in IRC queue unique before sending
- [x] Add unit-tests to test feature
- [x] Changelog entry
- [x] Check automated unit-tests
