### PR TITLE
Add lint-scan-modified-files-only option 

### DIFF
--- a/.vipgoci_phpcs_skip_folders
+++ b/.vipgoci_phpcs_skip_folders
@@ -1,0 +1,1 @@
+tests/unit

--- a/README.md
+++ b/README.md
@@ -406,6 +406,13 @@ The `phpcs-sniffs-include` is configured in the same way as the `phpcs-sniffs-ex
 
 Please note that should any of the PHPCS sniffs specified be invalid, a warning will be posted on any pull request scanned. The warning will be removed during next scan and not posted again if the issue is fixed.
 
+#### Options `--lint-modified-files-only`
+
+The ``lint-modified-files-only`` option specifies whether the ``vip-go-ci`` bot should scan all the PHP files in the repository (including already merged files) or files modified by the PR only.
+
+Due to performance concerns, the lint-modified-files-only option is enabled by default. It can be disabled through the ``.vipgoci_options`` configuration file. To disable the ``lint-modified-files-only`` option, ensure the ``.vipgoci_options`` configuration file is created in the git-repository and define the option as false. See the example below:
+
+> {"lint-modified-files-only":false}
 
 ### SVG scanning
 

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -243,7 +243,7 @@ function vipgoci_lint_scan_commit(
 		$options['skip-draft-prs']
 	);
 
-	if ( true === $options['lint-scan-modified-files-only'] ) {
+	if ( true === $options['lint-modified-files-only'] ) {
 		vipgoci_gitrepo_scan_modified_files_only( $prs_implicated, $options, $commit_skipped_files,$commit_issues_stats, $commit_issues_submit );
 	} else {
 		/**

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -120,13 +120,8 @@ function vipgoci_lint_parse_results(
 	$file_issues_arr_new = array();
 
 	// Loop through everything we got from the command
-	foreach ( $file_issues_arr as $index => $message ) {
-		if (
-			( 0 === strpos(
-					$message,
-					'No syntax errors detected'
-				) )
-		) {
+	foreach ( $file_issues_arr as $message ) {
+		if ( 0 === strpos( $message, 'No syntax errors detected' ) ) {
 			// Skip non-errors we do not care about
 			continue;
 		}

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -233,19 +233,6 @@ function vipgoci_lint_scan_commit(
 				=> array( 'added', 'modified' ),
 		)
 	);
-
-	// Fetch list of files that exist in the commit
-	$commit_tree = vipgoci_gitrepo_fetch_tree(
-		$options,
-		$commit_id,
-		array(
-			'file_extensions'
-				=> array( 'php' ),
-			'skip_folders'
-				=> $options['lint-skip-folders'],
-		)
-	);
-
 	// Ask for all Pull-Requests that this commit is part of
 	$prs_implicated = vipgoci_github_prs_implicated(
 		$repo_owner,
@@ -256,122 +243,76 @@ function vipgoci_lint_scan_commit(
 		$options['skip-draft-prs']
 	);
 
-
-	/*
-	 * Lint every PHP file existing in the commit
-	 * $commit_tree is an array of files for that commit
-	 */
-
-	foreach( $commit_tree as $filename ) {
-		vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'lint_scan_single_file' );
-
-		$file_contents = vipgoci_gitrepo_fetch_committed_file(
-			$repo_owner,
-			$repo_name,
-			$github_token,
-			$commit_id,
-			$filename,
-			$options['local-git-repo']
-		);
-
-		// Save the file-contents in a temporary-file
-		$temp_file_name = vipgoci_save_temp_file(
-			'lint-scan-',
-			null,
-			$file_contents
-		);
-
+	if ( true === $options['lint-scan-only-modified-files'] ) {
+		vipgoci_gitrepo_scan_modified_files_only( $prs_implicated, array('.php'), '', $options, $commit_skipped_files,$commit_issues_stats, $commit_issues_submit );
+	} else {
 		/**
-		 * Validates the file
-		 * and if it's not valid, the scans skips it
+		 * Keep it as is
 		 */
-		if ( true === $options['skip-large-files'] ) {
-			$validation = vipgoci_validate(
-				$temp_file_name,
-				$filename,
-				$commit_id,
-				$options[ 'skip-large-files-limit' ]
-			);
-			if ( 0 !== $validation[ 'total' ] ) {
-				unlink( $temp_file_name );
-
-				vipgoci_set_prs_implicated_skipped_files( $prs_implicated, $commit_skipped_files, $validation );
-				vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'lint_scan_single_file' );
-
-				continue;
-			}
-		}
-
-		/**
-		 * The lint scan will only proceed if the file is valid
-		 *
-		 */
-		/*
-		 * Keep statistics of what we do.
-		 */
-
-		vipgoci_stats_per_file(
+		// Fetch list of files that exist in the commit
+		$commit_tree = vipgoci_gitrepo_fetch_tree(
 			$options,
-			$filename,
-			'linted'
-		);
-
-		/*
-		 * Actually lint the file
-		 */
-
-		vipgoci_log(
-			'About to PHP-lint file',
-
+			$commit_id,
 			array(
-				'repo_owner' => $repo_owner,
-				'repo_name' => $repo_name,
-				'commit_id' => $commit_id,
-				'filename' => $filename,
-				'temp_file_name' => $temp_file_name,
+				'file_extensions'
+				=> array( 'php' ),
+				'skip_folders'
+				=> $options['lint-skip-folders'],
 			)
 		);
-
-		$file_issues_arr_raw = vipgoci_lint_do_scan_file(
-			$options['php-path'],
-			$temp_file_name
-		);
-
-		/* Get rid of temporary file */
-		unlink( $temp_file_name );
-
-
 		/*
-		 * Process the results, get them in an array format
+		 * Lint every PHP file existing in the commit
+		 * $commit_tree is an array of files for that commit
 		 */
 
-		$file_issues_arr = vipgoci_lint_parse_results(
-			$filename,
-			$temp_file_name,
-			$file_issues_arr_raw
+		/**
+		 * This doesnt need to cover any previous commit in the PR since it scans the entire repo
+		 */
+		scan_commit_tree_toRename0(
+			$commit_tree,
+			$options,
+			$prs_implicated,
+			$commit_skipped_files,
+			$commit_issues_submit,
+			$commit_issues_stats
 		);
+	}
 
-		vipgoci_log(
-			'Linting issues details',
-			array(
-				'repo_owner'		=> $repo_owner,
-				'repo_name'		=> $repo_name,
-				'commit_id'		=> $commit_id,
-				'filename'		=> $filename,
-				'temp_file_name'	=> $temp_file_name,
-				'file_issues_arr'	=> $file_issues_arr,
-				'file_issues_arr_raw'	=> $file_issues_arr_raw,
-			),
-			2
-		);
 
-		/* Get rid of the raw version of issues */
-		unset( $file_issues_arr_raw );
 
+	/*
+	 * Reduce memory-usage, as possible.
+	 */
+	unset( $prs_implicated );
+	unset( $commit_tree );
+	unset( $commit_info );
+
+
+	gc_collect_cycles();
+
+	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'lint_scan_commit' );
+}
+
+/**
+ * @param array $commit_tree
+ * @param array $options
+ * @param array $prs_implicated
+ * @param array $commit_skipped_files
+ * @param array $commit_issues_submit
+ * @param array $commit_issues_stats
+ */
+function scan_commit_tree_toRename0( array $commit_tree, array $options, array $prs_implicated, array &$commit_skipped_files, array &$commit_issues_submit, array &$commit_issues_stats): void {
+	$repo_owner = $options['repo-owner'];
+	$repo_name  = $options['repo-name'];
+	$commit_id  = $options['commit'];
+
+	foreach ( $commit_tree as $filename ) {
+		vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'lint_scan_single_file' );
+
+		$file_issues_arr = scan_file_toRename1( $filename, $options, $prs_implicated, $commit_skipped_files );
 		// If there are no new issues, just leave it at that
 		if ( empty( $file_issues_arr ) ) {
 			vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'lint_scan_single_file' );
-			continue;
 		}
 
 		/*
@@ -379,22 +320,22 @@ function vipgoci_lint_scan_commit(
 		 * for each Pull-Request -- actually
 		 * queue issues for submission.
 		 */
-		foreach( $prs_implicated as $pr_item ) {
+		foreach ( $prs_implicated as $pr_item ) {
 			vipgoci_log(
 				'Linting issues found',
 				array(
-					'repo_owner'		=> $repo_owner,
-					'repo_name'		=> $repo_name,
-					'commit_id'		=> $commit_id,
+					'repo_owner' => $repo_owner,
+					'repo_name'  => $repo_name,
+					'commit_id'  => $commit_id,
 
 					'filename'
-						=> $filename,
+					=> $filename,
 
 					'pr_number'
-						=> $pr_item->number,
+					=> $pr_item->number,
 
 					'file_issues_arr'
-						=> $file_issues_arr,
+					=> $file_issues_arr,
 				),
 				2
 			);
@@ -404,47 +345,11 @@ function vipgoci_lint_scan_commit(
 			 * Loop through array of lines in which
 			 * issues exist.
 			 */
-
-			foreach (
-				$file_issues_arr as
-					$file_issue_line => $file_issue_values
-			) {
-				/*
-				 * Loop through each issue for the particular
-				 * line.
-				 */
-
-				foreach (
-					$file_issue_values as
-						$file_issue_val_item
-				) {
-					$commit_issues_submit[
-						$pr_item->number
-					][] = array(
-						'type'		=> VIPGOCI_STATS_LINT,
-
-						'file_name'	=>
-							$filename,
-
-						'file_line'	=> intval(
-							$file_issue_line
-						),
-
-						'issue'		=>
-							$file_issue_val_item
-					);
-
-					$commit_issues_stats[
-						$pr_item->number
-					]['error']++;
-				}
-			}
+			add_scan_results_toRename2( $file_issues_arr, $filename, $commit_issues_submit, $pr_item->number, $commit_issues_stats );
 		}
 
 		vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'lint_scan_single_file' );
 	}
-
-
 	/*
 	 * Reduce memory-usage, as possible.
 	 */
@@ -455,8 +360,295 @@ function vipgoci_lint_scan_commit(
 	unset( $file_issue_values );
 	unset( $commit_tree );
 	unset( $commit_info );
+}
 
-	gc_collect_cycles();
+/**
+ * @param array|null $file_issues_arr
+ * @param string $filename
+ * @param array $commit_issues_submit
+ * @param int $pr_number
+ * @param array $commit_issues_stats
+ * @param array $file_issue_values
+ */
+function add_scan_results_toRename2( ?array $file_issues_arr, string $filename, array &$commit_issues_submit, int $pr_number, array &$commit_issues_stats ): void {
+	foreach (
+		$file_issues_arr as
+		$file_issue_line => $file_issue_values
+	) {
+		/*
+		 * Loop through each issue for the particular
+		 * line.
+		 */
 
-	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'lint_scan_commit' );
+		foreach (
+			$file_issue_values as
+			$file_issue_val_item
+		) {
+			$commit_issues_submit[ $pr_number ][] = array(
+				'type' => VIPGOCI_STATS_LINT,
+
+				'file_name' =>
+					$filename,
+
+				'file_line' => intval(
+					$file_issue_line
+				),
+
+				'issue' =>
+					$file_issue_val_item
+			);
+
+			$commit_issues_stats[ $pr_number ]['error']++;
+		}
+	}
+}
+
+/**
+ * @param string $filename
+ * @param array $options
+ * @param array $prs_implicated
+ * @param array $commit_skipped_files
+ *
+ * @return array|null
+ */
+function scan_file_toRename1( string $filename, array $options, array $prs_implicated, array &$commit_skipped_files ): ?array {
+
+	$repo_owner = $options['repo-owner'];
+	$repo_name  = $options['repo-name'];
+	$commit_id  = $options['commit'];
+	$github_token = $options['token'];
+
+	$file_contents = vipgoci_gitrepo_fetch_committed_file(
+		$repo_owner,
+		$repo_name,
+		$github_token,
+		$commit_id,
+		$filename,
+		$options['local-git-repo']
+	);
+
+	// Save the file-contents in a temporary-file
+	$temp_file_name = vipgoci_save_temp_file(
+		'lint-scan-',
+		null,
+		$file_contents
+	);
+
+	/**
+	 * Validates the file
+	 * and if it's not valid, the scans skips it
+	 */
+	if ( true === $options['skip-large-files'] ) {
+		$validation = vipgoci_validate(
+			$temp_file_name,
+			$filename,
+			$commit_id,
+			$options['skip-large-files-limit']
+		);
+		if ( 0 !== $validation['total'] ) {
+			unlink( $temp_file_name );
+
+			vipgoci_set_prs_implicated_skipped_files( $prs_implicated, $commit_skipped_files, $validation );
+			vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'lint_scan_single_file' );
+
+			return null;
+		}
+	}
+
+	/**
+	 * The lint scan will only proceed if the file is valid
+	 *
+	 */
+	/*
+	 * Keep statistics of what we do.
+	 */
+
+	vipgoci_stats_per_file(
+		$options,
+		$filename,
+		'linted'
+	);
+
+	/*
+	 * Actually lint the file
+	 */
+
+	vipgoci_log(
+		'About to PHP-lint file',
+
+		array(
+			'repo_owner'     => $repo_owner,
+			'repo_name'      => $repo_name,
+			'commit_id'      => $commit_id,
+			'filename'       => $filename,
+			'temp_file_name' => $temp_file_name,
+		)
+	);
+
+	$file_issues_arr_raw = vipgoci_lint_do_scan_file(
+		$options['php-path'],
+		$temp_file_name
+	);
+
+	/* Get rid of temporary file */
+	unlink( $temp_file_name );
+
+
+	/*
+	 * Process the results, get them in an array format
+	 */
+
+	$file_issues_arr = vipgoci_lint_parse_results(
+		$filename,
+		$temp_file_name,
+		$file_issues_arr_raw
+	);
+
+	vipgoci_log(
+		'Linting issues details',
+		array(
+			'repo_owner'          => $repo_owner,
+			'repo_name'           => $repo_name,
+			'commit_id'           => $commit_id,
+			'filename'            => $filename,
+			'temp_file_name'      => $temp_file_name,
+			'file_issues_arr'     => $file_issues_arr,
+			'file_issues_arr_raw' => $file_issues_arr_raw,
+		),
+		2
+	);
+
+	/* Get rid of the raw version of issues */
+	unset( $file_issues_arr_raw );
+
+
+	return $file_issues_arr;
+
+}
+
+
+/**
+ * This signature is not ready
+ *
+ * This function will be split into different functions that can be moved to
+ * other files (eg git-repo.php for git function calls)
+ *
+ * @param array $prs_implicated
+ * @param array $filter_extensions
+ * @param string $filter_skip_folders
+ * @param array $options
+ * @param array $commit_skipped_files
+ * @param array $commit_issues_stats
+ * @param array $commit_issues_submit
+ *
+ * @return array
+ */
+function vipgoci_gitrepo_scan_modified_files_only( array $prs_implicated, array $filter_extensions = [], string $filter_skip_folders = '', array $options, array &$commit_skipped_files, array &$commit_issues_stats, array &$commit_issues_submit  ): array {
+
+	/**
+	 * Get modified files in each PR that is implicated by the commit
+	 * Iterate it and compare base with head
+	 */
+
+
+	$local_git_repo = $options['local-git-repo'];
+	$prs_modified_files = array();
+
+	/**
+	 * @todo split param arrays and mout the desired strings:
+	 * -- '\'*.php\' '
+	 * -- '\':!tests1/*\' \':!tests/*\''
+	 */
+	$filter_extensions = '-- \'*.php\'';
+//	$filter_skip_folders = '-- \':!tests1/*\'';
+
+	/**
+	 * Save current branch so that we can checkout it at the end of the process
+	 */
+	$cmd     = sprintf(
+		"git -C %s branch --show-current 2>&1",
+		$local_git_repo
+	);
+	$local_git_branch = shell_exec($cmd);
+
+	foreach ($prs_implicated as $pr_number => $pr) {
+		/**
+		 * @todo these attributions are not required
+		 */
+		$pr_base_ref    = $pr->base->ref; // develop main
+		$pr_head_ref    = $pr->head->ref; // branches that contains that commit at the top of the tree, and has open PRs
+
+		/**
+		 * Checkout PR base branch so that git local gets information to compare
+		 */
+		$cmd     = sprintf(
+			"git -C %s checkout %s 2>&1",
+			$local_git_repo,
+			$pr_base_ref
+		);
+		$checkout_base_output = shell_exec( $cmd );
+
+		/**
+		 * Checkout PR branch so that git local gets information to compare
+		 */
+		$cmd     = sprintf(
+			"git -C %s checkout %s 2>&1",
+			$local_git_repo,
+			$pr_head_ref
+		);
+		$checkout_head_output = shell_exec( $cmd );
+
+		/**
+		 * Compares base and head log to get modified files only
+		 * git -C LOCAL_ATH log -M --no-merges --name-only --pretty=format: develop.. -- '*.php' -- . ':!tests1/*' 2>&1
+		 */
+		$cmd     = sprintf(
+			'git  -C %s log -M --oneline --no-merges --name-only --pretty=format: %s.. %s %s 2>&1',
+			$local_git_repo,
+			$pr_base_ref,
+			$filter_extensions,
+			$filter_skip_folders
+		);
+		$pr_modified_files = shell_exec( $cmd );
+
+		if ( 0 < strpos( $pr_modified_files, 'fatal' ) ) {
+			continue;
+		}
+
+		$pr_modified_files = explode("\n", $pr_modified_files);
+
+		$files = array_filter(array_unique($pr_modified_files), function($file) {
+			return trim($file) !== '';
+		});
+
+		if ( ! is_array( $files ) ) {
+			continue;
+		}
+
+		/**
+		 * Gets the modified files to scan lint
+		 */
+//		$prs_modified_files[$pr_number] = array_values( $files );
+		$files = array_values($files);
+
+		/**
+		 * @todo IMPLEMENT SCAN THE FILES AND ADD PR ERRORS STATS HERE.
+		 */
+		foreach ( $files as $filename ) {
+			$file_issues_arr = scan_file_toRename1( $filename, $options, $prs_implicated, $commit_skipped_files );
+			add_scan_results_toRename2( $file_issues_arr, $filename, $commit_issues_submit, $pr_number, $commit_issues_stats );
+		}
+	}
+
+	/**
+	 * Add state back
+	 */
+	$cmd     = sprintf(
+		"git -C %s checkout %s 2>&1",
+		$local_git_repo,
+		$local_git_branch
+	);
+	$results = shell_exec( $cmd );
+
+	return $prs_modified_files;
 }

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -313,6 +313,7 @@ function scan_commit_tree_toRename0( array $commit_tree, array $options, array $
 		// If there are no new issues, just leave it at that
 		if ( empty( $file_issues_arr ) ) {
 			vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'lint_scan_single_file' );
+			continue;
 		}
 
 		/*

--- a/main.php
+++ b/main.php
@@ -57,6 +57,10 @@ function vipgoci_help_print( $argv ) {
 		PHP_EOL .
 		'PHP Linting configuration:' . PHP_EOL .
 		"\t" . '--lint=BOOL                    Whether to do PHP linting. Default is true.' . PHP_EOL .
+		"\t" . '--lint-modified-files-only=BOOL   Whether to limit lint scan to run against only modified or new' . PHP_EOL .
+		"\t" . '                               files in the PR to be scanned. Default is true. It can be ' . PHP_EOL .
+		"\t" . '                               modified via options file ("' . VIPGOCI_OPTIONS_FILE_NAME . '") placed in' . PHP_EOL .
+		"\t" . '                               root of the repository.' . PHP_EOL .
 		"\t" . '--lint-skip-folders=STRING     Specify folders relative to root of the git repository in which' . PHP_EOL .
 		"\t" . '                               files should not be PHP linted. Values are comma separated.' . PHP_EOL .
 		"\t" . '--lint-skip-folders-in-repo-options-file=BOOL   Whether to allow specifying folders that are not' . PHP_EOL .
@@ -252,6 +256,7 @@ function vipgoci_options_recognized() {
 		'lint:',
 		'lint-skip-folders:',
 		'lint-skip-folders-in-repo-options-file:',
+		'lint-modified-files-only:',
 		'php-path:',
 
 		/*
@@ -845,6 +850,8 @@ function vipgoci_run() {
 
 	vipgoci_option_bool_handle( $options, 'lint', 'true' );
 
+	vipgoci_option_bool_handle( $options, 'lint-modified-files-only', 'true' );
+
 	vipgoci_option_bool_handle( $options, 'skip-large-files', 'true' );
 
 	vipgoci_option_bool_handle( $options, 'lint-skip-folders-in-repo-options-file', 'false' );
@@ -1110,6 +1117,7 @@ function vipgoci_run() {
 			'svg-checks',
 			'autoapprove',
 			'autoapprove-php-nonfunctional-changes',
+			'lint-modified-files-only'
 		)
 	);
 
@@ -1623,6 +1631,11 @@ function vipgoci_run() {
 			),
 
 			'autoapprove-php-nonfunctional-changes' => array(
+				'type'		=> 'boolean',
+				'valid_values'	=> array( true, false ),
+			),
+
+			'lint-modified-files-only' => array(
 				'type'		=> 'boolean',
 				'valid_values'	=> array( true, false ),
 			),

--- a/tests/integration/A09LintLintScanCommitTest.php
+++ b/tests/integration/A09LintLintScanCommitTest.php
@@ -608,10 +608,120 @@ final class A09LintLintScanCommitTest extends TestCase {
 		unset( $this->options['commit'] );
 	}
 
-	private function getDefaultSkippedFilesDueIssuesMock() {
+	/**
+	 * @return array
+	 */
+	private function getDefaultSkippedFilesDueIssuesMock(): array {
 		return array(
 			'issues' => array(),
 			'total'  => 0
 		);
+	}
+
+	/**
+	 * @covers ::vipgoci_lint_scan_commit
+	 */
+	public function testLintDoScan3() {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'github-token', 'token' ),
+			$this
+		);
+
+		if ( - 1 === $options_test ) {
+			return;
+		}
+
+		$this->options['commit'] = $this->options['commit-test-lint-scan-commit-1'];
+
+		vipgoci_unittests_output_suppress();
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
+
+		if ( false === $this->options['local-git-repo'] ) {
+			$this->markTestSkipped(
+				'Could not set up git repository: ' .
+				vipgoci_unittests_output_get()
+			);
+
+			return;
+		}
+
+		$issues_submit  = array();
+		$issues_stat    = array();
+		$issues_skipped = array();
+
+		/*
+		 * Get PRs implicated and warm up stats.
+		 */
+		$prs_implicated = vipgoci_github_prs_implicated(
+			$this->options['repo-owner'],
+			$this->options['repo-name'],
+			$this->options['commit'],
+			$this->options['github-token'],
+			$this->options['branches-ignore']
+		);
+
+		foreach ( $prs_implicated as $pr_item ) {
+			$issues_stat[ $pr_item->number ]['error'] = 0;
+			$issues_skipped[ $pr_item->number ]['issues']['total'] = 0;
+		}
+
+		if ( ! isset( $pr_item->number ) || ! is_numeric( $pr_item->number ) ) {
+			$this->markTestSkipped(
+				'Could not get Pull-Request information for the test: ' .
+				vipgoci_unittests_output_get()
+			);
+
+			return;
+		}
+
+		$this->options['lint-modified-files-only'] = true;
+		vipgoci_lint_scan_commit(
+			$this->options,
+			$issues_submit,
+			$issues_stat,
+			$issues_skipped
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		/*
+		 * Some versions of PHP reverse the ',' and ';'
+		 * in the string below; deal with that.
+		 */
+		$issues_submit[ $pr_item->number ][0]['issue']['message'] = vipgoci_unittests_php_syntax_error_compat(
+			$issues_submit[ $pr_item->number ][0]['issue']['message']
+		);
+
+		$this->assertSame(
+			array(
+				$pr_item->number => array(
+					array(
+						'type'      => 'lint',
+						'file_name' => 'lint-scan-commit-test-2.php',
+						'file_line' => 4,
+						'issue'     => array(
+							'message'  => "syntax error, unexpected end of file, expecting ',' or ';'",
+							'level'    => 'ERROR',
+							'severity' => 5,
+						)
+					)
+				)
+			),
+			$issues_submit
+		);
+
+		$this->assertSame(
+			array(
+				$pr_item->number => array( 'error' => 1 )
+			),
+			$issues_stat
+		);
+
+		unset( $this->options['commit'] );
 	}
 }

--- a/tests/integration/A09LintLintScanCommitTest.php
+++ b/tests/integration/A09LintLintScanCommitTest.php
@@ -125,7 +125,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 		);
 
 		foreach ( $prs_implicated as $pr_item ) {
-			$issues_stat[ $pr_item->number ]['error'] = 0;
+			$issues_stat[ $pr_item->number ]['error']              = 0;
 			$issues_skipped[ $pr_item->number ]['issues']['total'] = 0;
 		}
 
@@ -529,7 +529,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 
 		$this->options['commit'] = $this->options['commit-test-lint-scan-commit-4'];
 
-		$this->options['skip-large-files'] = true;
+		$this->options['skip-large-files']       = true;
 		$this->options['skip-large-files-limit'] = 15;
 
 		vipgoci_unittests_output_suppress();
@@ -591,12 +591,12 @@ final class A09LintLintScanCommitTest extends TestCase {
 
 		$expected_issues_skipped = array(
 			43 => array(
-			        'issues' => array(
-		            'max-lines' => array (
-		                0 => 'tests1/myfile1.php'
+				'issues' => array(
+					'max-lines' => array(
+						0 => 'tests1/myfile1.php'
 					)
-	            ),
-                'total' => 1
+				),
+				'total'  => 1
 			)
 		);
 
@@ -636,10 +636,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 
 		vipgoci_unittests_output_suppress();
 
-		$this->options['local-git-repo'] =
-			vipgoci_unittests_setup_git_repo(
-				$this->options
-			);
+		$this->options['local-git-repo'] = vipgoci_unittests_setup_git_repo( $this->options );
 
 		if ( false === $this->options['local-git-repo'] ) {
 			$this->markTestSkipped(
@@ -666,7 +663,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 		);
 
 		foreach ( $prs_implicated as $pr_item ) {
-			$issues_stat[ $pr_item->number ]['error'] = 0;
+			$issues_stat[ $pr_item->number ]['error']              = 0;
 			$issues_skipped[ $pr_item->number ]['issues']['total'] = 0;
 		}
 
@@ -716,9 +713,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 		);
 
 		$this->assertSame(
-			array(
-				$pr_item->number => array( 'error' => 1 )
-			),
+			array( $pr_item->number => array( 'error' => 1 ) ),
 			$issues_stat
 		);
 

--- a/tests/integration/A09LintLintScanCommitTest.php
+++ b/tests/integration/A09LintLintScanCommitTest.php
@@ -620,14 +620,20 @@ final class A09LintLintScanCommitTest extends TestCase {
 
 	/**
 	 * @covers ::vipgoci_lint_scan_commit
+	 * With the lint-modified-files-only option on
 	 */
-	public function testLintDoScan3() {
-		$options_test = vipgoci_unittests_options_test(
-			$this->options,
-			array( 'github-token', 'token' ),
-			$this
-		);
+	public function testLintDoScan3(): void {
+		$options_test = $this->options['github-token'] =
+			vipgoci_unittests_get_config_value(
+				'git-secrets',
+				'github-token',
+				true // Fetch from secrets file
+			);
+		if ( empty( $this->options['github-token'] ) ) {
+			$this->options['github-token'] = '';
+		}
 
+		$this->options['token'] = $this->options['github-token'];
 		if ( - 1 === $options_test ) {
 			return;
 		}
@@ -636,8 +642,10 @@ final class A09LintLintScanCommitTest extends TestCase {
 
 		vipgoci_unittests_output_suppress();
 
-		$this->options['local-git-repo'] = vipgoci_unittests_setup_git_repo( $this->options );
-
+		$this->options['local-git-repo']           = vipgoci_unittests_setup_git_repo(
+			$this->options
+		);
+		$this->options['lint-modified-files-only'] = true;
 		if ( false === $this->options['local-git-repo'] ) {
 			$this->markTestSkipped(
 				'Could not set up git repository: ' .
@@ -676,7 +684,6 @@ final class A09LintLintScanCommitTest extends TestCase {
 			return;
 		}
 
-		$this->options['lint-modified-files-only'] = true;
 		vipgoci_lint_scan_commit(
 			$this->options,
 			$issues_submit,

--- a/tests/integration/A09LintLintScanCommitTest.php
+++ b/tests/integration/A09LintLintScanCommitTest.php
@@ -58,7 +58,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 
 		$this->options['skip-large-files-limit'] = 3;
 
-		$this->options['lint-scan-only-modified-files'] = false;
+		$this->options['lint-modified-files-only'] = false;
 
 		global $vipgoci_debug_level;
 		$vipgoci_debug_level = 2;

--- a/tests/integration/A09LintLintScanCommitTest.php
+++ b/tests/integration/A09LintLintScanCommitTest.php
@@ -58,6 +58,8 @@ final class A09LintLintScanCommitTest extends TestCase {
 
 		$this->options['skip-large-files-limit'] = 3;
 
+		$this->options['lint-scan-only-modified-files'] = false;
+
 		global $vipgoci_debug_level;
 		$vipgoci_debug_level = 2;
 	}
@@ -332,7 +334,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 	/**
 	 * @covers ::vipgoci_lint_scan_commit
 	 */
-	public function testLintWillSkipLargeFileWhenOptionIsOn() {
+	public function testLintWillSkipLargeFileWhenOptionIsOn(): void {
 
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
@@ -513,7 +515,7 @@ final class A09LintLintScanCommitTest extends TestCase {
 	/**
 	 * @covers ::vipgoci_lint_scan_commit
 	 */
-	public function testLintShouldValidateAndSkipLargeFileWhenSkipLargeFilesAndLimitOptionsAreOn() {
+	public function testLintShouldValidateAndSkipLargeFileWhenSkipLargeFilesAndLimitOptionsAreOn(): void {
 
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,

--- a/tests/integration/ApSvgFilesTest.php
+++ b/tests/integration/ApSvgFilesTest.php
@@ -75,7 +75,7 @@ final class ApSvgFilesTest extends TestCase {
 
 		$this->options['skip-large-files-limit'] = 15;
 
-		$this->options['lint-scan-only-modified-files'] = false;
+		$this->options['lint-modified-files-only'] = false;
 	}
 
 	protected function tearDown(): void {

--- a/tests/integration/ApSvgFilesTest.php
+++ b/tests/integration/ApSvgFilesTest.php
@@ -74,6 +74,8 @@ final class ApSvgFilesTest extends TestCase {
 		$this->options['skip-large-files'] = false;
 
 		$this->options['skip-large-files-limit'] = 15;
+
+		$this->options['lint-scan-only-modified-files'] = false;
 	}
 
 	protected function tearDown(): void {

--- a/tests/integration/PhpcsScanSingleFileTest.php
+++ b/tests/integration/PhpcsScanSingleFileTest.php
@@ -59,6 +59,8 @@ final class PhpcsScanSingleFileTest extends TestCase {
 		$this->options['skip-large-files'] = true;
 
 		$this->options['skip-large-files-limit'] = 15000;
+
+		$this->options['lint-scan-only-modified-files'] = false;
 	}
 
 	protected function tearDown(): void {

--- a/tests/integration/PhpcsScanSingleFileTest.php
+++ b/tests/integration/PhpcsScanSingleFileTest.php
@@ -60,7 +60,7 @@ final class PhpcsScanSingleFileTest extends TestCase {
 
 		$this->options['skip-large-files-limit'] = 15000;
 
-		$this->options['lint-scan-only-modified-files'] = false;
+		$this->options['lint-modified-files-only'] = false;
 	}
 
 	protected function tearDown(): void {

--- a/tests/integration/SvgScanScanCommitTest.php
+++ b/tests/integration/SvgScanScanCommitTest.php
@@ -78,7 +78,7 @@ final class SvgScanScanCommitTest extends TestCase {
 
 		$this->options['skip-large-files-limit'] = 15;
 
-		$this->options['lint-scan-only-modified-files'] = false;
+		$this->options['lint-modified-files-only'] = false;
 	}
 
 	protected function tearDown(): void {

--- a/tests/integration/SvgScanScanCommitTest.php
+++ b/tests/integration/SvgScanScanCommitTest.php
@@ -77,6 +77,8 @@ final class SvgScanScanCommitTest extends TestCase {
 		$this->options['skip-large-files'] = false;
 
 		$this->options['skip-large-files-limit'] = 15;
+
+		$this->options['lint-scan-only-modified-files'] = false;
 	}
 
 	protected function tearDown(): void {

--- a/tests/integration/SvgScanScanSingleFileTest.php
+++ b/tests/integration/SvgScanScanSingleFileTest.php
@@ -48,6 +48,8 @@ final class SvgScanScanSingleFileTest extends TestCase {
 		$this->options['skip-large-files'] = true;
                 
 		$this->options['skip-large-files-limit'] = 15000;
+
+		$this->options['lint-scan-only-modified-files'] = false;
 	}
 
 	protected function tearDown(): void {

--- a/tests/integration/SvgScanScanSingleFileTest.php
+++ b/tests/integration/SvgScanScanSingleFileTest.php
@@ -49,7 +49,7 @@ final class SvgScanScanSingleFileTest extends TestCase {
                 
 		$this->options['skip-large-files-limit'] = 15000;
 
-		$this->options['lint-scan-only-modified-files'] = false;
+		$this->options['lint-modified-files-only'] = false;
 	}
 
 	protected function tearDown(): void {

--- a/tests/unit/OptionsReadRepositoryConfigFileTest.php
+++ b/tests/unit/OptionsReadRepositoryConfigFileTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Vipgoci\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once( __DIR__ . '/helper/OptionsReadRepositoryConfigFile.php' );
+require_once( __DIR__ . '/../../misc.php' );
+require_once( __DIR__ . '/../../options.php' );
+
+// phpcs:disable PSR1.Files.SideEffects
+
+final class OptionsReadRepositoryConfigFileTest extends TestCase {
+
+	/**
+	 * @covers ::vipgoci_options_read_repo_file
+	 *
+	 * Tests against the --lint-modified-files-only option.
+	 */
+	public function testIfOptionLintOnlyModifiedFilesOptionIsReplacedTest(): void {
+		$overritable_mock = $this->getOverritableMock();
+		$file_name_mock   = '.vipgoci_options';
+		$options          = $this->getOptionsMock();
+
+		vipgoci_options_read_repo_file( $options, $file_name_mock, $overritable_mock );
+
+		$this->assertFalse( $options['lint-modified-files-only'] );
+	}
+
+	/**
+	 * @return array[]
+	 */
+	private function getOverritableMock(): array {
+		return array(
+			'skip-execution' => array(
+				'type'         => 'boolean',
+				'valid_values' => array( true, false ),
+			),
+
+			'skip-draft-prs' => array(
+				'type'         => 'boolean',
+				'valid_values' => array( true, false ),
+			),
+
+			'review-comments-sort' => array(
+				'type'         => 'boolean',
+				'valid_values' => array( true, false ),
+			),
+
+			'review-comments-include-severity' => array(
+				'type'         => 'boolean',
+				'valid_values' => array( true, false ),
+			),
+
+			'phpcs' => array(
+				'type'         => 'boolean',
+				'valid_values' => array( true, false ),
+			),
+
+			'phpcs-severity' => array(
+				'type'         => 'integer',
+				'valid_values' => array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ),
+			),
+
+			'post-generic-pr-support-comments' => array(
+				'type'         => 'boolean',
+				'valid_values' => array( true, false ),
+			),
+
+			'phpcs-sniffs-include' => array(
+				'type'         => 'array',
+				'append'       => true,
+				'valid_values' => null,
+			),
+
+			'phpcs-sniffs-exclude' => array(
+				'type'         => 'array',
+				'append'       => true,
+				'valid_values' => null,
+			),
+
+			'hashes-api' => array(
+				'type'         => 'boolean',
+				'valid_values' => array( true, false ),
+			),
+
+			'svg-checks' => array(
+				'type'         => 'boolean',
+				'valid_values' => array( true, false ),
+			),
+
+			'autoapprove' => array(
+				'type'         => 'boolean',
+				'valid_values' => array( true, false ),
+			),
+
+			'autoapprove-php-nonfunctional-changes' => array(
+				'type'         => 'boolean',
+				'valid_values' => array( true, false ),
+			),
+
+			'lint-modified-files-only' => array(
+				'type'         => 'boolean',
+				'valid_values' => array( true, false ),
+			),
+		);
+	}
+
+	/**
+	 * @return array
+	 */
+	private function getOptionsMock(): array {
+		return json_decode( '{"repo-owner":"any","repo-name":"any","commit":"any","token":"any","local-git-repo":"any","phpcs-path":"any","phpcs":true,"enforce-https-urls":false,"repo-options":true,"env-options":[],"branches-ignore":[],"phpcs-standard":["WordPress-VIP-Go"],"phpcs-sniffs-include":[],"phpcs-sniffs-exclude":[],"phpcs-runtime-set":[],"phpcs-skip-folders":[],"review-comments-ignore":[],"dismissed-reviews-exclude-reviews-from-team":[],"phpcs-severity":1,"php-path":"php","hashes-api":false,"svg-checks":false,"svg-scanner-path":"invalid","debug-level":0,"max-exec-time":0,"review-comments-max":10,"review-comments-total-max":200,"skip-large-files-limit":15000,"skip-draft-prs":false,"phpcs-skip-folders-in-repo-options-file":false,"phpcs-skip-scanning-via-labels-allowed":false,"lint":true,"lint-modified-files-only":true,"skip-large-files":true,"lint-skip-folders-in-repo-options-file":false,"dismiss-stale-reviews":false,"dismissed-reviews-repost-comments":true,"review-comments-sort":false,"review-comments-include-severity":false,"phpcs-standard-file":false,"skip-execution":false,"autoapprove":false,"autoapprove-php-nonfunctional-changes":false,"autoapprove-filetypes":[],"post-generic-pr-support-comments":false,"post-generic-pr-support-comments-on-drafts":false,"post-generic-pr-support-comments-string":null,"post-generic-pr-support-comments-skip-if-label-exists":null,"post-generic-pr-support-comments-branches":[],"post-generic-pr-support-comments-repo-meta-match":[],"set-support-level-label":false,"set-support-level-label-prefix":null,"set-support-level-field":null,"repo-meta-api-user-id":null,"repo-meta-api-access-token":null,"lint-skip-folders":[],"repo-options-allowed":["skip-execution","skip-draft-prs","review-comments-sort","review-comments-include-severity","phpcs","phpcs-severity","post-generic-pr-support-comments","phpcs-sniffs-include","phpcs-sniffs-exclude","hashes-api","svg-checks","autoapprove","autoapprove-php-nonfunctional-changes","lint-modified-files-only"],"autoapprove-label":false}', true );
+	}
+}

--- a/tests/unit/VipgociLintScanTest.php
+++ b/tests/unit/VipgociLintScanTest.php
@@ -106,18 +106,17 @@ final class VipgociLintScanTest extends TestCase {
 	 */
 	public function setFileIssuesResultProvider(): array {
 		$submitExpected      = array(
-			0 =>
-				array(
-					'type'      => 'lint',
-					'file_name' => 'MySuccessClass.php',
-					'file_line' => 15,
-					'issue'     =>
-						array(
-							'message'  => 'syntax error, unexpected end of file',
-							'level'    => 'ERROR',
-							'severity' => 5,
-						),
-				),
+			array(
+				'type'      => 'lint',
+				'file_name' => 'MySuccessClass.php',
+				'file_line' => 15,
+				'issue'     =>
+					array(
+						'message'  => 'syntax error, unexpected end of file',
+						'level'    => 'ERROR',
+						'severity' => 5,
+					),
+			),
 		);
 		$statsExpected       = array(
 			'error'   => 1,
@@ -125,15 +124,13 @@ final class VipgociLintScanTest extends TestCase {
 			'info'    => 0
 		);
 		$fileScanningResults = array(
-			15 =>
+			15 => array(
 				array(
-					0 =>
-						array(
-							'message'  => 'syntax error, unexpected end of file',
-							'level'    => 'ERROR',
-							'severity' => 5,
-						),
+					'message'  => 'syntax error, unexpected end of file',
+					'level'    => 'ERROR',
+					'severity' => 5,
 				),
+			),
 		);
 
 		// File with 1 line with issues && 2 issues in the same line
@@ -168,18 +165,16 @@ final class VipgociLintScanTest extends TestCase {
 		);
 		$fileScanningResults1x2 = array(
 			15 => array(
-				0 =>
-					array(
-						'message'  => '1 syntax error, unexpected end of file',
-						'level'    => 'ERROR',
-						'severity' => 5,
-					),
-				1 =>
-					array(
-						'message'  => '2 syntax error, unexpected end of file',
-						'level'    => 'ERROR',
-						'severity' => 5,
-					),
+				array(
+					'message'  => '1 syntax error, unexpected end of file',
+					'level'    => 'ERROR',
+					'severity' => 5,
+				),
+				array(
+					'message'  => '2 syntax error, unexpected end of file',
+					'level'    => 'ERROR',
+					'severity' => 5,
+				),
 			),
 		);
 
@@ -214,24 +209,20 @@ final class VipgociLintScanTest extends TestCase {
 			'info'    => 0
 		);
 		$fileScanningResults2x1 = array(
-			15 =>
+			15 => array(
 				array(
-					0 =>
-						array(
-							'message'  => '1 syntax error, unexpected end of file',
-							'level'    => 'ERROR',
-							'severity' => 5,
-						),
+					'message'  => '1 syntax error, unexpected end of file',
+					'level'    => 'ERROR',
+					'severity' => 5,
 				),
-			21 =>
+			),
+			21 => array(
 				array(
-					0 =>
-						array(
-							'message'  => '1 syntax error, unexpected end of file',
-							'level'    => 'ERROR',
-							'severity' => 5,
-						),
+					'message'  => '1 syntax error, unexpected end of file',
+					'level'    => 'ERROR',
+					'severity' => 5,
 				),
+			),
 		);
 
 		// File with 2 lines with 2 issues each line
@@ -287,36 +278,30 @@ final class VipgociLintScanTest extends TestCase {
 			'info'    => 0
 		);
 		$fileScanningResults2x2 = array(
-			15 =>
+			15 => array(
 				array(
-					0 =>
-						array(
-							'message'  => '1 syntax error, unexpected end of file',
-							'level'    => 'ERROR',
-							'severity' => 5,
-						),
-					1 =>
-						array(
-							'message'  => '2 syntax error, unexpected end of file',
-							'level'    => 'ERROR',
-							'severity' => 5,
-						),
+					'message'  => '1 syntax error, unexpected end of file',
+					'level'    => 'ERROR',
+					'severity' => 5,
 				),
-			21 =>
 				array(
-					0 =>
-						array(
-							'message'  => '1 syntax error, unexpected end of file',
-							'level'    => 'ERROR',
-							'severity' => 5,
-						),
-					1 =>
-						array(
-							'message'  => '2 syntax error, unexpected end of file',
-							'level'    => 'ERROR',
-							'severity' => 5,
-						),
+					'message'  => '2 syntax error, unexpected end of file',
+					'level'    => 'ERROR',
+					'severity' => 5,
 				),
+			),
+			21 => array(
+				array(
+					'message'  => '1 syntax error, unexpected end of file',
+					'level'    => 'ERROR',
+					'severity' => 5,
+				),
+				array(
+					'message'  => '2 syntax error, unexpected end of file',
+					'level'    => 'ERROR',
+					'severity' => 5,
+				),
+			),
 
 		);
 

--- a/tests/unit/VipgociLintScanTest.php
+++ b/tests/unit/VipgociLintScanTest.php
@@ -1,0 +1,365 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Vipgoci\Tests\Unit;
+
+require_once( __DIR__ . '/helper/GitRepoDiffsFetch.php' );
+require_once( __DIR__ . './../../defines.php' );
+require_once( __DIR__ . './../../lint-scan.php' );
+
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+final class VipgociLintScanTest extends TestCase {
+
+	/**
+	 * @param int $prNumber
+	 * @param string $fileName
+	 * @param array $fileScanningResults
+	 * @param array $submitExpected
+	 * @param array $statsExpected
+	 *
+	 * @covers       vipgoci_set_file_issues_result
+	 * @dataProvider setFileIssuesResultProvider
+	 */
+	public function testSetFileIssuesResult(
+		int $prNumber,
+		string $fileName,
+		array $fileScanningResults,
+		array $submitExpected,
+		array $statsExpected
+	): void {
+		$commitIssuesStats  = $this->getStatsMock();
+		$commitIssuesSubmit = $this->getSubmitMock();
+
+		vipgoci_set_file_issues_result( $commitIssuesSubmit[ $prNumber ], $commitIssuesStats[30]['error'], $fileName, $fileScanningResults );
+
+		$this->assertSame( $statsExpected, $commitIssuesStats[30] );
+		$this->assertSame( $submitExpected, $commitIssuesSubmit[30] );
+	}
+
+	/**
+	 * @covers       vipgoci_get_prs_modified_files
+	 * @dataProvider vipgociGetPrsModifiedFilesProvider
+	 */
+	public function testVipgociGetPrsModifiedFiles( array $prsImplicated, array $expected ): void {
+		$options['local-git-repo']     = 'any';
+		$options['repo-owner']         = 'any';
+		$options['repo-name']          = 'any';
+		$options['token']              = 'any';
+		$options['commit']             = 'any';
+		$options['phpcs-skip-folders'] = 'any';
+
+		$actual = vipgoci_get_prs_modified_files( $options, $prsImplicated );
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * @return array
+	 * Provider for testVipgociGetPrsModifiedFiles test
+	 */
+	public function vipgociGetPrsModifiedFilesProvider(): array {
+		return [
+			array(
+				array(
+					30 => (object) array( 'base' => (object) array( 'sha' => 'any' ) ),
+					28 => (object) array( 'base' => (object) array( 'sha' => 'any' ) ),
+				),
+				array(
+					'all'            =>
+						array(
+							0 => 'File1.php',
+							1 => 'File2.php',
+							2 => 'src/File3.php',
+							3 => 'src/File4.php',
+						),
+					'prs_implicated' =>
+						array(
+							30 =>
+								array(
+									0 => 'File1.php',
+									1 => 'File2.php',
+									2 => 'src/File3.php',
+									3 => 'src/File4.php',
+								),
+							28 =>
+								array(
+									0 => 'File1.php',
+									1 => 'File2.php',
+									2 => 'src/File3.php',
+									3 => 'src/File4.php',
+								),
+						),
+				)
+			),
+		];
+	}
+
+	/**
+	 * @return array[]
+	 * Data provider to support testSetFileIssuesResult test
+	 * returns:
+	 * PR number, file name, scanning results, expected_submit, expected_stats
+	 */
+	public function setFileIssuesResultProvider(): array {
+		$submitExpected      = array(
+			0 =>
+				array(
+					'type'      => 'lint',
+					'file_name' => 'MySuccessClass.php',
+					'file_line' => 15,
+					'issue'     =>
+						array(
+							'message'  => 'syntax error, unexpected end of file',
+							'level'    => 'ERROR',
+							'severity' => 5,
+						),
+				),
+		);
+		$statsExpected       = array(
+			'error'   => 1,
+			'warning' => 0,
+			'info'    => 0
+		);
+		$fileScanningResults = array(
+			15 =>
+				array(
+					0 =>
+						array(
+							'message'  => 'syntax error, unexpected end of file',
+							'level'    => 'ERROR',
+							'severity' => 5,
+						),
+				),
+		);
+
+		// File with 1 line with issues && 2 issues in the same line
+		$submitExpected1x2      = array(
+			array(
+				'type'      => 'lint',
+				'file_name' => 'MySuccessClass.php',
+				'file_line' => 15,
+				'issue'     =>
+					array(
+						'message'  => '1 syntax error, unexpected end of file',
+						'level'    => 'ERROR',
+						'severity' => 5,
+					),
+			),
+			array(
+				'type'      => 'lint',
+				'file_name' => 'MySuccessClass.php',
+				'file_line' => 15,
+				'issue'     =>
+					array(
+						'message'  => '2 syntax error, unexpected end of file',
+						'level'    => 'ERROR',
+						'severity' => 5,
+					),
+			),
+		);
+		$statsExpected1x2       = array(
+			'error'   => 2,
+			'warning' => 0,
+			'info'    => 0
+		);
+		$fileScanningResults1x2 = array(
+			15 => array(
+				0 =>
+					array(
+						'message'  => '1 syntax error, unexpected end of file',
+						'level'    => 'ERROR',
+						'severity' => 5,
+					),
+				1 =>
+					array(
+						'message'  => '2 syntax error, unexpected end of file',
+						'level'    => 'ERROR',
+						'severity' => 5,
+					),
+			),
+		);
+
+		// File with 2 issues in different lines
+		$submitExpected2x1      = array(
+			array(
+				'type'      => 'lint',
+				'file_name' => 'MySuccessClass.php',
+				'file_line' => 15,
+				'issue'     =>
+					array(
+						'message'  => '1 syntax error, unexpected end of file',
+						'level'    => 'ERROR',
+						'severity' => 5,
+					),
+			),
+			array(
+				'type'      => 'lint',
+				'file_name' => 'MySuccessClass.php',
+				'file_line' => 21,
+				'issue'     =>
+					array(
+						'message'  => '1 syntax error, unexpected end of file',
+						'level'    => 'ERROR',
+						'severity' => 5,
+					),
+			),
+		);
+		$statsExpected2x1       = array(
+			'error'   => 2,
+			'warning' => 0,
+			'info'    => 0
+		);
+		$fileScanningResults2x1 = array(
+			15 =>
+				array(
+					0 =>
+						array(
+							'message'  => '1 syntax error, unexpected end of file',
+							'level'    => 'ERROR',
+							'severity' => 5,
+						),
+				),
+			21 =>
+				array(
+					0 =>
+						array(
+							'message'  => '1 syntax error, unexpected end of file',
+							'level'    => 'ERROR',
+							'severity' => 5,
+						),
+				),
+		);
+
+		// File with 2 lines with 2 issues each line
+		$submitExpected2x2      = array(
+			array(
+				'type'      => 'lint',
+				'file_name' => 'MySuccessClass.php',
+				'file_line' => 15,
+				'issue'     =>
+					array(
+						'message'  => '1 syntax error, unexpected end of file',
+						'level'    => 'ERROR',
+						'severity' => 5,
+					),
+			),
+			array(
+				'type'      => 'lint',
+				'file_name' => 'MySuccessClass.php',
+				'file_line' => 15,
+				'issue'     =>
+					array(
+						'message'  => '2 syntax error, unexpected end of file',
+						'level'    => 'ERROR',
+						'severity' => 5,
+					),
+			),
+			array(
+				'type'      => 'lint',
+				'file_name' => 'MySuccessClass.php',
+				'file_line' => 21,
+				'issue'     =>
+					array(
+						'message'  => '1 syntax error, unexpected end of file',
+						'level'    => 'ERROR',
+						'severity' => 5,
+					),
+			),
+			array(
+				'type'      => 'lint',
+				'file_name' => 'MySuccessClass.php',
+				'file_line' => 21,
+				'issue'     =>
+					array(
+						'message'  => '2 syntax error, unexpected end of file',
+						'level'    => 'ERROR',
+						'severity' => 5,
+					),
+			),
+		);
+		$statsExpected2x2       = array(
+			'error'   => 4,
+			'warning' => 0,
+			'info'    => 0
+		);
+		$fileScanningResults2x2 = array(
+			15 =>
+				array(
+					0 =>
+						array(
+							'message'  => '1 syntax error, unexpected end of file',
+							'level'    => 'ERROR',
+							'severity' => 5,
+						),
+					1 =>
+						array(
+							'message'  => '2 syntax error, unexpected end of file',
+							'level'    => 'ERROR',
+							'severity' => 5,
+						),
+				),
+			21 =>
+				array(
+					0 =>
+						array(
+							'message'  => '1 syntax error, unexpected end of file',
+							'level'    => 'ERROR',
+							'severity' => 5,
+						),
+					1 =>
+						array(
+							'message'  => '2 syntax error, unexpected end of file',
+							'level'    => 'ERROR',
+							'severity' => 5,
+						),
+				),
+
+		);
+
+		return [
+			// File with single issue in line
+			// PR number, file name, scanning results, expected_submit, expected_stats
+			[ 30, 'MySuccessClass.php', $fileScanningResults, $submitExpected, $statsExpected ],
+			// File with 1 line with issues && 2 issues in the same line
+			[ 30, 'MySuccessClass.php', $fileScanningResults1x2, $submitExpected1x2, $statsExpected1x2 ],
+			// File with 2 issues in different lines
+			[ 30, 'MySuccessClass.php', $fileScanningResults2x1, $submitExpected2x1, $statsExpected2x1 ],
+			// File with 2 lines with 2 issues each line
+			[ 30, 'MySuccessClass.php', $fileScanningResults2x2, $submitExpected2x2, $statsExpected2x2 ],
+		];
+	}
+
+	/**
+	 * @return \int[][]
+	 */
+	public function getStatsMock(): array {
+		return array(
+			30 =>
+				array(
+					'error'   => 0,
+					'warning' => 0,
+					'info'    => 0,
+				),
+			28 =>
+				array(
+					'error'   => 0,
+					'warning' => 0,
+					'info'    => 0,
+				),
+		);
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function getSubmitMock(): array {
+		return array(
+			30 => array(),
+			28 => array(),
+		);
+	}
+}

--- a/tests/unit/helper/GitRepoDiffsFetch.php
+++ b/tests/unit/helper/GitRepoDiffsFetch.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types=1 );
+
+function vipgoci_git_diffs_fetch(
+	string $local_git_repo,
+	string $repo_owner,
+	string $repo_name,
+	string $github_token,
+	string $commit_id_a,
+	string $commit_id_b,
+	bool $renamed_files_also = false,
+	bool $removed_files_also = true,
+	bool $permission_changes_also = false,
+	?array $filter = null
+): array {
+	return array(
+		'files' => array(
+			'File1.php'     => 'any',
+			'File2.php'     => 'any',
+			'src/File3.php' => 'any',
+			'src/File4.php' => 'any'
+		),
+	);
+}

--- a/tests/unit/helper/OptionsReadRepositoryConfigFile.php
+++ b/tests/unit/helper/OptionsReadRepositoryConfigFile.php
@@ -1,0 +1,30 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Mock functions required to execute tests/OptionsReadRepositoryConfigFileTest.php
+ */
+
+/**
+ * Mock options.php @ vipgoci_gitrepo_fetch_committed_file
+ *
+ * @param $repo_owner
+ * @param $repo_name
+ * @param $github_token
+ * @param $commit_id
+ * @param $file_name
+ * @param $local_git_repo
+ *
+ * @return string
+ */
+function vipgoci_gitrepo_fetch_committed_file(
+	$repo_owner,
+	$repo_name,
+	$github_token,
+	$commit_id,
+	$file_name,
+	$local_git_repo
+): string {
+	return "{\"lint-modified-files-only\":false}\n";
+}


### PR DESCRIPTION
Nowadays, the VIP Code Analysis Bot executes the lint scan against the entire repository during every single scan execution. 

Concerns in regards to performance led to this modification: The behavior described above could potentially impact the build performance since the larger is the repository, the longer the vip-go-ci would take to scan the code, and the more significant is the number of resources consumed to execute the PHP linter scan especially. 


This PR:

- Introduces a new option called `lint-modified-files-only`` that defines whether the repository will be entirely scanned or only modified files will be scanned. The option default value is true, which means the bot will lint scan the PR's modified  files only by default, so that only relevant files are scanned and performance issues are prevented by default;

