### PR TITLE
Bump PHPCS version from 3.5.5 to 3.6.1

### DIFF
--- a/tools-init.sh
+++ b/tools-init.sh
@@ -4,11 +4,10 @@
 # Before updating these version numbers and
 # hashes, please read the documentation here:
 # https://github.com/Automattic/vip-go-ci/#updating-tools-initsh-with-new-versions
-#
 
 # https://github.com/squizlabs/PHP_CodeSniffer/releases
-export PHP_CODESNIFFER_VER="3.5.5"
-export PHP_CODESNIFFER_SHA1SUM="0f51879e5caa7147ef47f61f7b3ecdc2d088422a"
+export PHP_CODESNIFFER_VER="3.6.1"
+export PHP_CODESNIFFER_SHA1SUM="6e81bc997045d5634d00bacb9cf95e33d5f6b189"
 
 # https://github.com/WordPress/WordPress-Coding-Standards/releases
 export WP_CODING_STANDARDS_VER="2.3.0"


### PR DESCRIPTION
<!-- ATTENTION: :wave: Just a quick reminder that this is a PUBLIC repository. Please do not include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask! -->
<!--
Pull-Requests should have a TODO included. Here is a draft:

TODO:
- [ ] Specify a parameter to make [feature] configurable
- [ ] Implement [new feature / logic]
- [ ] Add/update unit-tests
- [ ] Add or update `PHPDoc` comments for new or updated functions (main code only).
- [ ] Update README
- [ ] Changelog entry
- [ ] Public documentation changes
- [ ] Run full-unit tests 
- [ ] Check automated unit-tests
- [ ] Manual testing
  - [ ] Pull request with PHP linting issues
  - [ ] Pull request with PHPCS issues
  - [ ] Pull request without PHPCS issues, not auto-approved
  - [ ] Pull request without PHPCS issues, is auto-approved
  - [ ] Pull request with SVG issues
  - [ ] Pull request with large file to be skipped
-->
