### PR TITLE
Add request changes deduplication logic 

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -2561,19 +2561,6 @@ function vipgoci_github_pr_review_submit(
 			'comments'	=> array(),
 		);
 
-		$pr_reviews_commented = vipgoci_github_pr_reviews_get(
-			$repo_owner,
-			$repo_name,
-			$pr_number,
-			$github_token,
-			array(
-				'login' => 'myself',
-				'state' => array( 'COMMENTED' )
-			)
-		);
-
-		$results['skipped-files'][ $pr_number ] = vipgo_skip_file_check_previous_pr_comments( $results['skipped-files'][ $pr_number ], $pr_reviews_commented );
-
 		/*
 		 * For each issue reported, format
 		 * and prepare to be published on
@@ -2827,22 +2814,24 @@ function vipgoci_github_pr_review_submit(
 			$github_token,
 			array(
 				'login' => 'myself',
-				'state' => array( 'COMMENTED' )
+				'state' => array( 'COMMENTED', 'CHANGES_REQUESTED' )
 			)
 		);
-		$results['skipped-files'][ $pr_number ] = vipgo_skip_file_check_previous_pr_comments( $results['skipped-files'][ $pr_number ], $pr_reviews_commented );
+
+		$validation_message = get_validation_message_prefix( VIPGOCI_VALIDATION_MAXIMUM_LINES, $skip_large_files_limit );
+		$results[VIPGOCI_SKIPPED_FILES][ $pr_number ] = vipgo_skip_file_check_previous_pr_comments( $results[VIPGOCI_SKIPPED_FILES][ $pr_number ], $pr_reviews_commented, $validation_message );
 
 		/**
 		 * Format skipped files message if the validation has issues
 		 */
-		if ( 0 === $results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ]['total'] ) {
+		if ( 0 < $results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ]['total'] ) {
 			vipgoci_markdown_comment_add_pagebreak(
 				$github_postfields['body']
 			);
 
 			$github_postfields[ 'body' ] .= vipgoci_get_skipped_files_message(
 				$results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ],
-				$skip_large_files_limit
+				$validation_message
 			);
 		}
 

