### PR TITLE
Attempt to reduce GitHub API usage a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,11 +604,13 @@ All utilities in `tools-init.sh` follow the same pattern.
 
 ## Unittests
 
-To run the unitests for `vip-go-ci`, you will need to install `phpunit` and any dependencies needed (this would include `xdebug`). Then run the unittests using the following command:
+To run the unit tests for `vip-go-ci`, you will need to install `phpunit` and any dependencies needed (this would include `xdebug`). Then run the unit tests using the following command:
 
 > phpunit tests/ -vv
 
-By using this command, you will run the whole test-suite and get feedback on any errors or warnings. 
+By using this command, you will run the whole test-suite and get feedback on any errors or warnings. Note that when run, requests will be made to the GitHub API, but using anonymous calls (unless configured as shown below). It can happen that the GitHub API returns with an error indicating that the maximum limit of API requests has been reached; the solution is to wait and re-run or use authenticated calls (see below). 
+
+`vip-go-ci` ships with a default `unittests.ini` file which includes configuration details needed for the unit tests to run. This includes repository to use for testing, pull request IDs and more.
 
 Note that by default, some tests will be skipped, as these will require a GitHub token to write to GitHub in order to complete, need access to the hashes-to-hashes database, or to a repo-meta API. To enable the testing of these, you need to set up a `unittests-secrets.ini` file in the root of the repository. It should include the following fields:
 

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ To run the unit tests for `vip-go-ci`, you will need to install `phpunit` and an
 
 > phpunit tests/ -vv
 
-By using this command, you will run the whole test-suite and get feedback on any errors or warnings. Note that when run, requests will be made to the GitHub API, but using anonymous calls (unless configured as shown below). It can happen that the GitHub API returns with an error indicating that the maximum limit of API requests has been reached; the solution is to wait and re-run or use authenticated calls (see below). 
+By using this command, you will run the tests of the test-suite which can be run (depending on tokens and other detail), and get feedback on any errors or warnings. Note that when run, requests will be made to the GitHub API, but using anonymous calls (unless configured as shown below). It can happen that the GitHub API returns with an error indicating that the maximum limit of API requests has been reached; the solution is to wait and re-run or use authenticated calls (see below). 
 
 `vip-go-ci` ships with a default `unittests.ini` file which includes configuration details needed for the unit tests to run. This includes repository to use for testing, pull request IDs and more.
 

--- a/tests/ApHashesApiScanCommitTest.php
+++ b/tests/ApHashesApiScanCommitTest.php
@@ -93,7 +93,7 @@ final class ApHashesApiScanCommitTest extends TestCase {
 	public function testApHashesApiScanCommitTest1() {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
-			array( 'github-token', 'token' ),
+			array( ),
 			$this
 		);
 

--- a/tests/GitHubPrGenericSupportCommentTest.php
+++ b/tests/GitHubPrGenericSupportCommentTest.php
@@ -76,7 +76,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		$this->options['commit'] =
 			$this->options['test-github-pr-generic-support-comment-1'];
 
-		if ( empty( $this->current_user_info ) ) {
+		/*
+		 * Try to fetch information about current user,
+		 * but only if we have a token. This info will
+		 * be re-used.
+		 */
+		if (
+			( empty( $this->current_user_info ) ) &&
+			( ! empty( $this->options['github-token'] ) )
+		) {
 			$this->current_user_info = vipgoci_github_authenticated_user_get(
 				$this->options['github-token']
 			);

--- a/unittests.ini
+++ b/unittests.ini
@@ -47,7 +47,7 @@ commit-test-svg-files-2b=bc23e8530ad4881af447646c6e53f2acd1ef364d
 autoapprove-filetypes=txt,gif,jpg,png,md
 commit-test-ap-hashes-file-approved-1=3dc1135e4bc1dbc5c5a57cdf45c2ba2bd5690b51
 commit-test-ap-auto-approval-1=a96b12cc806fef600818085cf26dad61321ddc81
-pr-test-ap-auto-approval-1=14
+pr-test-ap-auto-approval-1=40
 commit-test-hashes-api-scan-commit=f8a50f557b25dca72978854eae97bd8ba07f0a55
 
 commit-test-ap-nonfunctionalchanges-1b=c4a3fe05f67f329cdf884392df29e55f5b8d4498
@@ -91,7 +91,7 @@ commit-test-repo-pr-diffs-4-a=81a5a85c1392b1ecafb691e32599beb2e397c32e
 
 pr-test-github-pr-reviews-get-1=11
 commit-test-github-pr-reviews-get-1=a23730447e46564d72b75d12d6bbf86737717c5f
-test-github-pr-reviews-event-get-pr-number=14
+test-github-pr-reviews-event-get-pr-number=40
 test-github-pr-reviews-event-get-username=gudmdharalds
 test-github-pr-generic-support-comment-1=37a5be155aa03cf61f13842ab46e036b62d3cecb
 commit-test-options-read-repo-skip-files-1=6d94aa26126d1a568677d04b8076ee6503011d65


### PR DESCRIPTION
Recently the GitHub API usage limits have been reached when running unit-tests without any access tokens. This PR attempts to address this.

TODO:
- [x] Reduce API usage
- [x] Update README.md
- [x] Changelog entry [#184]