### PR TITLE
Remove code block that enforces lint scan for the entire repository

### DIFF
--- a/lint-scan.php
+++ b/lint-scan.php
@@ -233,18 +233,6 @@ function vipgoci_lint_scan_commit(
 		)
 	);
 
-	// Fetch list of files that exist in the commit
-	$commit_tree = vipgoci_gitrepo_fetch_tree(
-		$options,
-		$commit_id,
-		array(
-			'file_extensions'
-				=> array( 'php' ),
-			'skip_folders'
-				=> $options['lint-skip-folders'],
-		)
-	);
-
 	// Ask for all Pull-Requests that this commit is part of
 	$prs_implicated = vipgoci_github_prs_implicated(
 		$repo_owner,
@@ -260,7 +248,9 @@ function vipgoci_lint_scan_commit(
 	 * Lint every PHP file existing in the commit
 	 */
 
-	foreach( $commit_tree as $filename ) {
+	$commit_tree = $commit_info->files;
+	foreach( $commit_tree as $file ) {
+		$filename = $file->filename;
 		vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'lint_scan_single_file' );
 
 		$file_contents = vipgoci_gitrepo_fetch_committed_file(


### PR DESCRIPTION
<!-- ATTENTION: :wave: Just a quick reminder that this is a PUBLIC repository. Please do not include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask! -->
<!--
Pull-Requests should have a TODO included. Here is a draft:

TODO:
- [ ] Specify a parameter to make [feature] configurable
- [ ] Implement [new feature / logic]
- [ ] Add/update unit-tests
- [ ] Update README
- [ ] Changelog entry
- [ ] Public documentation changes
- [ ] Run full-unit tests 
- [ ] Check automated unit-tests
- [ ] Manual testing
  - [ ] Pull-Request with PHP linting issues
  - [ ] Pull-Request with PHPCS issues
  - [ ] Pull-Request without PHPCS issues, not auto-approved
  - [ ] Pull-Request without PHPCS issues, is auto-approved
  - [ ] Pull-Request with SVG issues
-->
