### PR TITLE
Fix commit sha used for large files tests

### DIFF
--- a/unittests.ini
+++ b/unittests.ini
@@ -23,7 +23,7 @@ commit-test-phpcs-scan-commit-2=1c63fd89388e3f5563869ca5dc54ae7d4da9f1a4
 commit-test-phpcs-scan-commit-3=ba678917a65855a3129ff4f95de3b2ede3d76f4b
 commit-test-phpcs-scan-commit-4=4702a1416ee36510a3cc43c68e631be572acddfe
 commit-test-phpcs-scan-commit-5=dd60c66a7c1e27fc78c400f0c5160c9a80c4bd49
-commit-test-phpcs-scan-commit-6=c45ea112564ce395da252fc692ebc19b605d5412
+commit-test-phpcs-scan-commit-6=84985c25706e83dada8c40061e6f1496cfe3c522
 
 phpcs-validate-sniffs-and-report-include-commit=fa1b1a695a0c25895ed8ccb3c0d475e077f396f8
 phpcs-validate-sniffs-and-report-include-invalid=MyInvalidSniff.SniffName
@@ -41,7 +41,7 @@ php-path=/usr/bin/php
 commit-test-lint-scan-commit-1=6968d452099d2b43fd85953076b34a5b2e2d707f
 commit-test-lint-scan-commit-2=20fee28020873cb7fdfadf1cfa101f94026bc75e
 commit-test-lint-scan-commit-3=dd60c66a7c1e27fc78c400f0c5160c9a80c4bd49
-commit-test-lint-scan-commit-4=c45ea112564ce395da252fc692ebc19b605d5412
+commit-test-lint-scan-commit-4=84985c25706e83dada8c40061e6f1496cfe3c522
 
 [auto-approvals]
 commit-test-file-types-1=2d864e5dd9d89ea3362d965477432873bf970345


### PR DESCRIPTION
Apparently, the large files unit tests are using the incorrect commit sha when executing. This PR updates it to the correct one. 
- [ X ] Check automated unit-tests
