### PR TITLE
Add vipgoci_sysexit() unit test

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -72,13 +72,20 @@ function vipgoci_log(
 /**
  * Exit program, using vipgoci_log() to print a
  * message before doing so.
+ *
+ * @param string $str         Log message to print before exiting.
+ * @param array  $debug_data  Debug data to print along with log message.
+ * @param int    $exit_status Exit status of program to use.
+ * @param bool   $irc         Whether to send log message to IRC or not.
+ *
+ * @return void|int Does not return when running normally, will return
+ *                  an integer value when running in unit-test mode.
  */
-
 function vipgoci_sysexit(
-	$str,
-	$debug_data = array(),
-	$exit_status = VIPGOCI_EXIT_USAGE_ERROR,
-	$irc = false
+	string $str,
+	array $debug_data = array(),
+	int $exit_status = VIPGOCI_EXIT_USAGE_ERROR,
+	bool $irc = false
 ) {
 	if ( $exit_status === VIPGOCI_EXIT_USAGE_ERROR ) {
 		$str = 'Usage: ' . $str;

--- a/misc.php
+++ b/misc.php
@@ -92,11 +92,10 @@ function vipgoci_sysexit(
 	);
 
 	/*
-	 * For SysExitTest.php unit-test
+	 * If running SysExitTest.php unit-test, return
+	 * with exit status.
 	 */
-	global $_vipgoci_sysexit_test;
-
-	if ( isset( $_vipgoci_sysexit_test ) && ( true === $_vipgoci_sysexit_test ) ) {
+	if ( vipgoci_unittests_check_indication_for_test_id( 'SysExitTest' ) ) {
 		return $exit_status;
 	}
 

--- a/misc.php
+++ b/misc.php
@@ -95,7 +95,10 @@ function vipgoci_sysexit(
 	 * If running SysExitTest.php unit-test, return
 	 * with exit status.
 	 */
-	if ( vipgoci_unittests_check_indication_for_test_id( 'SysExitTest' ) ) {
+	if (
+		( function_exists( 'vipgoci_unittests_check_indication_for_test_id' )) &&
+		( vipgoci_unittests_check_indication_for_test_id( 'SysExitTest' ) )
+	) {
 		return $exit_status;
 	}
 

--- a/misc.php
+++ b/misc.php
@@ -93,6 +93,15 @@ function vipgoci_sysexit(
 		$irc
 	);
 
+	/*
+	 * For SysExitTest.php unit-test
+	 */
+	global $_vipgoci_sysexit_test;
+
+	if ( isset( $_vipgoci_sysexit_test ) && ( true === $_vipgoci_sysexit_test ) ) {
+		return $exit_status;
+	}
+
 	exit( $exit_status );
 }
 

--- a/misc.php
+++ b/misc.php
@@ -72,8 +72,6 @@ function vipgoci_log(
 /**
  * Exit program, using vipgoci_log() to print a
  * message before doing so.
- *
- * @codeCoverageIgnore
  */
 
 function vipgoci_sysexit(

--- a/tests/HttpRespSunsetHeaderCheckTest.php
+++ b/tests/HttpRespSunsetHeaderCheckTest.php
@@ -13,23 +13,6 @@ final class HttpRespSunsetHeaderCheckTest extends TestCase {
 		vipgoci_irc_api_alert_queue( null, true ); // Empty IRC queue
 	}
 
-	private function _searchIrcMsgQueue() :bool {
-		$found = false;
-
-		$irc_msg_queue = vipgoci_irc_api_alert_queue( null, true );
-
-		foreach( $irc_msg_queue as $irc_msg_queue_item ) {
-			if ( false !== strpos(
-				$irc_msg_queue_item,
-				'Warning: Sunset HTTP header detected, feature will become unavailable'
-			) ) {
-				$found = true;
-			}
-		}
-
-		return $found;
-	}
-
 	/**
 	 * @covers ::vipgoci_http_resp_sunset_header_check
 	 */
@@ -50,7 +33,9 @@ final class HttpRespSunsetHeaderCheckTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$found = $this->_searchIrcMsgQueue();
+		$found = vipgoci_unittests_check_irc_api_alert_queue(
+			'Warning: Sunset HTTP header detected, feature will become unavailable'
+		);
 
 		$this->assertTrue(
 			$found
@@ -76,7 +61,9 @@ final class HttpRespSunsetHeaderCheckTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
-		$found = $this->_searchIrcMsgQueue();
+		$found = vipgoci_unittests_check_irc_api_alert_queue(
+			'Warning: Sunset HTTP header detected, feature will become unavailable'
+		);
 
 		$this->assertFalse(
 			$found

--- a/tests/IncludesForTests.php
+++ b/tests/IncludesForTests.php
@@ -345,8 +345,14 @@ function vipgoci_unittests_php_syntax_error_compat( $str ) {
 
 /*
  * Check for expected data in IRC queue.
+ *
+ * @param string $str_expected String to look for in the IRC queue.
+ *
+ * @return bool True if something was found, false if not.
  */
-function vipgoci_unittests_check_irc_api_alert_queue( $str_expected ) {
+function vipgoci_unittests_check_irc_api_alert_queue(
+	string $str_expected
+): bool {
 	$found = false;
 
 	$irc_msg_queue = vipgoci_irc_api_alert_queue( null, true );
@@ -372,15 +378,25 @@ function vipgoci_unittests_check_irc_api_alert_queue( $str_expected ) {
 
 /**
  * Indicate that we are running a particular test.
+ *
+ * @param string $test_id Test ID to use.
+ *
+ * @return void Does not return a value.
  */
-function vipgoci_unittests_indicate_test_id( string $test_id ) {
+function vipgoci_unittests_indicate_test_id( string $test_id ): void {
 	$GLOBALS[ VIPGOCI_UNIT_TESTS_TEST_ID_KEY ][ $test_id ] = true;
 }
 
 /**
  * Remove indication of running a particular test.
+ *
+ * @param string $test_id Test ID to use.
+ *
+ * @return void Does not return a value.
  */
-function vipgoci_unittests_remove_indication_for_test_id( string $test_id ) {
+function vipgoci_unittests_remove_indication_for_test_id(
+	string $test_id
+): void {
 	$GLOBALS[ VIPGOCI_UNIT_TESTS_TEST_ID_KEY ][ $test_id ] = false;
 
 	unset( $GLOBALS[ VIPGOCI_UNIT_TESTS_TEST_ID_KEY ][ $test_id ] );
@@ -388,8 +404,15 @@ function vipgoci_unittests_remove_indication_for_test_id( string $test_id ) {
 
 /**
  * Determine if we are running a particular test.
+ *
+ * @param string $test_id Test ID to use.
+ *
+ * @return bool True if we are running the test indicated in $test_id, false
+ * otherwise.
  */
-function vipgoci_unittests_check_indication_for_test_id( string $test_id ) {
+function vipgoci_unittests_check_indication_for_test_id(
+	string $test_id
+): bool {
 	if (
 		( ( isset( $GLOBALS[ VIPGOCI_UNIT_TESTS_TEST_ID_KEY ][ $test_id ] ) ) ) &&
 		( true === $GLOBALS[ VIPGOCI_UNIT_TESTS_TEST_ID_KEY ][ $test_id ] )

--- a/tests/IncludesForTests.php
+++ b/tests/IncludesForTests.php
@@ -341,5 +341,25 @@ function vipgoci_unittests_php_syntax_error_compat( $str ) {
 	return $str;
 }
 
+/*
+ * Check for expected data in IRC queue.
+ */
+function vipgoci_unittests_check_irc_api_alert_queue( $str_expected ) {
+	$found = false;
+
+	$irc_msg_queue = vipgoci_irc_api_alert_queue( null, true );
+
+	foreach( $irc_msg_queue as $irc_msg_queue_item ) {
+		if ( false !== strpos(
+			$irc_msg_queue_item,
+			$str_expected
+		) ) {
+			$found = true;
+		}
+	}
+
+	return $found;
+}
+
 require_once( __DIR__ . '/../requires.php' );
 

--- a/tests/IncludesForTests.php
+++ b/tests/IncludesForTests.php
@@ -10,6 +10,8 @@ if ( ! defined( 'VIPGOCI_UNIT_TESTS_INI_DIR_PATH' ) ) {
 	define( 'VIPGOCI_UNIT_TESTS_INI_DIR_PATH', dirname( __DIR__ ) );
 }
 
+define( 'VIPGOCI_UNIT_TESTS_TEST_ID_KEY', 'vipgoci_unittests_test_ids' );
+
 function vipgoci_unittests_get_config_value(
 	$section,
 	$key,
@@ -359,6 +361,43 @@ function vipgoci_unittests_check_irc_api_alert_queue( $str_expected ) {
 	}
 
 	return $found;
+}
+
+/*
+ * Functions to easily indicate and determine if we are running
+ * specific unit-tests. This is useful if we need to add or 
+ * bypass particular functionality in the main code base 
+ * while running a particular unit-test.
+ */
+
+/**
+ * Indicate that we are running a particular test.
+ */
+function vipgoci_unittests_indicate_test_id( string $test_id ) {
+	$GLOBALS[ VIPGOCI_UNIT_TESTS_TEST_ID_KEY ][ $test_id ] = true;
+}
+
+/**
+ * Remove indication of running a particular test.
+ */
+function vipgoci_unittests_remove_indication_for_test_id( string $test_id ) {
+	$GLOBALS[ VIPGOCI_UNIT_TESTS_TEST_ID_KEY ][ $test_id ] = false;
+
+	unset( $GLOBALS[ VIPGOCI_UNIT_TESTS_TEST_ID_KEY ][ $test_id ] );
+}
+
+/**
+ * Determine if we are running a particular test.
+ */
+function vipgoci_unittests_check_indication_for_test_id( string $test_id ) {
+	if (
+		( ( isset( $GLOBALS[ VIPGOCI_UNIT_TESTS_TEST_ID_KEY ][ $test_id ] ) ) ) &&
+		( true === $GLOBALS[ VIPGOCI_UNIT_TESTS_TEST_ID_KEY ][ $test_id ] )
+	) {
+		return true;
+	}
+
+	return false;
 }
 
 require_once( __DIR__ . '/../requires.php' );

--- a/tests/SysExitTest.php
+++ b/tests/SysExitTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Vipgoci\tests;
+
+require_once( __DIR__ . '/IncludesForTests.php' );
+
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+final class SysExitTest extends TestCase {
+	protected function setUp(): void {
+		global $_vipgoci_sysexit_test;
+
+		$_vipgoci_sysexit_test = true;
+
+		vipgoci_irc_api_alert_queue( null, true ); // Empty IRC queue
+	}
+
+	protected function tearDown(): void {
+		global $_vipgoci_sysexit_test;
+
+		$_vipgoci_sysexit_test = false;
+
+		unset( $_vipgoci_sysexit_test );
+	}
+
+	/**
+	 * Check if vipgoci_sysexit() returns
+	 * with correct exit status, check
+	 * if it prints the expected data, and
+	 * if it logs to the IRC queue.
+	 * 
+	 * @covers ::vipgoci_sysexit
+	 */
+	public function testSysExit1() {
+		ob_start();
+
+		$sysexit_status = vipgoci_sysexit(
+			'Missing parameter',
+			array(
+				'key1' => 'value1',
+			),
+			VIPGOCI_EXIT_CODE_ISSUES,
+			true
+		);
+
+		$printed_data = ob_get_contents();
+
+		ob_end_clean();
+
+		/*
+		 * Check for correct exit status
+		 */
+		$this->assertSame(
+			VIPGOCI_EXIT_CODE_ISSUES,
+			$sysexit_status
+		);
+
+		/*
+		 * Check if expected string was printed
+		 * as well as debug data.
+		 */
+		$printed_data_found = strpos(
+			$printed_data,
+			'Usage: Missing parameter;'
+		);
+
+		$this->assertTrue(
+			$printed_data_found !== false
+		);
+
+		$printed_data_found = strpos(
+			$printed_data,
+			'"key1": "value1"'
+		);
+
+		$this->assertTrue(
+			$printed_data_found !== false
+		);
+
+		/*
+		 * Check IRC queue.
+		 */
+		$found_in_irc_msg_queue = vipgoci_unittests_check_irc_api_alert_queue(
+			'Usage: Missing parameter'
+		);
+
+		$this->assertTrue(
+			$found_in_irc_msg_queue
+		);
+	}
+}

--- a/tests/SysExitTest.php
+++ b/tests/SysExitTest.php
@@ -41,7 +41,7 @@ final class SysExitTest extends TestCase {
 			array(
 				'key1' => 'value1',
 			),
-			VIPGOCI_EXIT_CODE_ISSUES,
+			VIPGOCI_EXIT_USAGE_ERROR,
 			true
 		);
 
@@ -53,7 +53,7 @@ final class SysExitTest extends TestCase {
 		 * Check for correct exit status
 		 */
 		$this->assertSame(
-			VIPGOCI_EXIT_CODE_ISSUES,
+			VIPGOCI_EXIT_USAGE_ERROR,
 			$sysexit_status
 		);
 

--- a/tests/SysExitTest.php
+++ b/tests/SysExitTest.php
@@ -10,19 +10,23 @@ use PHPUnit\Framework\TestCase;
 
 final class SysExitTest extends TestCase {
 	protected function setUp(): void {
-		global $_vipgoci_sysexit_test;
-
-		$_vipgoci_sysexit_test = true;
+		/*
+		 * Indicate that this particular test is running,
+		 * needed so that vipgoci_sysexit() can return
+		 * with exit status instead of exiting. See the
+		 * function itself.
+		 */
+		vipgoci_unittests_indicate_test_id( 'SysExitTest' ); 
 
 		vipgoci_irc_api_alert_queue( null, true ); // Empty IRC queue
 	}
 
 	protected function tearDown(): void {
-		global $_vipgoci_sysexit_test;
-
-		$_vipgoci_sysexit_test = false;
-
-		unset( $_vipgoci_sysexit_test );
+		/*
+	 	 * We are no longer running the test,
+		 * remove the indication.
+		 */
+		vipgoci_unittests_remove_indication_for_test_id( 'SysExitTest' );
 	}
 
 	/**


### PR DESCRIPTION
This patch will add a unit-test to test `vipgoci_sysexit()`.

TODO:
- [X] Add/update unit-test for `vipgoci_sysexit()`
- [X] Changelog entry
- [x] Check automated unit-tests
- [x] Add or update PHPDoc comments for new or updated functions.
- [X] Changelog entry [#206]
