### PR TITLE
Validate SVG files, added details to message, and formatting changed slightly, add logging

### DIFF
--- a/defines.php
+++ b/defines.php
@@ -154,3 +154,5 @@ define(
 			=> 'Maximum number of lines exceeded (%d)'
 	]
 );
+
+define( 'VIPGOCI_VALIDATION_MAXIMUM_DETAIL_MSG', 'Note that the above file(s) were not analyzed due to their length.');

--- a/file-validation.php
+++ b/file-validation.php
@@ -68,7 +68,7 @@ function vipgoci_is_number_of_lines_valid( string $temp_file_name, string $file_
 	);
 
 	vipgoci_log(
-		'Validation number of lines ',
+		'Validating number of lines output',
 		array( 'file_name' => $file_name, 'cmd' => $cmd, 'output' => $output )
 	);
 

--- a/github-api.php
+++ b/github-api.php
@@ -2688,7 +2688,7 @@ function vipgoci_github_pr_review_submit(
 			( false === $github_errors ) &&
 			( false === $github_warnings ) &&
 			( false === $github_info ) &&
-			empty( $results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ] )
+			empty( $results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ]['issues'] )
 		) {
 			continue;
 		}
@@ -2807,7 +2807,7 @@ function vipgoci_github_pr_review_submit(
 		/**
 		 * Format skipped files message if it validation has issues
 		 */
-		if ( ! empty( $results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ] ) ) {
+		if ( ! empty( $results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ]['issues'] ) ) {
 			$github_postfields[ 'body' ] .= vipgoci_get_skipped_files_message(
 				$results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ],
 				$pr_number

--- a/github-api.php
+++ b/github-api.php
@@ -2808,6 +2808,10 @@ function vipgoci_github_pr_review_submit(
 		 * Format skipped files message if it validation has issues
 		 */
 		if ( ! empty( $results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ]['issues'] ) ) {
+			vipgoci_markdown_comment_add_pagebreak(
+				$github_postfields['body']
+			);
+
 			$github_postfields[ 'body' ] .= vipgoci_get_skipped_files_message(
 				$results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ],
 				$pr_number

--- a/main.php
+++ b/main.php
@@ -2125,6 +2125,33 @@ function vipgoci_run() {
 	}
 
 	/*
+	 * Temporary: Log if any files were skipped.
+	 */
+	foreach ( $prs_implicated as $pr_item ) {	
+		if ( ! empty(
+			$results[
+				VIPGOCI_SKIPPED_FILES
+			][
+				$pr_item->number
+			][
+				'issues'
+			]
+		) ) {
+			vipgoci_log(
+				'Too large file(s) was/were detected during analysis: ' .
+					VIPGOCI_GITHUB_WEB_BASE_URL . '/' . $options['repo-owner'] . '/' . $options['repo-name'] . '/pull/' . $pr_item->number,
+				array(
+					'repo_owner'	=> $options['repo-owner'],
+					'repo_name'	=> $options['repo-name'],
+					'pr_number'     => $pr_item->number,
+				),
+				0,
+				true
+			);
+		}
+	}
+
+	/*
 	 * Submit any remaining issues to GitHub
 	 */
 

--- a/misc.php
+++ b/misc.php
@@ -1236,6 +1236,13 @@ function vipgoci_markdown_comment_add_pagebreak(
 	$comment_copy = rtrim( $comment_copy, " \n\r" );
 
 	/*
+	 * If there is no comment, do not add pagebreak.
+	 */
+	if ( empty( $comment_copy ) ) {
+		return;
+	}
+
+	/*
 	 * Find the last pagebreak in the comment.
 	 */
 	$pagebreak_location = strrpos(

--- a/options.php
+++ b/options.php
@@ -166,7 +166,7 @@ function vipgoci_options_read_repo_file(
 					'option_overwritable_conf'
 						=> $option_overwritable_conf,
 
-					'repo_options_arr[' . $option_overwritable_name .' ]'
+					'repo_options_arr[' . $option_overwritable_name . ']'
 						=> $repo_options_arr[ $option_overwritable_name ],
 
 					'repo_options_allowed'

--- a/skip-file.php
+++ b/skip-file.php
@@ -55,7 +55,7 @@ function vipgoci_set_prs_implicated_skipped_files(
  */
 function vipgoci_get_skipped_files_message( array $skipped ): string
 {
-	$body = '****' . PHP_EOL . '**' . VIPGOCI_SKIPPED_FILES . '**' . PHP_EOL;
+	$body = PHP_EOL . '**' . VIPGOCI_SKIPPED_FILES . '**' . PHP_EOL;
 	foreach ( $skipped[ 'issues' ] as $issue => $file ) {
 		$body .= vipgoci_get_skipped_files_issue_message(
 			$skipped[ 'issues' ][ $issue ],

--- a/skip-file.php
+++ b/skip-file.php
@@ -78,14 +78,14 @@ function vipgoci_get_skipped_files_issue_message(
 	string $issue_type,
 	int $max_lines = 15000
 ): string {
-	$affected_files = implode( PHP_EOL . ' -', $affected_files );
+	$affected_files = implode( PHP_EOL . ' - ', $affected_files );
 	$validation_message = sprintf(
 		VIPGOCI_VALIDATION[ $issue_type ],
 		$max_lines
 	);
 
 	return sprintf(
-		'%s:%s -%s',
+		'%s:%s - %s',
 		$validation_message,
 		PHP_EOL,
 		$affected_files

--- a/skip-file.php
+++ b/skip-file.php
@@ -55,13 +55,15 @@ function vipgoci_set_prs_implicated_skipped_files(
  */
 function vipgoci_get_skipped_files_message( array $skipped ): string
 {
-	$body = PHP_EOL . '**' . VIPGOCI_SKIPPED_FILES . '**' . PHP_EOL;
+	$body = PHP_EOL . '**' . VIPGOCI_SKIPPED_FILES . '**' . PHP_EOL . PHP_EOL;
 	foreach ( $skipped[ 'issues' ] as $issue => $file ) {
 		$body .= vipgoci_get_skipped_files_issue_message(
 			$skipped[ 'issues' ][ $issue ],
 			$issue
 		);
 	}
+
+	$body .= PHP_EOL . PHP_EOL . VIPGOCI_VALIDATION_MAXIMUM_DETAIL_MSG;
 
 	return $body;
 }

--- a/svg-scan.php
+++ b/svg-scan.php
@@ -353,7 +353,7 @@ function vipgoci_svg_scan_single_file(
 		'file_issues_arr_master'	=> $results,
 		'file_issues_str'		=> json_encode( $results ),
 		'temp_file_name'		=> $temp_file_name,
-		'validation'			=> $validation ?? [],
+		'validation'                    => $validation ?? [],
 	);
 }
 

--- a/svg-scan.php
+++ b/svg-scan.php
@@ -286,7 +286,7 @@ function vipgoci_svg_scan_single_file(
 			'file_issues_arr_master'	=> $results,
 			'file_issues_str'		=> null,
 			'temp_file_name'		=> $temp_file_name,
-			'validation'            	=> array( 'total' => 0 )
+			'validation'                    => array( 'total' => 0 )
 		);
 	}
 

--- a/svg-scan.php
+++ b/svg-scan.php
@@ -227,6 +227,31 @@ function vipgoci_svg_scan_single_file(
 		$file_contents
 	);
 
+	/*
+	 * Skips the SVG scanning when the validation contains any issue
+	 */
+	if ( true === $options['skip-large-files'] ) {
+		$validation = vipgoci_validate(
+			$temp_file_name,
+			$file_name,
+			$options['commit'],
+			$options['skip-large-files-limit']
+		);
+
+		if ( 0 !== $validation[ 'total' ] ) {
+			$skipped = array(
+				'file_issues_arr_master'	=> array(),
+				'file_issues_str'		=> null,
+				'temp_file_name'		=> $temp_file_name,
+				'validation'			=> $validation
+			);
+
+			unlink( $temp_file_name );
+
+			return $skipped;
+		}
+	}
+
 
 	/*
 	 * Use the svg-sanitizer's library scanner
@@ -261,7 +286,7 @@ function vipgoci_svg_scan_single_file(
 			'file_issues_arr_master'	=> $results,
 			'file_issues_str'		=> null,
 			'temp_file_name'		=> $temp_file_name,
-			'validation'            => array( 'total' => 0 )
+			'validation'            	=> array( 'total' => 0 )
 		);
 	}
 
@@ -328,6 +353,7 @@ function vipgoci_svg_scan_single_file(
 		'file_issues_arr_master'	=> $results,
 		'file_issues_str'		=> json_encode( $results ),
 		'temp_file_name'		=> $temp_file_name,
+		'validation'			=> $validation ?? [],
 	);
 }
 

--- a/tests/ApSvgFilesTest.php
+++ b/tests/ApSvgFilesTest.php
@@ -70,6 +70,10 @@ final class ApSvgFilesTest extends TestCase {
 		$this->options['branches-ignore'] = array();
 
 		$this->options['skip-draft-prs'] = false;
+		
+		$this->options['skip-large-files'] = false;
+
+		$this->options['skip-large-files-limit'] = 15;
 	}
 
 	protected function tearDown(): void {

--- a/tests/SvgScanScanCommitTest.php
+++ b/tests/SvgScanScanCommitTest.php
@@ -1,0 +1,217 @@
+<?php
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Minimal testing of scanning whole commits
+ * using SVG scanner. The reason is that most 
+ * of the functionality provided by 
+ * vipgoci_phpcs_scan_commit() -- the
+ * function being tested here -- is tested in 
+ * PhpcsScanScanCommitTest.php already and 
+ * re-implementing these tests here will not 
+ * yield much benefit.
+ * 
+ * Here we only test if SVG scanning does work 
+ * as expected.
+ */
+final class SvgScanScanCommitTest extends TestCase {
+	var $options_svg = array(
+		'svg-scanner-path'                        => null,
+		'commit-test-svg-scan-single-file-test-1' => null, // Re-use commit from SvgScanScanSingleFileTest
+	);
+
+	var $options_git_repo = array(
+		'repo-owner'      => null,
+		'repo-name'       => null,
+		'git-path'        => null,
+		'github-repo-url' => null,
+	);
+
+	protected function setUp(): void {
+		vipgoci_unittests_get_config_values(
+			'git',
+			$this->options_git_repo
+		);
+
+		vipgoci_unittests_get_config_values(
+			'svg-scan',
+			$this->options_svg
+		);
+
+		$this->options = array_merge(
+			$this->options_git_repo,
+			$this->options_svg
+		);
+
+		$this->options['github-token'] =
+			vipgoci_unittests_get_config_value(
+				'git-secrets',
+				'github-token',
+				true // Fetch from secrets file
+			);
+
+		if ( empty( $this->options['github-token'] ) ) {
+			$this->options['github-token'] = '';
+		}
+
+		$this->options['token'] =
+			$this->options['github-token'];
+
+		$this->options['branches-ignore'] = array();
+
+		$this->options['svg-checks'] = true;
+
+		$this->options['lint-skip-folders'] = array();
+
+		$this->options['phpcs-skip-folders'] = array();
+
+		$this->options['skip-draft-prs'] = false;
+
+		$this->options['phpcs-skip-scanning-via-labels-allowed'] = false;
+
+		$this->options['skip-large-files'] = false;
+
+		$this->options['skip-large-files-limit'] = 15;
+	}
+
+	protected function tearDown(): void {
+		if ( false !== $this->options['local-git-repo'] ) {
+			vipgoci_unittests_remove_git_repo(
+				$this->options['local-git-repo']
+			);
+		}
+
+		$this->options_svg      = null;
+		$this->options_git_repo = null;
+		$this->options          = null;
+	}
+
+	/**
+	 * Test SVG scanning of whole commit.
+	 *
+	 * @covers ::vipgoci_phpcs_scan_commit
+	 */
+	public function testDoScanTest1() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'github-token', 'token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$this->options['commit'] = $this->options['commit-test-svg-scan-single-file-test-1'];
+
+		$issues_submit = array();
+		$issues_stats = array();
+		$issues_skipped = array();
+
+
+		$prs_implicated = $this->getPRsImplicated();
+
+		foreach( $prs_implicated as $pr_item ) {
+			$issues_stats[
+			$pr_item->number
+			][
+			'error'
+			] = 0;
+
+			$issues_skipped[ $pr_item->number ][ 'issues' ][ 'max-lines' ] = array();
+			$issues_skipped[ $pr_item->number ][ 'issues' ][ 'total' ] = 0;
+		}
+
+		vipgoci_unittests_output_suppress();
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
+
+		if ( false === $this->options['local-git-repo'] ) {
+			$this->markTestSkipped(
+				'Could not set up git repository: ' .
+				vipgoci_unittests_output_get()
+			);
+
+			return;
+		}
+
+		vipgoci_phpcs_scan_commit(
+			$this->options,
+			$issues_submit,
+			$issues_stats,
+			$issues_skipped
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertSame(
+			array(
+				5 => array(
+					array(
+						'type'          => 'phpcs',
+						'file_name'     => 'svg-file-with-issues-1.svg',
+						'file_line'     => 8,
+						'issue'	=> array(
+							'message'  => "Suspicious attribute 'someotherfield2'",
+							'line'     => 8,
+							'severity' => 5,
+							'type'     => 'ERROR',
+							'source'   => 'VipgociInternal.SVG.DisallowedTags',
+							'level'    => 'ERROR',
+							'fixable'  => false,
+							'column'   => 0,
+						)
+					),
+
+					array(
+						'type'          => 'phpcs',
+						'file_name'     => 'svg-file-with-issues-1.svg',
+						'file_line'     => 5,
+						'issue'         => array(
+							'message'  => "Suspicious attribute 'myotherfield'",
+							'line'     => 5,
+							'severity' => 5,
+							'type'     => 'ERROR',
+							'source'   => 'VipgociInternal.SVG.DisallowedTags',
+							'level'    => 'ERROR',
+							'fixable'  => false,
+							'column'   => 0,
+						)
+					)
+				)
+			),
+  
+			$issues_submit
+		);
+
+		$this->assertSame(
+			array(
+				5 => array(
+					'error' => 2,
+				)
+			),
+			$issues_stats
+		);
+	}
+
+	/**
+	 * @return array|bool|mixed|null
+	 */
+	public function getPRsImplicated() {
+		$prs_implicated = vipgoci_github_prs_implicated(
+			$this->options['repo-owner'],
+			$this->options['repo-name'],
+			$this->options['commit'],
+			$this->options['github-token'],
+			$this->options['branches-ignore']
+		);
+
+		return $prs_implicated;
+	}
+}

--- a/tests/SvgScanScanSingleFileTest.php
+++ b/tests/SvgScanScanSingleFileTest.php
@@ -44,6 +44,10 @@ final class SvgScanScanSingleFileTest extends TestCase {
 			$this->options['github-token'];
 
 		$this->options['svg-checks'] = true;
+
+		$this->options['skip-large-files'] = false;
+                
+		$this->options['skip-large-files-limit'] = 15;
 	}
 
 	protected function tearDown(): void {
@@ -139,6 +143,7 @@ final class SvgScanScanSingleFileTest extends TestCase {
 
 			'file_issues_str'	=> '',
 			'temp_file_name'	=> $temp_file_name,
+			'validation'		=> array(),
 		);
 
 		$expected_result['file_issues_str'] = json_encode(

--- a/tests/SvgScanScanSingleFileTest.php
+++ b/tests/SvgScanScanSingleFileTest.php
@@ -143,7 +143,9 @@ final class SvgScanScanSingleFileTest extends TestCase {
 
 			'file_issues_str'	=> '',
 			'temp_file_name'	=> $temp_file_name,
-			'validation'		=> array(),
+			'validation'		=> array(
+				'total' => 0
+			),
 		);
 
 		$expected_result['file_issues_str'] = json_encode(

--- a/tests/SvgScanScanSingleFileTest.php
+++ b/tests/SvgScanScanSingleFileTest.php
@@ -45,9 +45,9 @@ final class SvgScanScanSingleFileTest extends TestCase {
 
 		$this->options['svg-checks'] = true;
 
-		$this->options['skip-large-files'] = false;
+		$this->options['skip-large-files'] = true;
                 
-		$this->options['skip-large-files-limit'] = 15;
+		$this->options['skip-large-files-limit'] = 15000;
 	}
 
 	protected function tearDown(): void {

--- a/tests/VipgociSkipFileTest.php
+++ b/tests/VipgociSkipFileTest.php
@@ -179,11 +179,14 @@ final class VipgociSkipFileTest extends TestCase {
 		);
 		$skipped_files_message = vipgoci_get_skipped_files_message( $skipped );
 
-		$expected_skipped_files_message = '****
+		$expected_skipped_files_message = '
 **skipped-files**
+
 Maximum number of lines exceeded (15000):
- -MyFailedClass.php
- -MyFailedClass2.php';
+ - MyFailedClass.php
+ - MyFailedClass2.php
+
+Note that the above file(s) were not analyzed due to their length.';
 
 		$this->assertSame( $expected_skipped_files_message, $skipped_files_message );
 	}
@@ -200,8 +203,8 @@ Maximum number of lines exceeded (15000):
 		);
 
 		$expected_skipped_files_issue_message = 'Maximum number of lines exceeded (15000):
- -MyFailedClass.php
- -MyFailedClass2.php';
+ - MyFailedClass.php
+ - MyFailedClass2.php';
 
 		$this->assertSame(
 			$expected_skipped_files_issue_message,


### PR DESCRIPTION
TODO:
- [X] Validate SVG files
  - [x] Update SVG unit-test `SvgScanScanSingleFileTest`
  - [x] Set up `SvgScanScanCommitTest` 
- [X] Add explanatory message when skipped files are noted
- [X] Alter formatting slightly for outputted message for consistency and easier reading
- [X] Update `VipgociSkipFileTest` test to match code
- [X] Log when files are skipped due to length
- [X] Update unit-tests as needed
- [x] Changelog entry [#190]
- [x] Check automated unit-tests