--- a/tests/unit/VipgociSkipFileTest.php
+++ b/tests/unit/VipgociSkipFileTest.php
@@ -8,15 +8,18 @@ require_once( __DIR__ . './../../defines.php' );
 require_once( __DIR__ . './../../skip-file.php' );
 
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 // phpcs:disable PSR1.Files.SideEffects
 
 final class VipgociSkipFileTest extends TestCase {
 
+	public $validationMessagePrefix = 'Maximum number of lines exceeded (15000):' . PHP_EOL . ' - ';
+
 	/**
 	 * @covers ::vipgoci_get_skipped_files
 	 */
-	public function testGetSkippedFilesWillReturnCorrectValue() {
+	public function testGetSkippedFilesWillReturnCorrectValue(): void {
 		$validation_mock = array(
 			'issues' => array( 'max-lines' => array( 'MyFailedClass1.php' ) ),
 			'total'  => 1
@@ -57,7 +60,7 @@ final class VipgociSkipFileTest extends TestCase {
 	/**
 	 * @covers ::vipgoci_get_skipped_files
 	 */
-	public function testGetSkippedFilesWillReturnCorrectValueForTotal0() {
+	public function testGetSkippedFilesWillReturnCorrectValueForTotal0(): void {
 		$validation_mock = array(
 			'issues' => array(),
 			'total'  => 0
@@ -132,7 +135,7 @@ final class VipgociSkipFileTest extends TestCase {
 	 * @covers ::vipgoci_set_prs_implicated_skipped_files
 	 */
 	public function testSetPRsImplicatedSkippedFilesWillSetCorrectValues(): void {
-		$pr                   = new \stdClass();
+		$pr                   = new stdClass();
 		$pr->number           = 8;
 		$prs_implicated       = array( 8 => $pr );
 		$commit_skipped_files = array(
@@ -175,13 +178,14 @@ final class VipgociSkipFileTest extends TestCase {
 	 */
 	public function testGetSkippedFilesMessage(): void {
 
-		$skipped               = array(
+		$skipped = array(
 			'issues' => array(
 				'max-lines' => array( 'MyFailedClass.php', 'MyFailedClass2.php' )
 			),
 			'total'  => 2
 		);
-		$skipped_files_message = vipgoci_get_skipped_files_message( $skipped, 15000 );
+
+		$skipped_files_message = vipgoci_get_skipped_files_message( $skipped, $this->validationMessagePrefix );
 
 		$expected_skipped_files_message = '
 **skipped-files**
@@ -198,15 +202,15 @@ Note that the above file(s) were not analyzed due to their length.';
 	/**
 	 * @covers ::vipgoci_get_skipped_files_message
 	 */
-	public function testGetSkippedFilesMessageWithNumberOfLinesExceededDifferentThanDefault() {
-
-		$skipped               = array(
+	public function testGetSkippedFilesMessageWithNumberOfLinesExceededDifferentThanDefault(): void {
+		$skipped                 = array(
 			'issues' => array(
 				'max-lines' => array( 'MyFailedClass.php', 'MyFailedClass2.php' )
 			),
 			'total'  => 2
 		);
-		$skipped_files_message = vipgoci_get_skipped_files_message( $skipped, 25000 );
+		$validationMessagePrefix = 'Maximum number of lines exceeded (25000):' . PHP_EOL . ' - ';
+		$skipped_files_message   = vipgoci_get_skipped_files_message( $skipped, $validationMessagePrefix );
 
 		$expected_skipped_files_message = '
 **skipped-files**
@@ -224,12 +228,10 @@ Note that the above file(s) were not analyzed due to their length.';
 	 * @covers ::vipgoci_get_skipped_files_issue_message
 	 */
 	public function testGetSkippedFilesIssueMessage(): void {
-		$affected_files_mock = array( 'MyFailedClass.php', 'MyFailedClass2.php' );
-
+		$affected_files_mock         = array( 'MyFailedClass.php', 'MyFailedClass2.php' );
 		$skipped_files_issue_message = vipgoci_get_skipped_files_issue_message(
 			$affected_files_mock,
-			'max-lines',
-			15000
+			$this->validationMessagePrefix
 		);
 
 		$expected_skipped_files_issue_message = 'Maximum number of lines exceeded (15000):
@@ -251,7 +253,8 @@ Note that the above file(s) were not analyzed due to their length.';
 
 		$result = vipgo_skip_file_check_previous_pr_comments(
 			$results_mock[15],
-			$comments_mock
+			$comments_mock,
+			$this->validationMessagePrefix
 		);
 
 		$expected = array(
@@ -274,9 +277,11 @@ Note that the above file(s) were not analyzed due to their length.';
 	 * @dataProvider vipgociVerifySkipFileMessageDuplicationWillReturnOfCommentsOreIssuesResultsAreZeroProvider
 	 */
 	public function testVipgociVerifySkipFileMessageDuplicationWillReturnOfCommentsOreIssuesResultsAreZero( array $skipped_files_result, array $comments ): void {
+
 		$result = vipgo_skip_file_check_previous_pr_comments(
 			$skipped_files_result,
 			$comments,
+			$this->validationMessagePrefix
 		);
 
 		$this->assertSame(
@@ -285,6 +290,9 @@ Note that the above file(s) were not analyzed due to their length.';
 		);
 	}
 
+	/**
+	 * @return array[]
+	 */
 	public function vipgociVerifySkipFileMessageDuplicationWillReturnOfCommentsOreIssuesResultsAreZeroProvider(): array {
 		return [
 			[ [ 'total' => 0 ], [ 'any' ] ],
@@ -298,8 +306,8 @@ Note that the above file(s) were not analyzed due to their length.';
 	 */
 	public function testGetLargeFilesFromComments(): void {
 		$skippedFileCommentMock = $this->getSkippedFilesCommentMock();
+		$result                 = vipgo_get_skipped_files_from_comment( $skippedFileCommentMock, $this->validationMessagePrefix );
 
-		$result   = vipgo_get_skipped_files_from_comment( $skippedFileCommentMock );
 		$expected = [
 			'GoogleAtom.php',
 			'MySuccessClass.php',
@@ -307,6 +315,23 @@ Note that the above file(s) were not analyzed due to their length.';
 			'src/MySuccesClasss.php',
 			'src/SyntaxError.php',
 			'tests1/myfile1.php',
+		];
+
+		$this->assertSame(
+			$expected,
+			$result
+		);
+	}
+
+	/**
+	 * @covers ::vipgo_get_skipped_files_from_comment
+	 */
+	public function testGetSingleLargeFilesFromComments(): void {
+		$skippedFileCommentMock = $this->getSkippedSingleFileCommentMock();
+
+		$result   = vipgo_get_skipped_files_from_comment( $skippedFileCommentMock, $this->validationMessagePrefix );
+		$expected = [
+			'file-10.php'
 		];
 
 		$this->assertSame(
@@ -321,7 +346,7 @@ Note that the above file(s) were not analyzed due to their length.';
 	public function testGetLargeFilesFromCommentsWillReturnEmptyWhenCommentIsNotAboutSkippedFiles(): void {
 		$commentMock = $this->getCommentMock();
 
-		$result   = vipgo_get_skipped_files_from_comment( $commentMock );
+		$result   = vipgo_get_skipped_files_from_comment( $commentMock, $this->validationMessagePrefix );
 		$expected = array();
 
 		$this->assertSame(
@@ -336,7 +361,7 @@ Note that the above file(s) were not analyzed due to their length.';
 	public function testGetLargeFilesFromPRComments(): void {
 		$commentsSkippedFilesMock = $this->getSkippedFilesCommentsMock();
 
-		$result   = vipgo_get_skipped_files_from_pr_comments( $commentsSkippedFilesMock );
+		$result   = vipgo_get_skipped_files_from_pr_comments( $commentsSkippedFilesMock, $this->validationMessagePrefix );
 		$expected = [
 			'GoogleAtom.php',
 			'MySuccessClass.php',
@@ -353,13 +378,53 @@ Note that the above file(s) were not analyzed due to their length.';
 	}
 
 	/**
+	 * @covers ::vipgo_get_skipped_files_message_from_comment()
+	 */
+	public function testGetLargeFilesMessageFromPRComment(): void {
+		$skippedFileCommentMock = $this->getSkippedSingleFileCommentMock();
+		$result                 = vipgo_get_skipped_files_message_from_comment( $skippedFileCommentMock->body, $this->validationMessagePrefix );
+		$expected               = 'file-10.php';
+
+		$this->assertSame(
+			$expected,
+			$result
+		);
+	}
+
+	/**
+	 * @covers ::vipgo_get_skipped_files_message_from_comment()
+	 * @dataProvider getLargeFilesMessageFromPRCommentShouldReturnEmptyForCommentsWithNoSkippedFilesProvider
+	 */
+	public function testGetLargeFilesMessageFromPRCommentShouldReturnEmptyForCommentsWithNoSkippedFiles( string $comment ): void {
+
+		$result   = vipgo_get_skipped_files_message_from_comment( $comment, $this->validationMessagePrefix );
+		$expected = '';
+
+		$this->assertSame(
+			$expected,
+			$result
+		);
+	}
+
+	/**
+	 * @return string[][]
+	 */
+	public function getLargeFilesMessageFromPRCommentShouldReturnEmptyForCommentsWithNoSkippedFilesProvider(): array {
+		return
+			[
+				[ 'any' ],
+				[ PHP_EOL . PHP_EOL . VIPGOCI_VALIDATION_MAXIMUM_DETAIL_MSG ],
+				[ '**skipped-files** ANY' . PHP_EOL . PHP_EOL . VIPGOCI_VALIDATION_MAXIMUM_DETAIL_MSG ]
+			];
+	}
+
+	/**
 	 * @covers ::vipgo_get_skipped_files_from_pr_comments
 	 */
 	public function testGetLargeFilesFromPRCommentsWhenCommentsAreNotAboutSkippedFilesWillReturnEmpty(): void {
 		$commentsMock = $this->getCommentMock();
-
-		$result   = vipgo_get_skipped_files_from_pr_comments( [ $commentsMock ] );
-		$expected = array();
+		$result       = vipgo_get_skipped_files_from_pr_comments( [ $commentsMock ], $this->validationMessagePrefix );
+		$expected     = array();
 
 		$this->assertSame(
 			$expected,
@@ -401,9 +466,29 @@ Note that the above file(s) were not analyzed due to their length.';
 	}
 
 	/**
+	 * @return stdClass
+	 */
+	private function getSkippedSingleFileCommentMock(): stdClass {
+		$mock       = $this->createMock( 'stdClass' );
+		$mock->body = '
+**skipped-files**
+
+Maximum number of lines exceeded (15000):
+ - file-10.php
+
+Note that the above file(s) were not analyzed due to their length.
+
+***
+
+This bot provides automated PHP linting and [PHPCS scanning](https://docs.wpvip.com/technical-references/code-review/phpcs-report/). For more information about the bot and available customizations, see [our documentation](https://docs.wpvip.com/technical-references/code-review/vip-code-analysis-bot/).';
+
+		return $mock;
+	}
+
+	/**
 	 * @return mixed
 	 */
-	private function getSkippedFilesCommentMock(): \stdClass {
+	private function getSkippedFilesCommentMock(): stdClass {
 		$mock       = $this->createMock( 'stdClass' );
 		$mock->body =
 			'**hashes-api**-scanning skipped
@@ -411,7 +496,7 @@ Note that the above file(s) were not analyzed due to their length.';
 
 **skipped-files**
 
-Maximum number of lines exceeded (3):
+Maximum number of lines exceeded (15000):
  - GoogleAtom.php
  - MySuccessClass.php
  - MySuccessClass2.php
@@ -427,7 +512,7 @@ Note that the above file(s) were not analyzed due to their length.';
 	/**
 	 * @return mixed
 	 */
-	private function getCommentMock(): \stdClass {
+	private function getCommentMock(): stdClass {
 		$commentMock       = $this->createMock( 'stdClass' );
 		$commentMock->body =
 			'**hashes-api**';


### PR DESCRIPTION
Large files comment logic should cover messages that have other error messages concatenated to them and also the requested changes comments. This PR address that.
Add refactor to avoid duplication code in regards to the skipped large files message.

Correct message after two build execution with request changes (not duplicating request changes):
<img width="323" alt="Screen Shot 2021-11-09 at 12 31 24 pm" src="https://user-images.githubusercontent.com/509607/140845249-cbacfde3-c91e-492d-beab-ec33f44572ab.png">

Correct message after two build execution(not duplicating info comment):
<img width="484" alt="Screen Shot 2021-11-09 at 12 33 10 pm" src="https://user-images.githubusercontent.com/509607/140845393-51638391-c077-4aa1-bb5c-9ac371c22b5b.png">


TODO:
- [ X ] Implement [logic]
- [ X ] Add/update unit-tests
- [ X ] Add or update `PHPDoc` comments for new or updated functions (main code only).
- [ X ] Run full-unit tests 
- [ X ] Check automated unit-tests
- [ X ] Manual testing (https://github.com/ariskataoka/vip-go-ci-manual-testing/pulls)
  - [ X ] Pull request with PHP linting issues
  - [ X ] Pull request with PHPCS issues
  - [ X ] Pull request without PHPCS issues, not auto-approved
  - [ X ] Pull request without PHPCS issues, is auto-approved
  - [ X ] Pull request with SVG issues
  - [ X ] Pull request with large file to be skipped