### PR TITLE
Adding missing namespace to SVG unit-test

### DIFF
--- a/tests/SvgScanScanCommitTest.php
+++ b/tests/SvgScanScanCommitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Vipgoci\tests;
+
 require_once( __DIR__ . '/IncludesForTests.php' );
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Adds missing namespace to `tests/SvgScanScanCommitTest.php`.

TODO:
- [X] Add missing namespace
- [X] Changelog entry [#190]
- [x] Check automated unit-tests
