### PR TITLE
Add Sunset HTTP header detection

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -117,6 +117,68 @@ function vipgoci_curl_set_security_options( $ch ) {
 	);
 }
 
+/*
+ * Log a warning if a Sunset HTTP header is
+ * found in array of response headers, as this indicates
+ * that the API feature will become deprecated in the
+ * future. Will log the URL called, but without query
+ * component, as it may contain sensitive information.
+ *
+ * Information on Sunset HTTP headers:
+ * https://datatracker.ietf.org/doc/html/draft-wilde-sunset-header-03
+ */
+function vipgoci_http_resp_sunset_header_check(
+	string $http_url,
+	array $resp_headers
+) {
+	/*
+	 * If no sunset header is found, do nothing.
+	 */
+	if (
+		( ! isset( $resp_headers['sunset'][0] ) ) ||
+		( strlen( $resp_headers['sunset'][0] ) <= 0 )
+	) {
+		return;
+	}
+
+	$sunset_date = $resp_headers['sunset'];
+
+	/*
+	 * To minimize likelihood of data-leaks via the URL being
+	 * logged, remove any query parameters and leave
+	 * only the base URL.
+	 */
+
+	$http_url_parsed = parse_url( $http_url );
+
+	$http_url_clean =
+		$http_url_parsed['scheme'] . '://' .
+		$http_url_parsed['host'];
+
+	
+	if ( isset( $http_url_parsed['port'] ) ) {
+		$http_url_clean .= ':' . (int) $http_url_parsed['port'];
+	}
+
+	if ( isset( $http_url_parsed['path'] ) ) {
+		$http_url_clean .=
+			'/' .
+			$http_url_parsed['path'];
+	}
+
+
+	vipgoci_log(
+		'Warning: Sunset HTTP header detected, feature will become unavailable',
+		array(
+			'http_url_clean'	=> $http_url_clean,
+			'sunset_date'		=> $sunset_date,
+		),
+		0,
+		true // Log to IRC.
+	);
+}
+
+
 /**
  * Detect if we exceeded the GitHub rate-limits,
  * and if so, exit with error.
@@ -623,6 +685,10 @@ function vipgoci_github_post_url(
 			$resp_headers
 		);
 
+		vipgoci_http_resp_sunset_header_check(
+			$github_url,
+			$resp_headers
+		);
 
 		curl_close( $ch );
 
@@ -766,6 +832,11 @@ function vipgoci_github_fetch_url(
 
 
 		vipgoci_github_rate_limits_check(
+			$github_url,
+			$resp_headers
+		);
+
+		vipgoci_http_resp_sunset_header_check(
 			$github_url,
 			$resp_headers
 		);
@@ -986,6 +1057,10 @@ function vipgoci_github_put_url(
 			$resp_headers
 		);
 
+		vipgoci_http_resp_sunset_header_check(
+			$github_url,
+			$resp_headers
+		);
 
 		curl_close( $ch );
 

--- a/tests/HttpRespSunsetHeaderCheckTest.php
+++ b/tests/HttpRespSunsetHeaderCheckTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Vipgoci\tests;
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+final class HttpRespSunsetHeaderCheckTest extends TestCase {
+	protected function setUp(): void {
+		vipgoci_irc_api_alert_queue( null, true ); // Empty IRC queue
+	}
+
+	private function _searchIrcMsgQueue() :boolean {
+		$found = false;
+
+		$irc_msg_queue = vipgoci_irc_api_alert_queue( null, true );
+
+		foreach( $irc_msg_queue as $irc_msg_queue_item ) {
+			if ( false !== strpos(
+				$irc_msg_queue_item,
+				'Warning: Sunset HTTP header detected, feature will become unavailable'
+			) ) {
+				$found = true;
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * @covers ::vipgoci_http_resp_sunset_header_check
+	 */
+	public function testSunsetHeaderExists() {
+		vipgoci_unittests_output_suppress();
+
+		/*
+		 * Do a header check, test if anything ends in IRC queue.
+		 */
+		vipgoci_http_resp_sunset_header_check(
+			'https://mytest.localdomain:5000/test/foo?test1=test2',
+			array(
+				'test1'		=> 'data',
+				'test2'		=> 'data2',
+				'sunset'	=> 'Tue 10 Aug 17:21:00 GMT 2051',
+			)
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$found = $this->_searchIrcMsgQueue();
+
+		$this->assertTrue(
+			$found
+		);
+	}
+
+	/**
+	 * @covers ::vipgoci_http_resp_sunset_header_check
+	 */
+	public function testSunsetHeaderNotExisting() {
+		vipgoci_unittests_output_suppress();
+
+		/*
+		 * Do a header check, test if anything ends in IRC queue.
+		 */
+		vipgoci_http_resp_sunset_header_check(
+			'https://mytest.localdomain:5000/test/foo?test1=test2',
+			array(
+				'test1'		=> 'data',
+				'test2'		=> 'data2',
+			)
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$found = $this->_searchIrcMsgQueue();
+
+		$this->assertFalse(
+			$found
+		);
+	}
+}

--- a/tests/HttpRespSunsetHeaderCheckTest.php
+++ b/tests/HttpRespSunsetHeaderCheckTest.php
@@ -13,7 +13,7 @@ final class HttpRespSunsetHeaderCheckTest extends TestCase {
 		vipgoci_irc_api_alert_queue( null, true ); // Empty IRC queue
 	}
 
-	private function _searchIrcMsgQueue() :boolean {
+	private function _searchIrcMsgQueue() :bool {
 		$found = false;
 
 		$irc_msg_queue = vipgoci_irc_api_alert_queue( null, true );


### PR DESCRIPTION

This pull request will add support for detecting if Sunset HTTP headers are present in responses from APIs, any detected instances will then be logged along with the URL called. The idea is to detect early and automatically any features that will be deprecated soon.

TODO:
- [X] Implement Sunset HTTP detection
- [X] Add unit-tests
- [ ] Update README
- [ ] Changelog entry
- [ ] Public documentation changes
- [ ] Run full-unit tests 
- [ ] Check automated unit-tests
- [ ] Manual testing
  - [ ] Pull-Request with PHP linting issues
  - [ ] Pull-Request with PHPCS issues
  - [ ] Pull-Request without PHPCS issues, not auto-approved
  - [ ] Pull-Request without PHPCS issues, is auto-approved
  - [ ] Pull-Request with SVG issues