- Allows the ``lint-modified-files-only`` to be configurable via ``.vipgoci_options`` file, so that users that still wish the bot to scan the git-repository every time the scans execute have control about it;


Option configuration file example: 

``.vipgoci_options`` should be added to the root file of the repository.

```
{"lint-modified-files-only":false}
```

**EG.:**

**Hypotetical scenarios** 

- Given a PR that contains modified files called ``file1.php`` file4.php, and the main branch contains a file called ``file3.php``;
- When a PR is opened, the bot is triggered and the ``lint-modified-files-only`` option is true;
- Then the bot will scan files ``file1.php`` and ``file4.php`` only;

	- Non-modified pre-existing files won't be scanned:

<img width="943" alt="Screen Shot 2021-11-26 at 4 33 54 pm" src="https://user-images.githubusercontent.com/509607/143533293-4cca2418-82da-4330-b5e1-8fce32d06792.png">


**Original implementation:**

- Given a PR that contains modified files called ``file1.php``and ``file4.php``, and that the git-repository contains a file called ``file3.php``;
- When a PR is opened and the bot is triggered;
- Then the bot will scan the files ``file1.php``, ``file4.php`` and ``file3.php`` (and any other pre-existing PHP file in the git-repository);

<img width="987" alt="Screen Shot 2021-11-26 at 4 37 02 pm" src="https://user-images.githubusercontent.com/509607/143533650-456043c3-5ffc-4ef2-838d-b5ce2eb34401.png">


TODO:
- [ X ] Specify a parameter to make [ lint-modified-files-only ] configurable
- [ X ] Implement [lint-modified-files-only]
- [ X ] Add/update unit-tests
- [ X ] Add or update `PHPDoc` comments for new or updated functions (main code only).
- [ X ] Update README
- [ ] Changelog entry
- [ ] Public documentation changes
- [ X ] Run full-unit tests 
- [ X ] Check automated unit-tests
- [ X ] Manual testing
  - [ X ] Pull request with PHP linting issues
  - [ X ] Pull request with PHPCS issues
  - [ X ] Pull request without PHPCS issues, not auto-approved
  - [ X ] Pull request without PHPCS issues, is auto-approved
  - [ X ] Pull request with SVG issues
  - [ X ] Pull request with large file to be skipped
