### PR TITLE
Add proxy option for hashes to hashes requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,14 @@ Specifies if to check for approved files in Hashes-API. For instance:
 {"hashes-api":true}
 ```
 
+#### Option `--hashes-oauth-proxy` and ``--hashes-oauth-proxy-type=5``
+
+Specifies proxy information to be used during requests to the hashes-api. 
+
+#### E.g.
+
+> ./vip-go-ci.php --autoapprove=true --hashes-api=true --hashes-api-url=https://myservice.mycompany.is/wp-json/viphash/ --hashes-oauth-proxy=localhost:3000 --hashes-oauth-proxy-type=5
+
 ### Ignore certain branches
 
 Sometimes users do not want specific branches scanned for any issues -- they want them effectively to be ignored. To do this, you can use the `--branches-ignore` option. 
@@ -701,6 +709,8 @@ hashes-oauth-consumer-key=
 hashes-oauth-consumer-secret=
 hashes-oauth-token=
 hashes-oauth-token-secret=
+hashes-oauth-proxy=
+hashes-oauth-proxy-type=
 
 [git-secrets]
 github-token= ; Personal access token from GitHub

--- a/ap-hashes-api.php
+++ b/ap-hashes-api.php
@@ -154,18 +154,14 @@ function vipgoci_ap_hashes_api_file_approved(
 		vipgoci_github_fetch_url(
 			$hashes_to_hashes_url,
 			array(
-				'oauth_consumer_key' =>
-					$options['hashes-oauth-consumer-key'],
+				'oauth_consumer_key' => $options['hashes-oauth-consumer-key'],
+				'oauth_consumer_secret' => $options['hashes-oauth-consumer-secret'],
+				'oauth_token' => $options['hashes-oauth-token'],
+				'oauth_token_secret' => $options['hashes-oauth-token-secret'],
+				'oauth_proxy' => $options['hashes-oauth-proxy'],
+				'oauth_proxy_type' => $options['hashes-oauth-proxy-type']
+			),
 
-				'oauth_consumer_secret' =>
-					$options['hashes-oauth-consumer-secret'],
-
-				'oauth_token' =>
-					$options['hashes-oauth-token'],
-
-				'oauth_token_secret' =>
-					$options['hashes-oauth-token-secret'],
-			)
 		);
 
 

--- a/github-api.php
+++ b/github-api.php
@@ -105,7 +105,7 @@ function vipgoci_curl_set_security_options( $ch ) {
 		$ch,
 		CURLOPT_MAXREDIRS,
 		0
-	);	
+	);
 
 	/*
 	 * Do not follow any "Location:" headers.
@@ -166,7 +166,7 @@ function vipgoci_http_resp_sunset_header_check(
 		$http_url_parsed['scheme'] . '://' .
 		$http_url_parsed['host'];
 
-	
+
 	if ( isset( $http_url_parsed['port'] ) ) {
 		$http_url_clean .= ':' . (int) $http_url_parsed['port'];
 	}
@@ -732,6 +732,11 @@ function vipgoci_github_fetch_url(
 		curl_setopt( $ch, CURLOPT_URL,			$github_url );
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER,	1 );
 		curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT,	20 );
+
+		if ( ! empty( $github_token[ 'oauth_proxy' ] ) ) {
+			curl_setopt( $ch, CURLOPT_PROXY, $github_token[ 'oauth_proxy' ] );
+			curl_setopt( $ch, CURLOPT_PROXYTYPE, $github_token[ 'oauth_proxy_type' ] );
+		}
 
 		curl_setopt(
 			$ch,
@@ -2253,7 +2258,7 @@ function vipgoci_github_pr_generic_support_comment_submit(
 		 * has been added to the Pull-Request.
 		 */
 
-		if ( ! empty( $options[ 'post-generic-pr-support-comments-skip-if-label-exists' ][ $option_key_no_match ] ) ) {			
+		if ( ! empty( $options[ 'post-generic-pr-support-comments-skip-if-label-exists' ][ $option_key_no_match ] ) ) {
 			$pr_label_support_comment_skip = vipgoci_github_pr_labels_get(
 				$options['repo-owner'],
 				$options['repo-name'],
@@ -3373,7 +3378,7 @@ function vipgoci_github_prs_implicated(
 }
 
 /**
- * @param string $repo_owner 
+ * @param string $repo_owner
  * @param string $repo_name
  * @param string $commit_id
  * @param string $github_token
@@ -3422,7 +3427,7 @@ function vipgoci_github_prs_implicated_with_retries(
 			$skip_draft_prs,
 			( $prs_implicated_retries === 0 ) ? false : true
 		);
-		
+
 		$prs_implicated_retries++;
 	} while (
 		( empty( $prs_implicated ) ) &&

--- a/main.php
+++ b/main.php
@@ -126,6 +126,8 @@ function vipgoci_help_print( $argv ) {
 		"\t" . '--hashes-oauth-token-secret=STRING,' . PHP_EOL .
 		"\t" . '--hashes-oauth-consumer-key=STRING,' . PHP_EOL .
 		"\t" . '--hashes-oauth-consumer-secret=STRING' . PHP_EOL .
+		"\t" . '--hashes-oauth-proxy=STRING' . PHP_EOL .
+		"\t" . '--hashes-oauth-proxy-type=STRING' . PHP_EOL .
 		"\t" . '                               OAuth 1.0 token, token secret, consumer key and' . PHP_EOL .
 		"\t" . '                               consumer secret needed for hashes-to-hashes HTTP requests.' . PHP_EOL .
 		"\t" . '                               All required for hashes-to-hashes requests.' . PHP_EOL .
@@ -297,6 +299,8 @@ function vipgoci_options_recognized() {
 		'hashes-oauth-token-secret:',
 		'hashes-oauth-consumer-key:',
 		'hashes-oauth-consumer-secret:',
+		'hashes-oauth-proxy:',
+		'hashes-oauth-proxy-type:',
 
 		/*
 		 * GitHub reviews & generic comments configuration
@@ -427,7 +431,9 @@ function vipgoci_run() {
 			'hashes-oauth-token',
 			'hashes-oauth-token-secret',
 			'hashes-oauth-consumer-key',
-			'hashes-oauth-consumer-secret'
+			'hashes-oauth-consumer-secret',
+			'hashes-oauth-proxy',
+			'hashes-oauth-proxy-type',
 		);
 
 

--- a/tests/integration/ApHashesApiFileApprovedTest.php
+++ b/tests/integration/ApHashesApiFileApprovedTest.php
@@ -52,6 +52,8 @@ final class ApHashesApiFileApprovedTest extends TestCase {
 				'hashes-oauth-token-secret',
 				'hashes-oauth-consumer-key',
 				'hashes-oauth-consumer-secret',
+				'hashes-oauth-proxy',
+				'hashes-oauth-proxy-type',
 			) as $option_secret_key
 		) {
 			$this->options[ $option_secret_key ] =

--- a/tests/integration/ApHashesApiScanCommitTest.php
+++ b/tests/integration/ApHashesApiScanCommitTest.php
@@ -54,6 +54,8 @@ final class ApHashesApiScanCommitTest extends TestCase {
 				'hashes-oauth-token-secret',
 				'hashes-oauth-consumer-key',
 				'hashes-oauth-consumer-secret',
+				'hashes-oauth-proxy',
+				'hashes-oauth-proxy-type',
 			) as $option_secret_key
 		) {
 			$this->options[ $option_secret_key ] =


### PR DESCRIPTION
The [hashes api](https://github.com/Automattic/vip-go-ci#hashes-api) HTTP requests in some environments might require to performed via proxy. 
This PR adds the proxy options: ``hashes-oauth-proxy`` and ``hashes-oauth-proxy-type``. Together, they allow the vip-go-ci bot to make requests to hashes API through a proxy. 

**Note:** 
The options are only necessary if you use the [hashes api](https://github.com/Automattic/vip-go-ci#hashes-api) functionality. 

TODO:
- [x] Specify a parameter to make [feature] configurable
- [x] Implement [new feature / logic]
- [x] Add/update unit-tests
- [x] Add or update `PHPDoc` comments for new or updated functions (main code only).
- [x] Update README
- [ ] Changelog entry
- [x] Run full-unit tests 
- [x] Check automated unit-tests
- [x] Manual testing
  - [x] Pull request with PHP linting issues
  - [x] Pull request with PHPCS issues
  - [x] Pull request without PHPCS issues, not auto-approved
  - [x] Pull request without PHPCS issues, is auto-approved
  - [x] Pull request with SVG issues
  - [x] Pull request with large file to be skipped