### PR TITLE
Adding function vipgoci_options_get_starting_with()

### DIFF
--- a/options.php
+++ b/options.php
@@ -1454,3 +1454,32 @@ function vipgoci_option_phpcs_runtime_set(
 	}
 }
 
+/*
+ * Return options as key-value pairs that start
+ * with $start_with, but skip any options in
+ * $options_skip. Will sort the results according
+ * to key.
+ */
+function vipgoci_options_get_starting_with(
+	array $options,
+	string $starts_with,
+	array $options_skip
+) :array {
+	$ret_vals = array();
+
+	foreach( array_keys( $options ) as $option_name ) {
+		if ( 0 !== strpos( $option_name, $starts_with ) ) {
+			continue;
+		}
+
+		if ( in_array( $option_name, $options_skip ) ) {
+			continue;
+		}
+
+		$ret_vals[ $option_name ] = $options[ $option_name ];
+	}
+
+	ksort( $ret_vals );
+
+	return $ret_vals;
+}

--- a/tests/GitHubPrsImplicatedTest.php
+++ b/tests/GitHubPrsImplicatedTest.php
@@ -88,7 +88,7 @@ final class GitHubPrsImplicatedTest extends TestCase {
 		);
 
 		$this->assertSame(
-			'80ebd6d65db88e87665b6ff1aa045f68d17ddeb7',
+			'0d205d30dbd0917f53d00171a602806d964cd915',
 			$prs_implicated[9]->merge_commit_sha
 		);
 

--- a/tests/OptionsGetStartingWithTest.php
+++ b/tests/OptionsGetStartingWithTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Vipgoci\tests;
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+final class OptionsGetStartingWithTest extends TestCase {
+	/**
+	 * @covers ::vipgoci_options_get_starting_with
+	 */
+	public function testOptionsStartingWith() {
+		$expected = array(
+			'test0' => 't0',
+			'test2' => 't9',
+		);
+
+		$result = vipgoci_options_get_starting_with(
+			array(
+				'test1' => 't1',
+				'test0' => 't0',
+				'test2' => 't9',
+				'atest3' => '999',
+				'atest4' => '888',
+				'atest0' => '777'
+			),
+			'test',
+			array(
+				'test1',
+			)
+		);
+
+		$this->assertsame(
+			$expected,
+			$result
+		);
+	}
+}


### PR DESCRIPTION
Adding function `vipgoci_options_get_starting_with` to help work with options. This function is currently used in `vip-go-compatibility-scanner` and will be used in `vip-go-ci` as well.

TODO:
- [x] Implement `vipgoci_options_get_starting_with()`
- [x] Add unit-test for `vipgoci_options_get_starting_with()`
- [x] Changelog entry [#190]
- [x] Check automated unit-tests
