### PR TITLE
Log shutdown message to IRC

### DIFF
--- a/main.php
+++ b/main.php
@@ -2305,11 +2305,19 @@ function vipgoci_run() {
 	vipgoci_log(
 		'Shutting down',
 		array(
+			'vipgoci_version'	=> VIPGOCI_VERSION,
+			'repo_owner'		=> $options['repo-owner'],
+			'repo_name'		=> $options['repo-name'],
+			'pr_numbers'		=> array_column( $prs_implicated, 'number' ),
 			'run_time_seconds'	=> time() - $startup_time,
 			'run_time_measurements'	=>
-				vipgoci_runtime_measure(
-					VIPGOCI_RUNTIME_DUMP,
-					null
+				vipgoci_round_array_items(
+					vipgoci_runtime_measure(
+						VIPGOCI_RUNTIME_DUMP,
+						null
+					),
+					4,
+					PHP_ROUND_HALF_UP
 				),
 			'counters_report'	=> $counter_report,
 
@@ -2317,7 +2325,9 @@ function vipgoci_run() {
 				$github_api_rate_limit_usage->resources->core,
 
 			'results'		=> $results,
-		)
+		),
+		0,
+		true // Log to IRC
 	);
 
 	/*

--- a/misc.php
+++ b/misc.php
@@ -278,6 +278,24 @@ function vipgoci_convert_string_to_type( $str ) {
 }
 
 /*
+ * Round items in an array to a certain precision, return
+ * new array with results. Essentially a wrapper around the
+ * PHP round() function.
+ */
+function vipgoci_round_array_items(
+	array $arr,
+	int $precision = 0,
+	int $mode = PHP_ROUND_HALF_UP
+): array {
+	return array_map(
+		function( $item ) use ( $precision, $mode ) {
+			return round( $item, $precision, $mode );
+		},
+		$arr
+	);
+}
+
+/*
  * Given a patch-file, the function will return an
  * associative array, mapping the patch-file
  * to the raw committed file.

--- a/statistics.php
+++ b/statistics.php
@@ -81,6 +81,11 @@ function vipgoci_runtime_measure( $action = null, $type = null ) {
 
 	// Dump all runtimes we have
 	if ( VIPGOCI_RUNTIME_DUMP === $action ) {
+		/*
+		 * Sort by value and maintain index association
+		 */
+		arsort( $runtime, SORT_NUMERIC );
+
 		return $runtime;
 	}
 

--- a/tests/MiscRoundArrayItemsTest.php
+++ b/tests/MiscRoundArrayItemsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Vipgoci\tests;
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+final class MiscRoundArrayItemsTest extends TestCase {
+	/**
+	 * @covers ::vipgoci_round_array_items
+	 */
+	public function testRoundArrayItems() {
+		$org_array = array(
+			'test1'	=> 10.333330,
+			'test2'	=> 0.034444444,
+			'test3'	=> 3.359999999,
+			'test4'	=> 5.0000003,
+			'test5'	=> 7.377777777,
+			'test6'	=> 5.00000001,
+		);
+
+		$res_array = vipgoci_round_array_items(
+			$org_array,
+			2,
+			PHP_ROUND_HALF_UP
+		);
+
+		$expected_array = array(
+			'test1'	=> 10.33,
+			'test2'	=> 0.03,
+			'test3'	=> 3.36,
+			'test4'	=> 5.00,
+			'test5'	=> 7.38,
+			'test6'	=> 5.0,
+		);
+
+		$this->assertSame(
+			$expected_array,
+			$res_array
+		);
+	}
+}


### PR DESCRIPTION
Log shutdown message found in `vipgoci_run()` to IRC, and add some further debug information as well to it. This will make it easier to figure out which parts of the program use the most time and what versions are deployed currently.

TODO:
- [X] Log shutdown message to IRC
- [X] Add more debug parameters to log, such as repo-owner, repo-name, PRs found and vip-go-ci version.
- [X] Add function to round items in array (`vipgoci_round_array_items()`).
- [x] Add unit-test for `vipgoci_round_array_items()`.
- [x] Changelog entry.
- [x] Check automated unit-tests.
