### PR TITLE
Rename branch "master" to "main" in tools-init.sh

### DIFF
--- a/tools-init.sh
+++ b/tools-init.sh
@@ -111,7 +111,7 @@ if [ "$VIP_GO_CI_VER" == "" ] ; then
 	TMP_FILE=`mktemp /tmp/vip-go-ci-latest-release-XXXXX.php`
 
 	echo "$0: Trying to determine latest release of vip-go-ci, need to fetch latest-release.php first..."
-	wget -O "$TMP_FILE" https://raw.githubusercontent.com/Automattic/vip-go-ci/master/latest-release.php && \
+	wget -O "$TMP_FILE" https://raw.githubusercontent.com/Automattic/vip-go-ci/main/latest-release.php && \
 	chmod u+x "$TMP_FILE" && \
 	export VIP_GO_CI_VER=`php $TMP_FILE` && \
 	rm "$TMP_FILE" && \


### PR DESCRIPTION
Branch "master" is now named "main", update `tools-init.sh` script to reflect this.

TODO:
- [X] Change `master` to `main` in `tools-init.sh`.
- [X] Run script to check if it succeeds.
- [X] Changelog entry [#190]
- [X] Check automated unit-tests.

