### PR TITLE
Add skip large files for post PHPCS checks

### DIFF
--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -872,6 +872,17 @@ function vipgoci_phpcs_scan_commit(
 				$_tmp => $file_name
 			) {
 
+			if (
+				isset( $commit_skipped_files[ $pr_item->number ][ 'issues' ][ VIPGOCI_VALIDATION_MAXIMUM_LINES ] )
+				&& true === in_array(
+					$file_name,
+					$commit_skipped_files[ $pr_item->number ][ 'issues' ][ VIPGOCI_VALIDATION_MAXIMUM_LINES ],
+					true
+				)
+			) {
+				continue;
+			}
+
 			/*
 			 * Get blame log for file
 			 */


### PR DESCRIPTION
After running the PHPCS scan, ``vip-go-ci `` performs a few checks; and they can be expensive for large files. 

E.g.: 

The following code block, which is called after the PHPCS, will potentially result in an OOM for a large file:
 
https://github.com/Automattic/vip-go-ci/blob/main/git-repo.php#L371-L396


Those checks should be skipped for the large files since the phpcs scan command itself is also skipped for the same scenario.
This PR applies the condition to skip large files during those checks - since they are not necessary. 

**Edit**
Obs about tests:

For this scenario, we ideally would write tests to assert if the expensive methods were called or not when the files are large. 

However, since this project is procedural, it's not possible to determine via ``phpunit`` whether a method is called or not. - not without rewriting the entire phpcs scan logic. 

Having that in mind, the tests found in the [PhpcsScanScanCommitTest.php](https://github.com/Automattic/vip-go-ci/blob/main/tests/integration/PhpcsScanScanCommitTest.php#L887) test class are still passing, and for the moment, that would be enough to validate that this code is not breaking any scenario. 

**Edit** to add TODO list in the description:

TODO:

- [ X ] Run full-unit tests 
- [ X ] Check automated unit-tests
- [X] Changelog entry [#206]