### PR TITLE
Renaming option --results-comments-sort to --review-comments-sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,12 +479,12 @@ One can sort the review comments posted according to severity of the issue found
 
 The option can be used in this way:
 
-> ./vip-go-ci.php --results-comments-sort=true
+> ./vip-go-ci.php --review-comments-sort=true
 
 This option can be configured via repository-config file as well:
 
 ```
-{"results-comments-sort":true}
+{"review-comments-sort":true}
 ```
 
 #### Including severity in review comments

--- a/main.php
+++ b/main.php
@@ -147,7 +147,7 @@ function vipgoci_run() {
 			'commit:',
 			'token:',
 			'skip-draft-prs:',
-			'results-comments-sort:',
+			'review-comments-sort:',
 			'review-comments-max:',
 			'review-comments-total-max:',
 			'review-comments-ignore:',
@@ -277,7 +277,7 @@ function vipgoci_run() {
 			"\t" . '--commit=STRING                Specify the exact commit to scan (SHA)' . PHP_EOL .
 			"\t" . '--token=STRING                 The access-token to use to communicate with GitHub' . PHP_EOL .
 			PHP_EOL .
-			"\t" . '--results-comments-sort=BOOL     Sort issues found according to severity, from high ' . PHP_EOL .
+			"\t" . '--review-comments-sort=BOOL     Sort issues found according to severity, from high ' . PHP_EOL .
 			"\t" . '                               to low, before submitting to GitHub. Not sorted by default.' . PHP_EOL .
 			"\t" . '--review-comments-max=NUMBER   Maximum number of inline comments to submit' . PHP_EOL .
 			"\t" . '                               to GitHub in one review. If the number of ' . PHP_EOL .
@@ -761,7 +761,7 @@ function vipgoci_run() {
 
 	vipgoci_option_bool_handle( $options, 'dismissed-reviews-repost-comments', 'true' );
 
-	vipgoci_option_bool_handle( $options, 'results-comments-sort', 'false' );
+	vipgoci_option_bool_handle( $options, 'review-comments-sort', 'false' );
 
 	vipgoci_option_bool_handle( $options, 'review-comments-include-severity', 'false' );
 
@@ -1007,7 +1007,7 @@ function vipgoci_run() {
 		array(
 			'skip-execution',
 			'skip-draft-prs',
-			'results-comments-sort',
+			'review-comments-sort',
 			'review-comments-include-severity',
 			'phpcs',
 			'phpcs-severity',
@@ -1475,7 +1475,7 @@ function vipgoci_run() {
 				'valid_values'	=> array( true, false ),
 			),
 
-			'results-comments-sort' => array(
+			'review-comments-sort' => array(
 				'type'		=> 'boolean',
 				'valid_values'	=> array( true, false ),
 			),

--- a/misc.php
+++ b/misc.php
@@ -1138,7 +1138,7 @@ function vipgoci_results_sort_by_severity(
 	&$results
 ) {
 
-	if ( true !== $options['results-comments-sort'] ) {
+	if ( true !== $options['review-comments-sort'] ) {
 		return;
 	}
 

--- a/tests/ReviewCommentsSortTest.php
+++ b/tests/ReviewCommentsSortTest.php
@@ -1,0 +1,324 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+final class ReviewCommentsSortBySeverityTest extends TestCase {
+	protected function setUp(): void {
+		$this->results = array(
+			'issues' => array(
+				24 => array(
+					array(
+						"type"		=> "phpcs",
+						"file_name"	=> "testfile1.php",
+						"file_line"	=> 100,
+						"issue"		=> array(
+							"message"	=> "Incorrect usage of function other_foo()",
+							"source"	=> "RandomStandard.OtherSniff.random_function",
+							"severity"	=> 100,
+							"fixable"	=> false,
+							"type"		=> "INFO",
+							"line"		=> 100,
+							"column"	=> 1,
+							"level"		=> "INFO"
+						)
+					),
+					array(
+						"type"		=> "phpcs",
+						"file_name"	=> "testfile1.php",
+						"file_line"	=> 3,
+						"issue"		=> array(
+							"message"	=> "Incorrect usage of function foo()",
+							"source"	=>  "RandomStandard.RandomSniff.random_function",
+							"severity"	=> 3,
+							"fixable"	=> false,
+							"type"		=> "INFO",
+							"line"		=> 3,
+							"column"	=> 1,
+							"level"		=> "INFO"
+						)
+					),
+					array(
+						"type"		=> "phpcs",
+						"file_name"	=> "testfile1.php",
+						"file_line"	=> 2,
+						"issue"		=> array(
+							"message"	=> "Incorrect usage of function foo()",
+							"source"	=> "RandomStandard.RandomSniff.random_function",
+							"severity"	=> 40,
+							"fixable"	=> false,
+							"type"		=> "INFO",
+							"line"		=> 2,
+							"column"	=> 1,
+							"level"		=> "INFO"
+						)
+					),
+					array(
+						"type"		=> "phpcs",
+						"file_name"	=> "testfile2.php",
+						"file_line"	=> 100,
+						"issue"		=> array(
+							"message"	=> "Incorrect usage of function foo()",
+							"source"	=> "RandomStandard.RandomSniff.random_function",
+							"severity"	=> 101,
+							"fixable"	=> false,
+							"type"		=> "INFO",
+							"line"		=> 100,
+							"column"	=> 1,
+							"level"		=> "INFO"
+						)
+					),
+					array(
+						"type"		=> "phpcs",
+						"file_name"	=> "testfile2.php",
+						"file_line"	=> 100,
+						"issue"		=> array(
+							"message"	=> "Incorrect usage of function foo()",
+							"source"	=> "RandomStandard.RandomSniff.random_function",
+							"severity"	=> 37,
+							"fixable"	=> false,
+							"type"		=> "INFO",
+							"line"		=> 100,
+							"column"	=> 1,
+							"level"		=> "INFO"
+						)
+					),
+				),
+
+				7 => array(
+					array(
+						"type"		=> "phpcs",
+						"file_name"	=> "testfile2.php",
+						"file_line"	=> 100,
+						"issue"		=> array(
+							"message"	=> "Incorrect usage of function foo()",
+							"source"	=> "RandomStandard.RandomSniff.random_function",
+							"severity"	=> 7,
+							"fixable"	=> false,
+							"type"		=> "INFO",
+							"line"		=> 100,
+							"column"	=> 1,
+							"level"		=> "INFO"
+						)
+					),
+					array(
+						"type"		=> "phpcs",
+						"file_name"	=> "testfile2.php",
+						"file_line"	=> 100,
+						"issue"		=> array(
+							"message"	=> "Incorrect usage of function testfoo()",
+							"source"	=> "RandomStandard.RandomSniff.test_function",
+							"severity"	=> 200,
+							"fixable"	=> false,
+							"type"		=> "INFO",
+							"line"		=> 100,
+							"column"	=> 1,
+							"level"		=> "INFO"
+						)
+					),
+					array(
+						"type"		=> "phpcs",
+						"file_name"	=> "testfile2.php",
+						"file_line"	=> 100,
+						"issue"		=> array(
+							"message"	=> "Incorrect usage of function myfoo()",
+							"source"	=> "RandomStandard.RandomSniff.myfoo_function",
+							"severity"	=> 377,
+							"fixable"	=> false,
+							"type"		=> "INFO",
+							"line"		=> 100,
+							"column"	=> 1,
+							"level"		=> "INFO"
+						)
+					),
+				),
+			)
+		);
+	}
+
+	protected function tearDown(): void {
+		$this->options = null;
+		$this->results = null;
+	}
+
+	/**
+	 * @covers ::vipgoci_results_sort_by_severity
+	 */
+	public function testSortingNotConfigured() {
+		$this->options['review-comments-sort'] = false;
+		$this->results_before = $this->results;
+
+		vipgoci_unittests_output_suppress();
+
+		vipgoci_results_sort_by_severity(
+			$this->options,
+			$this->results
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertNotEmpty(
+			$this->results_before
+		);
+
+		// Not configured to sort, should remain unchanged
+		$this->assertSame(
+			$this->results_before,
+			$this->results
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_results_sort_by_severity
+	 */
+	public function testSortingCorrect1() {
+		$this->options['review-comments-sort'] = true;
+
+		vipgoci_unittests_output_suppress();
+
+		vipgoci_results_sort_by_severity(
+			$this->options,
+			$this->results
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		// Configured to sort, should be changed
+		$this->assertSame(
+			array(
+				'issues' => array(
+					24 => array(
+						array(
+							"type"		=> "phpcs",
+							"file_name"	=> "testfile2.php",
+							"file_line"	=> 100,
+							"issue"		=> array(
+								"message"	=> "Incorrect usage of function foo()",
+								"source"	=> "RandomStandard.RandomSniff.random_function",
+								"severity"	=> 101,
+								"fixable"	=> false,
+								"type"		=> "INFO",
+								"line"		=> 100,
+								"column"	=> 1,
+								"level"		=> "INFO"
+							)
+						),
+						array(
+							"type"		=> "phpcs",
+							"file_name"	=> "testfile1.php",
+							"file_line"	=> 100,
+							"issue"		=> array(
+								"message"	=> "Incorrect usage of function other_foo()",
+								"source"	=> "RandomStandard.OtherSniff.random_function",
+								"severity"	=> 100,
+								"fixable"	=> false,
+								"type"		=> "INFO",
+								"line"		=> 100,
+								"column"	=> 1,
+								"level"		=> "INFO"
+							)
+						),
+						array(
+							"type"		=> "phpcs",
+							"file_name"	=> "testfile1.php",
+							"file_line"	=> 2,
+							"issue"		=> array(
+								"message"	=> "Incorrect usage of function foo()",
+								"source"	=> "RandomStandard.RandomSniff.random_function",
+								"severity"	=> 40,
+								"fixable"	=> false,
+								"type"		=> "INFO",
+								"line"		=> 2,
+								"column"	=> 1,
+								"level"		=> "INFO"
+							)
+						),
+						array(
+							"type"		=> "phpcs",
+							"file_name"	=> "testfile2.php",
+							"file_line"	=> 100,
+							"issue"		=> array(
+								"message"	=> "Incorrect usage of function foo()",
+								"source"	=> "RandomStandard.RandomSniff.random_function",
+								"severity"	=> 37,
+								"fixable"	=> false,
+								"type"		=> "INFO",
+								"line"		=> 100,
+								"column"	=> 1,
+								"level"		=> "INFO"
+							)
+						),
+						array(
+							"type"		=> "phpcs",
+							"file_name"	=> "testfile1.php",
+							"file_line"	=> 3,
+							"issue"		=> array(
+								"message"	=> "Incorrect usage of function foo()",
+								"source"	=>  "RandomStandard.RandomSniff.random_function",
+								"severity"	=> 3,
+								"fixable"	=> false,
+								"type"		=> "INFO",
+								"line"		=> 3,
+								"column"	=> 1,
+								"level"		=> "INFO"
+							)
+						),
+					),
+	
+					7 => array(
+						array(
+							"type"		=> "phpcs",
+							"file_name"	=> "testfile2.php",
+							"file_line"	=> 100,
+							"issue"		=> array(
+								"message"	=> "Incorrect usage of function myfoo()",
+								"source"	=> "RandomStandard.RandomSniff.myfoo_function",
+								"severity"	=> 377,
+								"fixable"	=> false,
+								"type"		=> "INFO",
+								"line"		=> 100,
+								"column"	=> 1,
+								"level"		=> "INFO"
+							)
+						),
+						array(
+							"type"		=> "phpcs",
+							"file_name"	=> "testfile2.php",
+							"file_line"	=> 100,
+							"issue"		=> array(
+								"message"	=> "Incorrect usage of function testfoo()",
+								"source"	=> "RandomStandard.RandomSniff.test_function",
+								"severity"	=> 200,
+								"fixable"	=> false,
+								"type"		=> "INFO",
+								"line"		=> 100,
+								"column"	=> 1,
+								"level"		=> "INFO"
+							)
+						),
+						array(
+							"type"		=> "phpcs",
+							"file_name"	=> "testfile2.php",
+							"file_line"	=> 100,
+							"issue"		=> array(
+								"message"	=> "Incorrect usage of function foo()",
+								"source"	=> "RandomStandard.RandomSniff.random_function",
+								"severity"	=> 7,
+								"fixable"	=> false,
+								"type"		=> "INFO",
+								"line"		=> 100,
+								"column"	=> 1,
+								"level"		=> "INFO"
+							)
+						),
+					),
+				)
+			),
+
+			$this->results
+		);
+	}
+
+
+}


### PR DESCRIPTION
Renaming option `--results-comments-sort` to `--review-comments-sort` so to be in line with current options.

TODO:
- [X] Rename option
- [X] Update unit-tests
- [X] Update README
- [ ] Changelog entry
- [ ] Check automated unit-tests
