### PR TITLE
Update string function usage for PHP 8

### DIFF
--- a/skip-file.php
+++ b/skip-file.php
@@ -290,7 +290,7 @@ function vipgoci_get_skipped_files_message_from_comment(
 		$message_end_pos - $message_start_pos
 	);
 
-	if ( false === $message ) {
+	if ( '' === $message ) {
 		$message = '';
 	}
 


### PR DESCRIPTION
This pull request updates usage of string functions.

TODO:

- [X]  `substr()` in PHP 8.0 and later returns empty string rather than false (see [here](https://www.php.net/manual/en/function.substr.php)). Update code accordingly.
- [x]  Check `strpos()` usage, as it is changed in PHP 8.0 (see [here](https://php.net/manual/en/function.strpos.php)).
- [x]  Check `strrpos()` usage due to same reasons.
- [x] Check automated unit-tests
- [X] Changelog entry (for VIP) [ #243 ]
