### PR TITLE
Fix bot feedback message for limit of lines exceeded

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -2501,7 +2501,8 @@ function vipgoci_github_pr_review_submit(
 	$results,
 	$informational_msg,
 	$github_review_comments_max,
-	$github_review_comments_include_severity
+	$github_review_comments_include_severity,
+	int $skip_large_files_limit
 ) {
 
 	$stats_types_to_process = array(
@@ -2814,7 +2815,7 @@ function vipgoci_github_pr_review_submit(
 
 			$github_postfields[ 'body' ] .= vipgoci_get_skipped_files_message(
 				$results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ],
-				$pr_number
+				$skip_large_files_limit
 			);
 		}
 

--- a/main.php
+++ b/main.php
@@ -27,7 +27,7 @@ function vipgoci_help_print( $argv ) {
 		"\t" . '--skip-large-files=true=BOOL          If true, skip scanning files that have number of lines higher than the skip-large-files-limit value.' . PHP_EOL .
 		"\t" . '                                      Default is true.' . PHP_EOL .
 		"\t" . '--skip-large-files-limit=INTEGER      Defines the maximum number of lines limit per file.' . PHP_EOL .
-		"\t" . '                                      Default is 15000 lines.' . PHP_EOL .
+		"\t" . '                                      Default is ' . VIPGOCI_VALIDATION_MAXIMUM_LINES_LIMIT . ' lines.' . PHP_EOL .
 		"\t" . '--branches-ignore=STRING,...   What branches to ignore -- useful to make sure' . PHP_EOL .
 		"\t" . '                               some branches never get scanned. Separate branches' . PHP_EOL .
 		"\t" . '                               with commas.' . PHP_EOL .
@@ -828,7 +828,7 @@ function vipgoci_run() {
 		range( 0, 500, 1 )
 	);
 
-	vipgoci_option_integer_handle( $options, 'skip-large-files-limit', 15000 );
+	vipgoci_option_integer_handle( $options, 'skip-large-files-limit', VIPGOCI_VALIDATION_MAXIMUM_LINES_LIMIT );
 
 	/*
 	 * Handle boolean parameters
@@ -2190,7 +2190,8 @@ function vipgoci_run() {
 		$results,
 		$options['informational-msg'],
 		$options['review-comments-max'],
-		$options['review-comments-include-severity']
+		$options['review-comments-include-severity'],
+		$options['skip-large-files-limit']
 	);
 
 	if ( true === $options['dismiss-stale-reviews'] ) {

--- a/skip-file.php
+++ b/skip-file.php
@@ -49,17 +49,19 @@ function vipgoci_set_prs_implicated_skipped_files(
 }
 
 /**
- * @param $skipped
+ * @param array $skipped
+ * @param int $skip_large_files_limit
  *
  * @return string
  */
-function vipgoci_get_skipped_files_message( array $skipped ): string
+function vipgoci_get_skipped_files_message( array $skipped, int $skip_large_files_limit ): string
 {
 	$body = PHP_EOL . '**' . VIPGOCI_SKIPPED_FILES . '**' . PHP_EOL . PHP_EOL;
 	foreach ( $skipped[ 'issues' ] as $issue => $file ) {
 		$body .= vipgoci_get_skipped_files_issue_message(
 			$skipped[ 'issues' ][ $issue ],
-			$issue
+			$issue,
+			$skip_large_files_limit
 		);
 	}
 
@@ -71,14 +73,16 @@ function vipgoci_get_skipped_files_message( array $skipped ): string
 /**
  * @param array $affected_files
  * @param string $issue_type
+ * @param int $max_lines
  *
  * Get Markdown Skipped File error message
+ *
  * @return string
  */
 function vipgoci_get_skipped_files_issue_message(
 	array $affected_files,
 	string $issue_type,
-	int $max_lines = 15000
+	int $max_lines
 ): string {
 	$affected_files = implode( PHP_EOL . ' - ', $affected_files );
 	$validation_message = sprintf(

--- a/tests/VipgociSkipFileTest.php
+++ b/tests/VipgociSkipFileTest.php
@@ -177,12 +177,37 @@ final class VipgociSkipFileTest extends TestCase {
 			),
 			'total'  => 2
 		);
-		$skipped_files_message = vipgoci_get_skipped_files_message( $skipped );
+		$skipped_files_message = vipgoci_get_skipped_files_message( $skipped, 15000 );
 
 		$expected_skipped_files_message = '
 **skipped-files**
 
 Maximum number of lines exceeded (15000):
+ - MyFailedClass.php
+ - MyFailedClass2.php
+
+Note that the above file(s) were not analyzed due to their length.';
+
+		$this->assertSame( $expected_skipped_files_message, $skipped_files_message );
+	}
+
+	/**
+	 * @covers ::vipgoci_get_skipped_files_message
+	 */
+	public function testGetSkippedFilesMessageWithNumberOfLinesExceededDifferentThanDefault() {
+
+		$skipped               = array(
+			'issues' => array(
+				'max-lines' => array( 'MyFailedClass.php', 'MyFailedClass2.php' )
+			),
+			'total'  => 2
+		);
+		$skipped_files_message = vipgoci_get_skipped_files_message( $skipped, 25000 );
+
+		$expected_skipped_files_message = '
+**skipped-files**
+
+Maximum number of lines exceeded (25000):
  - MyFailedClass.php
  - MyFailedClass2.php
 
@@ -199,7 +224,8 @@ Note that the above file(s) were not analyzed due to their length.';
 
 		$skipped_files_issue_message = vipgoci_get_skipped_files_issue_message(
 			$affected_files_mock,
-			'max-lines'
+			'max-lines',
+			15000
 		);
 
 		$expected_skipped_files_issue_message = 'Maximum number of lines exceeded (15000):


### PR DESCRIPTION
When the option skip-large-files-limit was defined, the bot was
continuing to use the default limit of lines value.

This PR fixes it.


TODO:
- [ X ] Add/update unit-tests
- [ X ] Run full-unit tests 
- [ X ] Check automated unit-tests
- [ X ] Manual testing
  - [ X ] Pull request with large file to be skipped

