### PR TITLE
Setting PHPCS memory limit

### DIFF
--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -108,7 +108,7 @@ function vipgoci_phpcs_do_scan(
 	 * Feed PHPCS the temporary file specified by our caller.
 	 */
 	$cmd = sprintf(
-		'%s %s --severity=%s --report=%s',
+		'%s -d memory_limit=500M %s --severity=%s --report=%s',
 		escapeshellcmd( $phpcs_php_path ),
 		escapeshellcmd( $phpcs_path ),
 		escapeshellarg( (string) $phpcs_severity ),


### PR DESCRIPTION
We have been seeing some PHPCS scans fail due to out of memory errors. Here we set it slightly higher, to 500MB, maximum. 

The rate of failure is low, so these are edge cases, indicating that the risk of setting higher memory limit is low.

TODO:
- [X] Set maximum memory limit for PHPCS to `500MB`.
- [x] Check automated unit-tests
- [X] Changelog entry (for VIP) [ #254 ]
