### PR TITLE
Update logging & memory management, retry certain HTTP requests, catch out of memory situations

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ While running, `vip-go-ci` will output log of its actions. Here is an example --
         "dry-run": false
     }
 }
-[ 2018-04-16T14:10:05+00:00 -- 0 ]  Fetching all open Pull-Requests from GitHub; {
+[ 2018-04-16T14:10:05+00:00 -- 0 ]  Fetching all open pull requests from GitHub; {
     "repo_owner": "mygithubuser",
     "repo_name": "testing123",
     "commit_id": "f978c17f8f648e5ce10aa16694c74a5544b1670e",
     "branches_ignore": []
 }
-[ 2018-04-16T14:10:14+00:00 -- 0 ]  Fetching information about all commits made to Pull-Request #17 from GitHub; {
+[ 2018-04-16T14:10:14+00:00 -- 0 ]  Fetching information about all commits made to pull request #17 from GitHub; {
     "repo_owner": "mygithubuser",
     "repo_name": "testing123",
     "pr_number": 17
@@ -146,7 +146,7 @@ While running, `vip-go-ci` will output log of its actions. Here is an example --
     "filename": "bla-2.php",
     "local_git_repo": "\/tmp\/git-testing123"
 }
-[ 2018-04-16T14:10:51+00:00 -- 0 ]  About to PHPCS-scan all files affected by any of the Pull-Requests; {
+[ 2018-04-16T14:10:51+00:00 -- 0 ]  About to PHPCS-scan all files affected by any of the pull requests; {
     "repo_owner": "mygithubuser",
     "repo_name": "testing123",
     "commit_id": "f978c17f8f648e5ce10aa16694c74a5544b1670e"

--- a/ap-file-types.php
+++ b/ap-file-types.php
@@ -101,17 +101,6 @@ function vipgoci_ap_file_types(
 		}
 	}
 
-	/*
-	 * Reduce memory-usage as possible.
-	 */
-	unset( $prs_implicated );
-	unset( $pr_diff );
-	unset( $pr_item );
-	unset( $pr_diff_file_extension );
-	unset( $pr_diff_file_name );
-
-	gc_collect_cycles();
-
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'ap_file_types' );
 }
 

--- a/ap-hashes-api.php
+++ b/ap-hashes-api.php
@@ -247,7 +247,7 @@ function vipgoci_ap_hashes_api_file_approved(
 
 /**
  * Scan a particular commit, look for altered
- * files in the Pull-Request we are associated with
+ * files in the pull request we are associated with
  * and for each of these files, check if they
  * are approved in the hashes-to-hashes API.
  *
@@ -267,7 +267,7 @@ function vipgoci_ap_hashes_api_scan_commit(
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'hashes_api_scan' );
 
 	vipgoci_log(
-		'Scanning altered or new files affected by Pull-Request(s) ' .
+		'Scanning altered or new files affected by pull request(s) ' .
 			'using hashes-to-hashes API',
 		array(
 			'repo_owner'     => $options['repo-owner'],
@@ -333,7 +333,7 @@ function vipgoci_ap_hashes_api_scan_commit(
 
 			/*
 			 * Add the file to a list of approved files
-			 * of these affected by the Pull-Request.
+			 * of these affected by the pull request.
 			 */
 			if ( true === $approval_status ) {
 				vipgoci_log(

--- a/ap-hashes-api.php
+++ b/ap-hashes-api.php
@@ -366,17 +366,6 @@ function vipgoci_ap_hashes_api_scan_commit(
 		}
 	}
 
-	/*
-	 * Reduce memory-usage as possible
-	 */
-	unset( $prs_implicated );
-	unset( $pr_item );
-	unset( $pr_diff );
-	unset( $pr_diff_contents );
-	unset( $approval_status );
-
-	gc_collect_cycles();
-
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'hashes_api_scan' );
 }
 

--- a/ap-nonfunctional-changes.php
+++ b/ap-nonfunctional-changes.php
@@ -225,19 +225,6 @@ function vipgoci_ap_nonfunctional_changes(
 		}
 	}
 
-	/*
-	 * Reduce memory-usage as possible
-	 */
-	unset( $prs_implicated );
-	unset( $pr_diff );
-	unset( $pr_item );
-	unset( $pr_diff_file_extension );
-	unset( $pr_diff_file_name );
-	unset( $tmp_file_old );
-	unset( $tmp_file_new );
-
-	gc_collect_cycles();
-
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'ap_nonfunctional_changes' );
 }
 

--- a/ap-nonfunctional-changes.php
+++ b/ap-nonfunctional-changes.php
@@ -100,7 +100,7 @@ function vipgoci_ap_nonfunctional_changes(
 
 			/*
 			 * Save contents of version of
-			 * file at the base of the Pull-Request
+			 * file at the base of the pull request
 			 * to a temporary file ("old version").
 			 */
 
@@ -141,7 +141,7 @@ function vipgoci_ap_nonfunctional_changes(
 
 			/*
 			 * Save contents of version of
-			 * file at the head of the Pull-Request
+			 * file at the head of the pull request
 			 * to a temporary file ("new version").
 			 */
 
@@ -182,9 +182,9 @@ function vipgoci_ap_nonfunctional_changes(
 
 			/*
 			 * Check if the version at the base of
-			 * of the Pull-Request ("old version")
+			 * of the pull request ("old version")
 			 * is the same as the latest version at
-			 * the head of the Pull-Request ("new version")
+			 * the head of the pull request ("new version")
 			 * are exactly the same, given that we remove
 			 * all whitespacing changes.
 			 */

--- a/ap-svg-files.php
+++ b/ap-svg-files.php
@@ -186,19 +186,6 @@ function vipgoci_ap_svg_files(
 		}
 	}
 
-	/*
-	 * Reduce memory-usage as possible
-	 */
-	unset( $tmp_scan_results );
-	unset( $prs_implicated );
-	unset( $pr_diff );
-	unset( $pr_item );
-	unset( $pr_diff_file_extension );
-	unset( $pr_diff_file_name );
-	unset( $file_issues_arr_master );
-
-	gc_collect_cycles();
-
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'ap_svg_files' );
 }
 

--- a/auto-approval.php
+++ b/auto-approval.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 /**
- * Pull-Request is not approved,
+ * pull request is not approved,
  * remove label if needed, leave messages
  * on files that are approved, dismiss
  * any previously approving PRs.
@@ -52,7 +52,7 @@ function vipgoci_auto_approval_non_approval(
 		'pull/' . (int) $pr_item->number;
 
 	vipgoci_log(
-		'Will not auto-approve Pull-Request #' .
+		'Will not auto-approve pull request #' .
 			(int) $pr_item->number . ' ' .
 			'as it contains ' .
 			'files which are not ' .
@@ -106,7 +106,7 @@ function vipgoci_auto_approval_non_approval(
 	) {
 		/*
 		 * Make sure that the file was
-		 * really altered in the Pull-Request;
+		 * really altered in the pull request;
 		 * this is to avoid any errors when
 		 * submitting inline comments.
 		 */
@@ -118,7 +118,7 @@ function vipgoci_auto_approval_non_approval(
 			vipgoci_log(
 				'Not adding auto-approved in hashes-api ' .
 				'database to results for file, as it ' .
-				'was not altered by the Pull-Request',
+				'was not altered by the pull request',
 				array(
 					'pr_number'        => $pr_item->number,
 					'file_name'        => $approved_file,
@@ -206,12 +206,12 @@ function vipgoci_auto_approval_non_approval(
 	}
 
 	/*
-	 * Get any approving reviews for the Pull-Request
+	 * Get any approving reviews for the pull request
 	 * submitted by us. Then dismiss them.
 	 */
 	vipgoci_log(
 		'Dismissing any approving reviews for ' .
-			'the Pull-Request, as it is not ' .
+			'the pull request, as it is not ' .
 			'approved anymore',
 		array(
 			'pr_number' => $pr_item->number,
@@ -248,7 +248,7 @@ function vipgoci_auto_approval_non_approval(
 }
 
 /**
- * Approve a particular Pull-Request,
+ * Approve a particular pull request,
  * alter label for the PR if needed,
  * remove old comments, and log everything
  * we do.
@@ -302,7 +302,7 @@ function vipgoci_autoapproval_do_approve(
 			'pull/' . (int) $pr_item->number;
 
 		vipgoci_log(
-			'Will auto-approve Pull-Request #' .
+			'Will auto-approve pull request #' .
 				(int) $pr_item->number . ' ' .
 				'as it alters or creates ' .
 				'only files that can be ' .
@@ -322,7 +322,7 @@ function vipgoci_autoapproval_do_approve(
 
 		/*
 		 * Actually approve, if not in dry-mode.
-		 * Also add a label to the Pull-Request
+		 * Also add a label to the pull request
 		 * if applicable.
 		 */
 		vipgoci_github_approve_pr(
@@ -331,7 +331,7 @@ function vipgoci_autoapproval_do_approve(
 			$options['token'],
 			$pr_item->number,
 			$options['commit'],
-			'Auto-approved Pull-Request #' .
+			'Auto-approved pull request #' .
 				(int) $pr_item->number . ' as it ' .
 				'contains only auto-approvable files' .
 				' -- either pre-approved files' .
@@ -362,7 +362,7 @@ function vipgoci_autoapproval_do_approve(
 		);
 	} else {
 		vipgoci_log(
-			'Will not actually approve Pull-Request #' .
+			'Will not actually approve pull request #' .
 				(int) $pr_item->number .
 				', as it is already approved by us',
 			array(
@@ -379,7 +379,7 @@ function vipgoci_autoapproval_do_approve(
 	}
 
 	/*
-	 * Add label to Pull-Request, but
+	 * Add label to pull request, but
 	 * only if it is not associated already.
 	 * If it is already associated, just log
 	 * that fact.
@@ -449,7 +449,7 @@ function vipgoci_autoapproval_do_approve(
 }
 
 /**
- * Process auto-approval(s) of the Pull-Request(s)
+ * Process auto-approval(s) of the pull request(s)
  * involved with the commit specified.
  *
  * @param array $options                 Array of options.
@@ -505,7 +505,7 @@ function vipgoci_auto_approval_scan_commit(
 
 		/*
 		 * Loop through all files that are
-		 * altered by the Pull-Request, look for
+		 * altered by the pull request, look for
 		 * files that can be auto-approved.
 		 */
 		foreach ( $pr_diff['files'] as
@@ -548,7 +548,7 @@ function vipgoci_auto_approval_scan_commit(
 				'pull/' . (int) $pr_item->number;
 
 			vipgoci_log(
-				'No action taken with Pull-Request #' .
+				'No action taken with pull request #' .
 					(int) $pr_item->number . ' ' .
 					'since no files were found' .
 					' -- PR URL: ' . $tmp_github_url,

--- a/auto-approval.php
+++ b/auto-approval.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 /**
- * pull request is not approved,
+ * Pull request is not approved,
  * remove label if needed, leave messages
  * on files that are approved, dismiss
  * any previously approving PRs.

--- a/auto-approval.php
+++ b/auto-approval.php
@@ -67,8 +67,7 @@ function vipgoci_auto_approval_non_approval(
 			'files_seen'              => $files_seen,
 			'pr_files_changed'        => $pr_files_changed,
 		),
-		0,
-		true // Send to IRC.
+		0
 	);
 
 	if ( false === $pr_label ) {
@@ -318,8 +317,7 @@ function vipgoci_autoapproval_do_approve(
 				'auto_approved_files_arr' => $auto_approved_files_arr,
 				'files_seen'              => $files_seen,
 			),
-			0,
-			true // Send to IRC.
+			0
 		);
 
 		/*
@@ -376,8 +374,7 @@ function vipgoci_autoapproval_do_approve(
 				'auto_approved_files_arr' => $auto_approved_files_arr,
 				'files_seen'              => $files_seen,
 			),
-			0,
-			true
+			0
 		);
 	}
 
@@ -469,7 +466,7 @@ function vipgoci_auto_approval_scan_commit(
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'auto_approve_commit' );
 
 	vipgoci_log(
-		'Doing auto-approval',
+		'Performing auto-approval',
 		array(
 			'repo_owner'             => $options['repo-owner'],
 			'repo_name'              => $options['repo-name'],
@@ -561,8 +558,7 @@ function vipgoci_auto_approval_scan_commit(
 					'pr_number'               => (int) $pr_item->number,
 					'pr_diff'                 => $pr_diff,
 				),
-				0,
-				true
+				0
 			);
 		} elseif (
 			( true === $did_foreach ) &&
@@ -592,23 +588,6 @@ function vipgoci_auto_approval_scan_commit(
 
 		unset( $files_seen );
 	}
-
-	/*
-	 * Reduce memory-usage as possible
-	 */
-
-	unset( $pr_diff );
-	unset( $pr_diff_file_name );
-	unset( $pr_diff_contents );
-	unset( $pr_item );
-	unset( $pr_label );
-	unset( $prs_implicated );
-	unset( $files_seen );
-	unset( $did_foreach );
-	unset( $can_auto_approve );
-	unset( $tmp_github_url );
-
-	gc_collect_cycles();
 
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'auto_approve_commit' );
 }
@@ -709,6 +688,11 @@ function vipgoci_auto_approval_process(
 		$options,
 		$results,
 		$auto_approved_files_arr
+	);
+
+	vipgoci_log(
+		'Auto-approval process complete',
+		array()
 	);
 }
 

--- a/auto-approval.php
+++ b/auto-approval.php
@@ -415,7 +415,7 @@ function vipgoci_autoapproval_do_approve(
 		'Removing any previously submitted comments ' .
 			'indicating that a particular file ' .
 			'is approved as the whole ' .
-			'Pull-Request is approved',
+			'pull request is approved',
 		array(
 			'pr_number' => $pr_item->number,
 		)

--- a/defines.php
+++ b/defines.php
@@ -43,7 +43,7 @@ define( 'VIPGOCI_FILE_IS_APPROVED_MSG', 'File is approved in review database (ha
 define(
 	'VIPGOCI_REVIEW_COMMENTS_TOTAL_MAX',
 	'Total number of active review comments per ' .
-					'Pull-Request has been reached and some ' .
+					'pull request has been reached and some ' .
 					'comments might not appear as a result. ' .
 					'Please resolve some issues to see more'
 );

--- a/defines.php
+++ b/defines.php
@@ -85,6 +85,11 @@ define(
 );
 
 define(
+	'VIPGOCI_OUT_OF_MEMORY_ERROR',
+	'Unable to analyze the pull request due to resource constraints. The pull request may be too large to process. Please try submitting a smaller pull request'
+);
+
+define(
 	'VIPGOCI_NO_ISSUES_FOUND_MSG_AND_NO_REVIEWS',
 	'No issues were found to report when scanning latest commit'
 );

--- a/git-repo.php
+++ b/git-repo.php
@@ -1400,7 +1400,7 @@ function vipgoci_git_diffs_fetch(
 		 * This can happen for example:
 		 * - When only part of the repository was fetched
 		 * - When the commit-ID refers to a repository 
-		 *   outside of this one, for example when a Pull-Request
+		 *   outside of this one, for example when a pull request
 		 *   refers to a forked repository.
 		 * - When there is an I/O error with the local filesystem.
 		 * - Previously, we had a problem with local git repo and

--- a/git-repo.php
+++ b/git-repo.php
@@ -37,6 +37,7 @@ function vipgoci_git_version(): ?string {
 				'cmd'    => $git_version_cmd,
 				'output' => $git_version_results,
 			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
 		);
 	}
 
@@ -139,6 +140,7 @@ function vipgoci_gitrepo_get_head( $local_git_repo ) {
 				'cmd'    => $cmd,
 				'output' => $result,
 			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
 		);
 	}
 
@@ -183,6 +185,7 @@ function vipgoci_gitrepo_branch_current_get( $local_git_repo ) {
 				'cmd'    => $cmd,
 				'output' => $results,
 			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
 		);
 	}
 
@@ -416,6 +419,7 @@ function vipgoci_gitrepo_blame_for_file(
 				'cmd'    => $cmd,
 				'output' => $result,
 			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
 		);
 	}
 
@@ -603,6 +607,7 @@ function vipgoci_gitrepo_get_file_at_commit(
 				'cmd'    => $cmd,
 				'output' => $result,
 			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
 		);
 	}
 
@@ -647,6 +652,7 @@ function vipgoci_gitrepo_submodules_setup( $local_git_repo ) {
 				'cmd'    => $cmd,
 				'output' => $result,
 			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
 		);
 	}
 
@@ -693,6 +699,7 @@ function vipgoci_gitrepo_submodules_list( $local_git_repo ) {
 				'cmd'    => $cmd,
 				'output' => $result,
 			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
 		);
 	}
 

--- a/github-api.php
+++ b/github-api.php
@@ -1440,7 +1440,7 @@ function vipgoci_github_pr_reviews_comments_get(
 			 * kinds of requests, returning HTTP 500 errors, probably
 			 * due to a bug in the API. We want to continue processing
 			 * despite this and return partial results, as it will not
-			 * have a great impact on the final output. 
+			 * have a great impact on the final output.
 			 */
 			$prs_comments_tmp = vipgoci_github_fetch_url(
 				$github_url,

--- a/github-api.php
+++ b/github-api.php
@@ -1436,6 +1436,15 @@ function vipgoci_github_pr_reviews_comments_get(
 				'page=' . rawurlencode( $page ) . '&' .
 				'per_page=' . rawurlencode( $per_page );
 
+			/*
+			 * Fetch results from GitHub, but do not stop
+			 * execution on failure. This is because in some edge
+			 * cases the GitHub API consistently cannot process these
+			 * kinds of requests, returning HTTP 500 errors, probably
+			 * due to a bug in the API. We want to continue processing
+			 * despite this and return partial results, as it will not
+			 * have a great impact on the final output. 
+			 */
 			$prs_comments_tmp = vipgoci_github_fetch_url(
 				$github_url,
 				$github_token,
@@ -1455,6 +1464,7 @@ function vipgoci_github_pr_reviews_comments_get(
 				);
 
 				$page++;
+				$prs_comments_tmp = array();
 
 				continue;
 			}

--- a/github-api.php
+++ b/github-api.php
@@ -804,21 +804,18 @@ function vipgoci_github_fetch_url(
 				'Sending request to GitHub failed, will ' .
 					'retry in a bit... ',
 				array(
-					'github_url'    => $github_url,
-					'curl_retries'  => $curl_retries,
-
-					'curl_errno'    => curl_errno(
+					'github_url'          => $github_url,
+					'curl_retries'        => $curl_retries,
+					'curl_errno'          => curl_errno(
 						$ch
 					),
-
-					'curl_errormsg' => curl_strerror(
+					'curl_errormsg'       => curl_strerror(
 						curl_errno( $ch )
 					),
-					'http_status'   =>
+					'http_status'         =>
 						isset( $resp_headers['status'] ) ?
 						$resp_headers['status'] : null,
-					'http_response' =>
-						$resp_data,
+					'http_response'       => $resp_data,
 					'x-github-request-id' =>
 						isset( $resp_headers['x-github-request-id'] ) ?
 						$resp_headers['x-github-request-id'] : null,

--- a/github-api.php
+++ b/github-api.php
@@ -858,7 +858,8 @@ function vipgoci_github_fetch_url(
 		vipgoci_sysexit(
 			'Gave up retrying request to GitHub, cannot continue',
 			array(),
-			VIPGOCI_EXIT_GITHUB_PROBLEM
+			VIPGOCI_EXIT_GITHUB_PROBLEM,
+			true // Log to IRC.
 		);
 	} elseif (
 		( false === $fatal_error_on_failure ) &&

--- a/github-api.php
+++ b/github-api.php
@@ -689,7 +689,8 @@ function vipgoci_github_post_url(
  */
 function vipgoci_github_fetch_url(
 	$github_url,
-	$github_token
+	$github_token,
+	$fatal_error_on_failure = true
 ) {
 
 	$curl_retries = 0;
@@ -784,31 +785,48 @@ function vipgoci_github_fetch_url(
 			null
 		);
 
-
 		/*
 		 * Detect and process possible errors
 		 */
 		if (
-			( false === $resp_data ) ||
+			( false === $resp_data )
+			||
 			( curl_errno( $ch ) )
+			||
+			(
+				// Detect internal server errors (HTTP 50X).
+				( isset( $resp_headers['status'][0] ) ) &&
+				( 500 <= (int) $resp_headers['status'][0] ) &&
+				( 600 > (int) $resp_headers['status'][0] )
+			)
 		) {
 			vipgoci_log(
 				'Sending request to GitHub failed, will ' .
 					'retry in a bit... ',
 
 				array(
-					'github_url' => $github_url,
-					'curl_retries' => $curl_retries,
+					'github_url'    => $github_url,
+					'curl_retries'  => $curl_retries,
 
-					'curl_errno' => curl_errno(
+					'curl_errno'    => curl_errno(
 						$ch
 					),
 
 					'curl_errormsg' => curl_strerror(
 						curl_errno( $ch )
 					),
+					'http_status'   =>
+						isset( $resp_headers['status'] ) ?
+						$resp_headers['status'] : null,
+					'http_response' =>
+						$resp_data,
+					'x-github-request-id' =>
+						isset( $resp_headers['x-github-request-id'] ) ?
+						$resp_headers['x-github-request-id'] : null,
 				)
 			);
+
+			$resp_data = false;
 
 			sleep( 10 );
 		}
@@ -828,16 +846,24 @@ function vipgoci_github_fetch_url(
 
 	} while (
 		( false === $resp_data ) &&
-		( $curl_retries++ < 2 )
+		( $curl_retries++ < 4 )
 	);
 
 
-	if ( false === $resp_data ) {
+	if (
+		( true === $fatal_error_on_failure ) &&
+		( false === $resp_data )
+	) {
 		vipgoci_sysexit(
 			'Gave up retrying request to GitHub, cannot continue',
 			array(),
 			VIPGOCI_EXIT_GITHUB_PROBLEM
 		);
+	} elseif (
+		( false === $fatal_error_on_failure ) &&
+		( false === $resp_data )
+	) {
+		return null;
 	}
 
 	return $resp_data;
@@ -1369,7 +1395,7 @@ function vipgoci_github_pr_reviews_comments_get(
 	$cached_data = vipgoci_cache( $cached_id );
 
 	vipgoci_log(
-		'Fetching Pull-Requests comments info from GitHub' .
+		'Fetching pull requests comments info from GitHub' .
 			vipgoci_cached_indication_str( $cached_data ),
 
 		array(
@@ -1408,13 +1434,28 @@ function vipgoci_github_pr_reviews_comments_get(
 				'page=' . rawurlencode( $page ) . '&' .
 				'per_page=' . rawurlencode( $per_page );
 
-			// FIXME: Detect when GitHub returned with an error
-			$prs_comments_tmp = json_decode(
-				vipgoci_github_fetch_url(
-					$github_url,
-					$github_token
-				)
+			$prs_comments_tmp = vipgoci_github_fetch_url(
+				$github_url,
+				$github_token,
+				false // Do not stop execution on failure.
 			);
+
+			if ( null !== $prs_comments_tmp ) {
+				$prs_comments_tmp = json_decode(
+					$prs_comments_tmp
+				);
+			} elseif ( null === $prs_comments_tmp ) {
+				vipgoci_log(
+					'Unable to fetch data from GitHub, returning partial results',
+					array(
+						'request_response' => $prs_comments_tmp,
+					)
+				);
+
+				$page++;
+
+				continue;
+			}
 
 			foreach ( $prs_comments_tmp as $pr_comment ) {
 				$prs_comments_cache[] = $pr_comment;
@@ -1460,7 +1501,7 @@ function vipgoci_github_pr_reviews_comments_get(
 
 /*
  * Get all review-comments submitted to a
- * particular Pull-Request.
+ * particular pull request.
  * Supports filtering by:
  * - User submitted (parameter: login)
  * - Comment state (parameter: comments_active, true/false)
@@ -1494,7 +1535,7 @@ function vipgoci_github_pr_reviews_comments_get_by_pr(
 	$cached_data = vipgoci_cache( $cache_id );
 
 	vipgoci_log(
-		'Fetching all review comments submitted to a Pull-Request' .
+		'Fetching all review comments submitted to a pull request' .
 			vipgoci_cached_indication_str( $cached_data ),
 		array(
 			'repo_owner'	=> $options['repo-owner'],
@@ -1592,8 +1633,8 @@ function vipgoci_github_pr_reviews_comments_delete(
 	$comment_id
 ) {
 	vipgoci_log(
-		'Deleting an inline comment from a Pull-Request ' .
-			'Review',
+		'Deleting an inline comment from a pull request ' .
+			'review',
 		array(
 			'repo_owner'	=> $options['repo-owner'],
 			'repo_name'	=> $options['repo-name'],
@@ -1619,7 +1660,7 @@ function vipgoci_github_pr_reviews_comments_delete(
 }
 
 /*
- * Get all generic comments made to a Pull-Request from Github.
+ * Get all generic comments made to a pull request from Github.
  */
 
 function vipgoci_github_pr_generic_comments_get_all(
@@ -1639,7 +1680,7 @@ function vipgoci_github_pr_generic_comments_get_all(
 	$cached_data = vipgoci_cache( $cached_id );
 
 	vipgoci_log(
-		'Fetching Pull-Requests generic comments from GitHub' .
+		'Fetching pull requests generic comments from GitHub' .
 			vipgoci_cached_indication_str( $cached_data ),
 
 		array(
@@ -1712,7 +1753,7 @@ function vipgoci_github_pr_comments_generic_submit(
 	$commit_id = null
 ) {
 	vipgoci_log(
-		'Posting a comment to a Pull-Request',
+		'Posting a comment to a pull request',
 		array(
 			'repo_owner' => $repo_owner,
 			'repo_name' => $repo_name,
@@ -1837,7 +1878,7 @@ function vipgoci_github_pr_comments_cleanup(
 
 
 /*
- * Delete generic comment made to Pull-Request.
+ * Delete generic comment made to pull request.
  */
 
 function vipgoci_github_pr_generic_comment_delete(
@@ -1878,7 +1919,7 @@ function vipgoci_github_pr_generic_comment_delete(
 }
 
 /*
- * Get all reviews for a particular Pull-Request,
+ * Get all reviews for a particular pull request,
  * and allow filtering by:
  * - User submitted (parameter: login)
  * - State of review (parameter: state,
@@ -1910,7 +1951,7 @@ function vipgoci_github_pr_reviews_get(
 	}
 
 	vipgoci_log(
-		'Fetching reviews for Pull-Request ' .
+		'Fetching reviews for pull request ' .
 			vipgoci_cached_indication_str( $cached_data ),
 		array(
 			'repo_owner' => $repo_owner,
@@ -2037,7 +2078,7 @@ function vipgoci_github_pr_reviews_get(
 
 /*
  * Dismiss a particular review
- * previously submitted to a Pull-Request.
+ * previously submitted to a pull request.
  */
 
 function vipgoci_github_pr_review_dismiss(
@@ -2050,7 +2091,7 @@ function vipgoci_github_pr_review_dismiss(
 ) {
 
 	vipgoci_log(
-		'Dismissing a Pull-Request Review',
+		'Dismissing a pull request review',
 		array(
 			'repo_owner'		=> $repo_owner,
 			'repo_name'		=> $repo_name,
@@ -2082,7 +2123,7 @@ function vipgoci_github_pr_review_dismiss(
 
 
 /*
- * Dismiss all Pull-Request Reviews that have no
+ * Dismiss all pull request reviews that have no
  * active comments attached to them.
  */
 function vipgoci_github_pr_reviews_dismiss_with_non_active_comments(
@@ -2090,7 +2131,7 @@ function vipgoci_github_pr_reviews_dismiss_with_non_active_comments(
 	$pr_number
 ) {
 	vipgoci_log(
-		'Dismissing any Pull-Request reviews submitted by ' .
+		'Dismissing any pull request reviews submitted by ' .
 			'us and contain no active inline comments any more',
 		array(
 			'repo_owner'		=> $options['repo-owner'],
@@ -2100,7 +2141,7 @@ function vipgoci_github_pr_reviews_dismiss_with_non_active_comments(
 	);
 
 	/*
-	 * Get any Pull-Request reviews with changes
+	 * Get any pull request reviews with changes
  	 * required status, and submitted by us.
 	 */
 	$pr_reviews = vipgoci_github_pr_reviews_get(
@@ -2115,7 +2156,7 @@ function vipgoci_github_pr_reviews_dismiss_with_non_active_comments(
 	);
 
 	/*
-	 * Get all comments to a the current Pull-Request.
+	 * Get all comments to the current pull request.
 	 *
 	 * Note that we must bypass cache here,
 	 */
@@ -2141,7 +2182,7 @@ function vipgoci_github_pr_reviews_dismiss_with_non_active_comments(
 		 */
 		vipgoci_log(
 			'Not dismissing any reviews, as no inactive ' .
-				'comments submitted to the Pull-Request ' .
+				'comments submitted to the pull request ' .
 				'were found',
 			array(
 				'repo_owner'	=> $options['repo-owner'],
@@ -2234,13 +2275,13 @@ function vipgoci_github_pr_reviews_dismiss_with_non_active_comments(
 }
 
 /*
- * Approve a Pull-Request, and afterwards
+ * Approve a pull request, and afterwards
  * make sure to verify that the latest commit
- * added to the Pull-Request is commit with
+ * added to the pull request is commit with
  * commit-ID $latest_commit_id -- this is to avoid
  * race-conditions.
  *
- * The race-conditions can occur when a Pull-Request
+ * The race-conditions can occur when a pull request
  * is approved, but it is approved after a new commit
  * was added which has not been scanned.
  */
@@ -2272,7 +2313,7 @@ function vipgoci_github_approve_pr(
 	$github_postfields['body'] = $message;
 
 	vipgoci_log(
-		'Sending request to GitHub to approve Pull-Request',
+		'Sending request to GitHub to approve pull request',
 		array(
 			'repo_owner'		=> $repo_owner,
 			'repo_name'		=> $repo_name,
@@ -2331,7 +2372,7 @@ function vipgoci_github_prs_implicated(
 	}
 
 	vipgoci_log(
-		'Fetching all open Pull-Requests from GitHub' .
+		'Fetching all open pull requests from GitHub' .
 			vipgoci_cached_indication_str( $cached_data ),
 		array(
 			'repo_owner'		=> $repo_owner,
@@ -2345,7 +2386,7 @@ function vipgoci_github_prs_implicated(
 
 	if ( false !== $cached_data ) {
 		/*
-		 * Filter away draft Pull-Requests if requested.
+		 * Filter away draft pull requests if requested.
 		 */
 		if ( true === $skip_draft_prs ) {
 			$cached_data = vipgoci_github_pr_remove_drafts(
@@ -2367,7 +2408,7 @@ function vipgoci_github_prs_implicated(
 	$per_page = 100;
 
 	/*
-	 * Fetch all open Pull-Requests, store
+	 * Fetch all open pull requests, store
 	 * PR IDs that have a commit-head that matches
 	 * the one we are working on.
 	 */
@@ -2398,7 +2439,7 @@ function vipgoci_github_prs_implicated(
 			}
 
 			/*
-			 * If the branch this Pull-Request is associated
+			 * If the branch this pull request is associated
 			 * with is one of those we are supposed to ignore,
 			 * then ignore it.
 			 */
@@ -2412,8 +2453,8 @@ function vipgoci_github_prs_implicated(
 
 			/*
 			 * If the commit we are processing currently
-			 * matches the head-commit of the Pull-Request,
-			 * then the Pull-Request should be considered to
+			 * matches the head-commit of the pull request,
+			 * then the pull request should be considered to
 			 * be relevant.
 			 */
 			if ( $commit_id === $pr_item->head->sha ) {
@@ -2445,7 +2486,7 @@ function vipgoci_github_prs_implicated(
 	vipgoci_cache( $cached_id, $prs_implicated );
 
 	/*
-	 * Filter away draft Pull-Requests if requested.
+	 * Filter away draft pull requests if requested.
 	 */
 	if ( true === $skip_draft_prs ) {
 		$prs_implicated = vipgoci_github_pr_remove_drafts(
@@ -2517,7 +2558,7 @@ function vipgoci_github_prs_implicated_with_retries(
 }
 
 /*
- * Get all commits that are a part of a Pull-Request.
+ * Get all commits that are a part of a pull request.
  */
 
 function vipgoci_github_prs_commits_list(
@@ -2540,7 +2581,7 @@ function vipgoci_github_prs_commits_list(
 
 	vipgoci_log(
 		'Fetching information about all commits made' .
-			' to Pull-Request #' .
+			' to pull request #' .
 			(int) $pr_number . ' from GitHub' .
 			vipgoci_cached_indication_str( $cached_data ),
 
@@ -2665,7 +2706,7 @@ function vipgoci_github_authenticated_user_get( $github_token ) {
 
 /*
  * Add a particular label to a specific
- * Pull-Request (or issue).
+ * pull request (or issue).
  */
 function vipgoci_github_label_add_to_pr(
 	$repo_owner,
@@ -2706,7 +2747,7 @@ function vipgoci_github_label_add_to_pr(
 
 /*
  * Fetch labels associated with a
- * particular issue/Pull-Request.
+ * particular issue/pull request.
  */
 function vipgoci_github_pr_labels_get(
 	$repo_owner,
@@ -2807,7 +2848,7 @@ function vipgoci_github_pr_labels_get(
 
 /*
  * Remove a particular label from a specific
- * Pull-Request (or issue).
+ * pull request (or issue).
  */
 function vipgoci_github_pr_label_remove(
 	$repo_owner,
@@ -2846,7 +2887,7 @@ function vipgoci_github_pr_label_remove(
 
 
 /*
- * Get all events issues related to a Pull-Request
+ * Get all events issues related to a pull request
  * from the GitHub API, and filter away any items that
  * do not match a given criteria (if applicable).
  *
@@ -2867,7 +2908,7 @@ function vipgoci_github_pr_review_events_get(
 	$cached_data = vipgoci_cache( $cached_id );
 
 	vipgoci_log(
-		'Getting issue events for Pull-Request from GitHub API' .
+		'Getting issue events for pull request from GitHub API' .
 		vipgoci_cached_indication_str( $cached_data ),
 		array(
 			'repo_owner' => $options['repo-owner'],

--- a/github-api.php
+++ b/github-api.php
@@ -803,7 +803,6 @@ function vipgoci_github_fetch_url(
 			vipgoci_log(
 				'Sending request to GitHub failed, will ' .
 					'retry in a bit... ',
-
 				array(
 					'github_url'    => $github_url,
 					'curl_retries'  => $curl_retries,
@@ -823,7 +822,9 @@ function vipgoci_github_fetch_url(
 					'x-github-request-id' =>
 						isset( $resp_headers['x-github-request-id'] ) ?
 						$resp_headers['x-github-request-id'] : null,
-				)
+				),
+				0,
+				true // Log to IRC.
 			);
 
 			$resp_data = false;

--- a/github-commit-status.php
+++ b/github-commit-status.php
@@ -121,7 +121,8 @@ switch ( $options['build-state'] ) {
 			'Invalid parameter for --build-state, only "pending", "failure", and "success" are valid',
 			array(
 				'build-state' => $options['build-state'],
-			)
+			),
+			VIPGOCI_EXIT_USAGE_ERROR
 		);
 }
 

--- a/github-misc.php
+++ b/github-misc.php
@@ -42,7 +42,7 @@ function vipgoci_patch_changed_lines(
 	string $file_name
 ): ?array {
 	/*
-	 * Fetch patch for all files of the Pull-Request
+	 * Fetch patch for all files of the pull request
 	 */
 	$patch_arr = vipgoci_git_diffs_fetch(
 		$local_git_repo,
@@ -179,7 +179,7 @@ function vipgoci_blame_filter_commits(
 	 * 'git blame' log for the file, so
 	 * so we can filter out issues not
 	 * stemming from commits that are a
-	 * part of the current Pull-Request.
+	 * part of the current pull request.
 	 */
 
 	$blame_log_filtered = array();

--- a/github-misc.php
+++ b/github-misc.php
@@ -319,3 +319,30 @@ function vipgoci_github_wait() {
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'github_forced_wait' );
 }
 
+/**
+ * Construct and return URLs to pull requests
+ * specified in $prs_arr
+ *
+ * @param array  $prs_arr    Pull requests.
+ * @param string $separator  Separator to use between URLs.
+ *
+ * @return string URLs to pull requests.
+ */
+function vipgoci_github_prs_urls_get(
+	array $prs_arr,
+	string $separator = ', '
+) :string {
+	$prs_urls = '';
+
+	foreach ( $prs_arr as $pr_item ) {
+		if ( ! empty( $prs_urls ) ) {
+			$prs_urls .= $separator;
+		}
+
+		$prs_urls .= $pr_item->head->repo->html_url .
+			'/pull/' .
+			rawurlencode( (string) $pr_item->number );
+	}
+
+	return $prs_urls;
+}

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -191,6 +191,18 @@ function vipgoci_lint_parse_results(
 			 */
 			$pos3 = strpos( $message, ' in ' . $temp_file_name );
 
+			if ( false === $pos3 ) {
+				vipgoci_sysexit(
+					'Temporary file name not found in PHPCS output, cannot continue',
+					array(
+						'file_name'      => $file_name,
+						'temp_file_name' => $temp_file_name,
+					),
+					VIPGOCI_EXIT_SYSTEM_PROBLEM,
+					true // Log to IRC.
+				);
+			}
+
 			$message = substr( $message, 0, $pos3 );
 			$message = ltrim( rtrim( $message ) );
 

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -630,6 +630,17 @@ function vipgoci_lint_scan_commit(
 		$options['skip-draft-prs']
 	);
 
+	vipgoci_log(
+		( false === $options['lint-modified-files-only'] ) ?
+			'PHP lint scanning all PHP files' :
+			'PHP lint scanning modified files only',
+		array(
+			'repo_owner' => $repo_owner,
+			'repo_name'  => $repo_name,
+			'commit_id'  => $commit_id,
+		)
+	);
+
 	if ( true === $options['lint-modified-files-only'] ) {
 		// Fetch list of files that exist in the commit.
 		$modified_files = vipgoci_lint_get_prs_modified_files(
@@ -697,6 +708,11 @@ function vipgoci_lint_scan_commit(
 			);
 		}
 	}
+
+	vipgoci_log(
+		'PHP linting complete',
+		array()
+	);
 
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'lint_scan_commit' );
 }

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -674,7 +674,7 @@ function vipgoci_lint_scan_commit(
 
 	/*
 	 * Process results of linting
-	 * for each Pull-Request -- actually
+	 * for each pull request -- actually
 	 * queue issues for submission.
 	 */
 	$file_names = array_keys( $scanning_results );

--- a/log.php
+++ b/log.php
@@ -42,7 +42,10 @@ function vipgoci_log(
 	}
 
 	echo '[ ' . gmdate( 'c' ) . ' GMT -- ' . (int) $debug_level . ' ]  ' .
-		$str .
+		json_encode(
+			$str,
+			JSON_PRETTY_PRINT
+		) .
 		'; ' .
 		print_r(
 			json_encode(

--- a/main.php
+++ b/main.php
@@ -2758,7 +2758,7 @@ function vipgoci_run_scan(
 		'Starting scanning PRs; ' . $prs_urls,
 		array(
 			'repo-owner' => $options['repo-owner'],
-			'repo-name' =>  $options['repo-name'],
+			'repo-name'  => $options['repo-name'],
 		),
 		0,
 		true // Log to IRC.
@@ -3122,7 +3122,7 @@ function vipgoci_run_init_vars() :array {
  */
 function vipgoci_run() :int {
 	// Set memory limit to 400MB.
-	ini_set( 'memory_limit', '400M' );
+	ini_set( 'memory_limit', '400M' ); // phpcs:ignore WordPress.PHP.IniSet.memory_limit_Blacklisted
 
 	/*
 	 * Assign a few variables.

--- a/main.php
+++ b/main.php
@@ -2750,9 +2750,8 @@ function vipgoci_run_scan(
 
 	// Log to IRC URLs to PRs implicated.
 	$prs_urls = vipgoci_github_prs_urls_get(
-		$options['repo-owner'],
-		$options['repo-name'],
-		$prs_implicated
+		$prs_implicated,
+		' -- '
 	);
 
 	vipgoci_log(

--- a/main.php
+++ b/main.php
@@ -1121,7 +1121,9 @@ function vipgoci_run_init_options_lint( array &$options ) :void {
 
 		if ( empty( $options['lint-php-versions'] ) ) {
 			vipgoci_sysexit(
-				'--lint-php-versions is empty and --lint option is set to true. Must define at least one PHP version for linting'
+				'--lint-php-versions is empty and --lint option is set to true. Must define at least one PHP version for linting',
+				array(),
+				VIPGOCI_EXIT_USAGE_ERROR
 			);
 		}
 
@@ -1136,7 +1138,9 @@ function vipgoci_run_init_options_lint( array &$options ) :void {
 
 		if ( empty( $options['lint-php-version-paths'] ) ) {
 			vipgoci_sysexit(
-				'--lint-php-version-paths is empty and --lint option is set to true. Must define at least one path to PHP interpreter'
+				'--lint-php-version-paths is empty and --lint option is set to true. Must define at least one path to PHP interpreter',
+				array(),
+				VIPGOCI_EXIT_USAGE_ERROR
 			);
 		}
 
@@ -1161,7 +1165,8 @@ function vipgoci_run_init_options_lint( array &$options ) :void {
 					'Invalid formatting of option --lint-php-version-paths',
 					array(
 						'lint-php-version-path-invalid' => $tmp_php_version_path,
-					)
+					),
+					VIPGOCI_EXIT_USAGE_ERROR
 				);
 			}
 
@@ -1170,7 +1175,8 @@ function vipgoci_run_init_options_lint( array &$options ) :void {
 					'Invalid formatting of option --lint-php-version-paths; version must be numeric',
 					array(
 						'lint-php-version-path-invalid' => $tmp_version_to_path_arr[0],
-					)
+					),
+					VIPGOCI_EXIT_USAGE_ERROR
 				);
 			}
 
@@ -1180,7 +1186,8 @@ function vipgoci_run_init_options_lint( array &$options ) :void {
 					array(
 						'php-version-key'   => $tmp_version_to_path_arr[0],
 						'path-not-existing' => $tmp_version_to_path_arr[1],
-					)
+					),
+					VIPGOCI_EXIT_USAGE_ERROR
 				);
 			}
 
@@ -1193,7 +1200,8 @@ function vipgoci_run_init_options_lint( array &$options ) :void {
 					'Option --lint-php-version-paths contains duplicate PHP version key',
 					array(
 						'lint-php-version-duplicate' => $tmp_version_to_path_arr[0],
-					)
+					),
+					VIPGOCI_EXIT_USAGE_ERROR
 				);
 			} else {
 				$tmp_php_paths_versions_seen[] = $tmp_version_to_path_arr[0];
@@ -1212,7 +1220,8 @@ function vipgoci_run_init_options_lint( array &$options ) :void {
 					'Unable to get PHP interpreter when parsing option --lint-php-version-paths',
 					array(
 						'lint-php-interpreter-path' => $tmp_version_to_path_arr[1],
-					)
+					),
+					VIPGOCI_EXIT_USAGE_ERROR
 				);
 			}
 
@@ -1225,7 +1234,8 @@ function vipgoci_run_init_options_lint( array &$options ) :void {
 					array(
 						'version-defined'            => $tmp_version_to_path_arr[0],
 						'actual-interpreter-version' => $tmp_lint_php_interpreter_version,
-					)
+					),
+					VIPGOCI_EXIT_USAGE_ERROR
 				);
 			}
 
@@ -1252,7 +1262,8 @@ function vipgoci_run_init_options_lint( array &$options ) :void {
 					array(
 						'version-not-defined' => $tmp_lint_php_version,
 						'versions-defined'    => array_keys( $options['lint-php-version-paths'] ),
-					)
+					),
+					VIPGOCI_EXIT_USAGE_ERROR
 				);
 			}
 		}
@@ -2119,7 +2130,8 @@ function vipgoci_run_init_options_repo_options( array &$options ):void {
 			array(
 				'allowed_values'   => $repo_options_allowed_arr,
 				'specified_values' => $options['repo-options-allowed'],
-			)
+			),
+			VIPGOCI_EXIT_USAGE_ERROR
 		);
 	}
 

--- a/main.php
+++ b/main.php
@@ -2748,6 +2748,23 @@ function vipgoci_run_scan(
 	// Find PRs relating to the commit we are processing.
 	$prs_implicated = vipgoci_run_scan_find_prs( $options );
 
+	// Log to IRC URLs to PRs implicated.
+	$prs_urls = vipgoci_github_prs_urls_get(
+		$options['repo-owner'],
+		$options['repo-name'],
+		$prs_implicated
+	);
+
+	vipgoci_log(
+		'Starting scanning PRs; ' . $prs_urls,
+		array(
+			'repo-owner' => $options['repo-owner'],
+			'repo-name' =>  $options['repo-name'],
+		),
+		0,
+		true // Log to IRC.
+	);
+
 	// Check that each PR has the commit specified as the latest one.
 	vipgoci_run_scan_check_latest_commit(
 		$options,
@@ -2834,6 +2851,9 @@ function vipgoci_run_scan(
 			$results['stats'][ VIPGOCI_STATS_LINT ],
 			$results[ VIPGOCI_SKIPPED_FILES ]
 		);
+
+		// Reduce memory usage as possible.
+		gc_collect_cycles();
 	}
 
 	// Next PHPCS scan if configured to do so.
@@ -2844,6 +2864,8 @@ function vipgoci_run_scan(
 			$results['stats'][ VIPGOCI_STATS_PHPCS ],
 			$results[ VIPGOCI_SKIPPED_FILES ]
 		);
+
+		gc_collect_cycles();
 	}
 
 	/*
@@ -2858,6 +2880,8 @@ function vipgoci_run_scan(
 		$options,
 		$results
 	);
+
+	gc_collect_cycles();
 
 	/*
 	 * Remove comments from $results that have
@@ -2914,6 +2938,8 @@ function vipgoci_run_scan(
 	} else {
 		$scan_details_msg = '';
 	}
+
+	gc_collect_cycles();
 
 	/*
 	 * Submit any remaining issues to GitHub
@@ -3096,6 +3122,9 @@ function vipgoci_run_init_vars() :array {
  * @codeCoverageIgnore
  */
 function vipgoci_run() :int {
+	// Set memory limit to 400MB.
+	ini_set( 'memory_limit', '400M' );
+
 	/*
 	 * Assign a few variables.
 	 */
@@ -3148,6 +3177,9 @@ function vipgoci_run() :int {
 
 	// Process options parameters.
 	vipgoci_run_init_options( $options, $options_recognized );
+
+	// Reduce memory usage as possible.
+	gc_collect_cycles();
 
 	// Run scans.
 	vipgoci_run_scan( $options, $results, $prs_implicated, $startup_time );

--- a/other-utilities.php
+++ b/other-utilities.php
@@ -45,6 +45,7 @@ function vipgoci_util_php_interpreter_get_version(
 				'cmd'    => $php_cmd,
 				'output' => $php_output,
 			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
 		);
 	}
 

--- a/other-utilities.php
+++ b/other-utilities.php
@@ -66,6 +66,15 @@ function vipgoci_util_php_interpreter_get_version(
 
 	$php_version_str = trim( $php_output_arr[0] );
 
+	vipgoci_log(
+		'Determined PHP version',
+		array(
+			'php-path'    => $php_path,
+			'php-version' => $php_version_str,
+		),
+		2
+	);
+
 	vipgoci_cache( $cache_id, $php_version_str );
 
 	return $php_version_str;

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -118,7 +118,7 @@ function vipgoci_phpcs_do_scan(
 	 * Feed PHPCS the temporary file specified by our caller.
 	 */
 	$cmd = sprintf(
-		'%s -d memory_limit=500M %s --severity=%s --report=%s',
+		'%s -d memory_limit=500M -d max_execution_time=300 %s --severity=%s --report=%s',
 		escapeshellcmd( $phpcs_php_path ),
 		escapeshellcmd( $phpcs_path ),
 		escapeshellarg( (string) $phpcs_severity ),

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -74,6 +74,15 @@ function vipgoci_phpcs_get_version(
 
 	$phpcs_version_str = $phpcs_output_arr[0];
 
+	vipgoci_log(
+		'PHPCS version retrieved',
+		array(
+			'phpcs-path'    => $phpcs_path,
+			'phpcs-version' => $phpcs_output,
+		),
+		2
+	);
+
 	vipgoci_cache( $cache_id, $phpcs_version_str );
 
 	return $phpcs_version_str;
@@ -196,11 +205,6 @@ function vipgoci_phpcs_do_scan(
 		$cmd,
 		'phpcs_cli'
 	);
-
-	if ( null !== $result ) {
-		/* Remove linebreak PHPCS possibly adds */
-		$result = rtrim( $result, "\n" );
-	}
 
 	return $result;
 }
@@ -367,6 +371,12 @@ function vipgoci_phpcs_scan_single_file(
 	);
 
 	if ( null !== $file_issues_str ) {
+		/* Remove linebreak PHPCS possibly adds */
+		$file_issues_str = rtrim(
+			$file_issues_str,
+			"\n"
+		);
+
 		$file_issues_arr_master = json_decode(
 			$file_issues_str,
 			true
@@ -1080,28 +1090,12 @@ function vipgoci_phpcs_scan_commit(
 				$commit_issues_stats[ $pr_item->number ][ strtolower( $file_issue_val_item['level'] ) ]++;
 			}
 		}
-
-		unset( $pr_item_commits );
-		unset( $file_blame_log );
-		unset( $file_changed_lines );
-		unset( $file_relative_lines );
-		unset( $file_issues_arr_filtered );
-
-		gc_collect_cycles();
 	}
 
-	/*
-	 * Clean up a bit
-	 */
 	vipgoci_log(
-		'Cleaning up after PHPCS-scanning...',
+		'PHPCS-scanning complete',
 		array()
 	);
-
-	unset( $prs_implicated );
-	unset( $pr_item_files_changed );
-
-	gc_collect_cycles();
 
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'phpcs_scan_commit' );
 }

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -512,7 +512,7 @@ function vipgoci_phpcs_scan_commit(
 		)
 	);
 
-	// Fetch list of all Pull-Requests which the commit is a part of.
+	// Fetch list of all pull requests which the commit is a part of.
 	$prs_implicated = vipgoci_github_prs_implicated(
 		$repo_owner,
 		$repo_name,
@@ -524,11 +524,11 @@ function vipgoci_phpcs_scan_commit(
 
 	/*
 	 * Get list of all files affected by
-	 * each Pull-Request implicated by the commit.
+	 * each pull request implicated by the commit.
 	 */
 
 	vipgoci_log(
-		'Fetching list of all files affected by each Pull-Request ' .
+		'Fetching list of all files affected by each pull request ' .
 			'implicated by the commit',
 		array(
 			'repo_owner' => $repo_owner,
@@ -550,7 +550,7 @@ function vipgoci_phpcs_scan_commit(
 
 		/*
 		 * Get list of all files changed
-		 * in this Pull-Request.
+		 * in this pull request.
 		 */
 
 		$pr_item_files_tmp = vipgoci_git_diffs_fetch(
@@ -600,7 +600,7 @@ function vipgoci_phpcs_scan_commit(
 	$files_issues_arr = array();
 
 	/*
-	 * Loop through each altered file in all the Pull-Requests,
+	 * Loop through each altered file in all the pull requests,
 	 * use PHPCS to scan for issues, save the issues; they will
 	 * be processed in the next step.
 	 */
@@ -884,11 +884,11 @@ function vipgoci_phpcs_scan_commit(
 	}
 
 	/*
-	 * Loop through each Pull-Request implicated,
+	 * Loop through each pull request implicated,
 	 * get comments made on GitHub already,
 	 * then filter out any PHPCS-issues irrelevant
 	 * as they are not due to any commit that is part
-	 * of the Pull-Request, and skip any PHPCS-issue
+	 * of the pull request, and skip any PHPCS-issue
 	 * already reported. Report the rest, if any.
 	 */
 
@@ -917,8 +917,8 @@ function vipgoci_phpcs_scan_commit(
 
 		/*
 		 * Check if user requested to turn off PHPCS
-		 * scanning for the Pull-Request by adding a label
-		 * to the Pull-Request, and if so, skip scanning.
+		 * scanning for the pull request by adding a label
+		 * to the pull request, and if so, skip scanning.
 		 * Make sure to indicate so in the statistics.
 		 *
 		 * This is only done if allowed via option.
@@ -938,7 +938,7 @@ function vipgoci_phpcs_scan_commit(
 
 			if ( ! empty( $pr_label_skip_phpcs ) ) {
 				vipgoci_log(
-					'Label on Pull-Request indicated to ' .
+					'Label on pull request indicated to ' .
 						'skip PHPCS-scanning; ' .
 						'scanning will be skipped',
 					array(
@@ -970,7 +970,7 @@ function vipgoci_phpcs_scan_commit(
 
 		/*
 		 * Get all commits related to the current
-		 * Pull-Request.
+		 * pull request.
 		 */
 		$pr_item_commits = vipgoci_github_prs_commits_list(
 			$repo_owner,
@@ -984,7 +984,7 @@ function vipgoci_phpcs_scan_commit(
 		 * 'git blame' log for the file, then
 		 * filter out issues stemming
 		 * from commits that are not a
-		 * part of the current Pull-Request.
+		 * part of the current pull request.
 		 */
 
 		foreach (
@@ -1056,7 +1056,7 @@ function vipgoci_phpcs_scan_commit(
 			 * the ones that the are not found
 			 * in the blame-log (meaning that
 			 * they are due to commits outside of
-			 * the Pull-Request).
+			 * the pull request).
 			 */
 
 			$file_issues_arr_filtered = vipgoci_results_filter_irrellevant(
@@ -1514,7 +1514,7 @@ function vipgoci_phpcs_validate_sniffs_in_options_and_report(
 		( ! empty( $phpcs_sniffs_excluded_and_included ) )
 	) {
 		/*
-		 * Post generic message with error for each Pull-Request
+		 * Post generic message with error for each pull request
 		 * implicated.
 		 */
 

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -50,6 +50,7 @@ function vipgoci_phpcs_get_version(
 				'cmd'    => $cmd,
 				'output' => $phpcs_output,
 			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
 		);
 	}
 
@@ -1153,6 +1154,7 @@ function vipgoci_phpcs_get_all_standards(
 				'cmd'    => $cmd,
 				'output' => $result,
 			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
 		);
 	}
 
@@ -1242,6 +1244,7 @@ function vipgoci_phpcs_get_sniffs_for_standard(
 				'cmd'    => $cmd,
 				'output' => $result,
 			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
 		);
 	}
 

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -79,7 +79,7 @@ function vipgoci_phpcs_get_version(
 		'PHPCS version retrieved',
 		array(
 			'phpcs-path'    => $phpcs_path,
-			'phpcs-version' => $phpcs_output,
+			'phpcs-version' => $phpcs_version_str,
 		),
 		2
 	);

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -607,7 +607,7 @@ function vipgoci_phpcs_scan_commit(
 
 	vipgoci_log(
 		'About to PHPCS-scan all files affected by any of the ' .
-			'Pull-Requests',
+			'pull requests',
 		array(
 			'repo_owner'               => $repo_owner,
 			'repo_name'                => $repo_name,
@@ -904,7 +904,7 @@ function vipgoci_phpcs_scan_commit(
 	foreach ( $prs_implicated as $pr_item ) {
 		vipgoci_log(
 			'Preparing to process PHPCS scanned files in ' .
-				'Pull-Request, to construct results ' .
+				'pull request, to construct results ' .
 				'to be submitted',
 			array(
 				'repo_owner'    => $repo_owner,

--- a/reports.php
+++ b/reports.php
@@ -151,6 +151,16 @@ function vipgoci_report_create_scan_details_software_versions(
 		}
 	}
 
+	if ( true === $options_copy['svg-checks'] ) {
+		$svg_php_version = vipgoci_util_php_interpreter_get_version(
+			$options_copy['svg-php-path']
+		);
+
+		if ( ! empty( $svg_php_version ) ) {
+			$details .= '<li>PHP runtime version for SVG scanner: <code>' . vipgoci_output_sanitize_version_number( $svg_php_version ) . '</code></li>' . PHP_EOL;
+		}
+	}
+
 	$details .= '</ul>' . PHP_EOL;
 
 	$details .= '<h4>Options file (<code>' . vipgoci_output_html_escape( VIPGOCI_OPTIONS_FILE_NAME ) . '</code>)</h4>' . PHP_EOL;

--- a/results.php
+++ b/results.php
@@ -9,8 +9,8 @@
 declare(strict_types=1);
 
 /**
- * Remove comments that exist on a GitHub Pull-Request from
- * the results array. Will loop through each Pull-Request
+ * Remove comments that exist on a GitHub pull request from
+ * the results array. Will loop through each pull request
  * affected by the current commit, and remove any comment
  * from the results array if it already exists.
  *
@@ -54,7 +54,7 @@ function vipgoci_results_remove_existing_github_comments(
 
 		/*
 		 * Get all commits related to the current
-		 * Pull-Request.
+		 * pull request.
 		 */
 
 		$pr_item_commits = vipgoci_github_prs_commits_list(
@@ -301,7 +301,7 @@ function vipgoci_results_remove_existing_github_comments(
  * do not do this for 'info' type messages,
  * as they are informational, and not problems.
  *
- * We do this, because sometimes Pull-Requests
+ * We do this, because sometimes pull requests
  * will be opened that contain approved code,
  * and we do not want to clutter them with
  * non-relevant comments.
@@ -332,14 +332,14 @@ function vipgoci_results_approved_files_comments_remove(
 	);
 
 	/*
-	 * Loop through each Pull-Request
+	 * Loop through each pull request
 	 */
 	foreach ( $results['issues'] as
 		$pr_number => $pr_issues
 	) {
 		/*
 		 * Loop through each issue affecting each
-		 * Pull-Request.
+		 * pull request.
 		 */
 		foreach ( $pr_issues as
 			$issue_number => $issue_item
@@ -408,8 +408,8 @@ function vipgoci_results_approved_files_comments_remove(
 
 /**
  * Limit the number of to-be-submitted comments to
- * the Pull-Requests. We take into account the number
- * to be submitted for each Pull-Request, the number of
+ * the pull requests. We take into account the number
+ * to be submitted for each pull request, the number of
  * comments already submitted, and the limit specified
  * on start-up. Comments are removed as needed, and
  * what comments are removed is reported.
@@ -455,7 +455,7 @@ function vipgoci_results_filter_comments_to_max(
 	) {
 		/*
 		 * Take into account previously submitted comments
-		 * by us for the current Pull-Request.
+		 * by us for the current pull request.
 		 */
 
 		$pr_previous_comments_cnt = count(
@@ -594,7 +594,7 @@ function vipgoci_results_filter_comments_to_max(
 
 	/*
 	 * Populate '$prs_comments_maxed' which
-	 * indicates which Pull-Requests have
+	 * indicates which pull requests have
 	 * had number of comments posted limited.
 	 */
 	$prs_comments_maxed = array_map(
@@ -952,7 +952,7 @@ function vipgoci_results_filter_irrellevant(
 	/*
 	 * Filter out any issues
 	 * that are due to commits outside
-	 * of the Pull-Request
+	 * of the pull request
 	 */
 
 	$file_blame_log_filtered =

--- a/support-level-label.php
+++ b/support-level-label.php
@@ -296,7 +296,7 @@ function vipgoci_repo_meta_api_data_match(
 
 /**
  * Attach support level label to
- * Pull-Requests, if configured to
+ * pull requests, if configured to
  * do so. Will fetch information
  * about support-level from an API.
  *
@@ -312,7 +312,7 @@ function vipgoci_support_level_label_set(
 
 	if ( true !== $options['set-support-level-label'] ) {
 		vipgoci_log(
-			'Not attaching support label to Pull-Requests ' .
+			'Not attaching support label to pull requests ' .
 				'implicated by commit, as not configured ' .
 				'to do so',
 			array(
@@ -325,7 +325,7 @@ function vipgoci_support_level_label_set(
 	}
 
 	vipgoci_log(
-		'Attaching support-level label to Pull-Requests implicated by commit',
+		'Attaching support-level label to pull requests implicated by commit',
 		array(
 			'repo_owner'             => $options['repo-owner'],
 			'repo_name'              => $options['repo-name'],
@@ -446,7 +446,7 @@ function vipgoci_support_level_label_set(
 	}
 
 	/*
-	 * Get Pull-Requests associated with the
+	 * Get pull requests associated with the
 	 * commit and repository.
 	 */
 	$prs_implicated = vipgoci_github_prs_implicated(
@@ -459,7 +459,7 @@ function vipgoci_support_level_label_set(
 	);
 
 	/*
-	 * Loop through each Pull-Request,
+	 * Loop through each pull request,
 	 * remove any invalid support levels
 	 * and add a correct one.
 	 *
@@ -489,7 +489,7 @@ function vipgoci_support_level_label_set(
 
 		/*
 		 * Loop through each label found for
-		 * Pull-Request, figure out if is support
+		 * pull request, figure out if is support
 		 * label, remove if not the same as is supposed
 		 * to be set.
 		 */
@@ -539,7 +539,7 @@ function vipgoci_support_level_label_set(
 			 * GitHub already.
 			 */
 			vipgoci_log(
-				'Correct support label already attached to Pull-Request, skipping',
+				'Correct support label already attached to pull request, skipping',
 				array(
 					'repo_owner'             => $options['repo-owner'],
 					'repo_name'              => $options['repo-name'],

--- a/tests/integration/PhpcsScanDoScanTest.php
+++ b/tests/integration/PhpcsScanDoScanTest.php
@@ -101,7 +101,7 @@ final class PhpcsScanDoScanTest extends TestCase {
 		unlink( $temp_file_path );
 
 		$this->assertSame(
-			'{"totals":{"errors":1,"warnings":1,"fixable":0},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":1,"warnings":1,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6},{"message":"`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.","source":"WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter","severity":5,"fixable":false,"type":"WARNING","line":4,"column":16}]}}}',
+			'{"totals":{"errors":1,"warnings":1,"fixable":0},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":1,"warnings":1,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6},{"message":"`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.","source":"WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter","severity":5,"fixable":false,"type":"WARNING","line":4,"column":16}]}}}' . PHP_EOL,
 			$phpcs_res
 		);
 	}
@@ -193,7 +193,7 @@ final class PhpcsScanDoScanTest extends TestCase {
 		unlink( $temp_file_path );
 
 		$this->assertSame(
-			'{"totals":{"errors":2,"warnings":1,"fixable":1},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":2,"warnings":1,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6},{"message":"`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.","source":"WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter","severity":5,"fixable":false,"type":"WARNING","line":4,"column":16},{"message":"Expected 1 space before array closer, found 5.","source":"WordPress.Arrays.ArrayDeclarationSpacing.SpaceBeforeArrayCloser","severity":5,"fixable":true,"type":"ERROR","line":5,"column":25}]}}}',
+			'{"totals":{"errors":2,"warnings":1,"fixable":1},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":2,"warnings":1,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6},{"message":"`strip_tags()` does not strip CSS and JS in between the script and style tags. Use `wp_strip_all_tags()` to strip all tags.","source":"WordPressVIPMinimum.Functions.StripTags.StripTagsOneParameter","severity":5,"fixable":false,"type":"WARNING","line":4,"column":16},{"message":"Expected 1 space before array closer, found 5.","source":"WordPress.Arrays.ArrayDeclarationSpacing.SpaceBeforeArrayCloser","severity":5,"fixable":true,"type":"ERROR","line":5,"column":25}]}}}' . PHP_EOL,
 			$phpcs_res
 		);
 	}
@@ -249,7 +249,7 @@ final class PhpcsScanDoScanTest extends TestCase {
 		unlink( $temp_file_path );
 
 		$this->assertSame(
-			'{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":1,"warnings":0,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6}]}}}',
+			'{"totals":{"errors":1,"warnings":0,"fixable":0},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":1,"warnings":0,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6}]}}}' . PHP_EOL,
 			$phpcs_res
 		);
 	}
@@ -324,7 +324,7 @@ final class PhpcsScanDoScanTest extends TestCase {
 		unlink( $temp_file_path );
 
 		$this->assertSame(
-			'{"totals":{"errors":2,"warnings":0,"fixable":1},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":2,"warnings":0,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6},{"message":"Expected 1 space before array closer, found 5.","source":"WordPress.Arrays.ArrayDeclarationSpacing.SpaceBeforeArrayCloser","severity":5,"fixable":true,"type":"ERROR","line":5,"column":25}]}}}',
+			'{"totals":{"errors":2,"warnings":0,"fixable":1},"files":{"' . addcslashes( $temp_file_path, '/' ) . '":{"errors":2,"warnings":0,"messages":[{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'time\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"type":"ERROR","line":2,"column":6},{"message":"Expected 1 space before array closer, found 5.","source":"WordPress.Arrays.ArrayDeclarationSpacing.SpaceBeforeArrayCloser","severity":5,"fixable":true,"type":"ERROR","line":5,"column":25}]}}}' . PHP_EOL,
 			$phpcs_res
 		);
 	}

--- a/tests/unit/GitHubMiscGithubPrsUrlsGetTest.php
+++ b/tests/unit/GitHubMiscGithubPrsUrlsGetTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Test vipgoci_github_prs_urls_get().
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class that implements the testing.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class GitHubMiscGithubPrsUrlsGetTest extends TestCase {
+	/**
+	 * Setup function. Require files, etc.
+	 */
+	protected function setUp() :void {
+		require_once __DIR__ . '/../../github-misc.php';
+		require_once __DIR__ . '/../../defines.php';
+	}
+
+	/**
+	 * Create and return mock pull requests.
+	 *
+	 * @return array Array of pull requests.
+	 */
+	private function createMockPullRequests() :array {
+		$pull_requests                          = array();
+		$pull_requests[0]                       = new \stdClass();
+		$pull_requests[0]->head                 = new \stdClass();
+		$pull_requests[0]->head->repo           = new \stdClass();
+		$pull_requests[0]->head->repo->html_url = 'https://github.com/test-owner/test-name';
+		$pull_requests[0]->number               = 100;
+
+		$pull_requests[1]         = clone $pull_requests[0];
+		$pull_requests[1]->number = 200;
+
+		$pull_requests[2]         = clone $pull_requests[0];
+		$pull_requests[2]->number = 300;
+
+		return $pull_requests;
+	}
+
+	/**
+	 * Test if function returns expected URLs to
+	 * pull requests.
+	 *
+	 * @covers ::vipgoci_github_prs_urls_get
+	 */
+	public function testPrsUrls(): void {
+		$pull_requests = $this->createMockPullRequests();
+
+		$prs_urls = vipgoci_github_prs_urls_get(
+			$pull_requests,
+			' -- '
+		);
+
+		$this->assertSame(
+			'https://github.com/test-owner/test-name/pull/100 --' .
+				' https://github.com/test-owner/test-name/pull/200 --' .
+				' https://github.com/test-owner/test-name/pull/300',
+			$prs_urls
+		);
+	}
+}

--- a/tests/unit/LogSysExitTest.php
+++ b/tests/unit/LogSysExitTest.php
@@ -75,7 +75,7 @@ final class LogSysExitTest extends TestCase {
 		 */
 		$printed_data_found = strpos(
 			$printed_data,
-			'Usage: Missing parameter;'
+			'"Usage: Missing parameter";'
 		);
 
 		$this->assertTrue(

--- a/tests/unit/MainRunScanLogSkippedFilesTest.php
+++ b/tests/unit/MainRunScanLogSkippedFilesTest.php
@@ -110,7 +110,7 @@ final class MainRunScanLogSkippedFilesTest extends TestCase {
 		$this->assertNotFalse(
 			strpos(
 				$printed_output,
-				'Too large file(s) was/were detected during analysis:'
+				'"Too large file(s) was\/were detected during analysis:'
 			),
 			'No message was logged about too large files'
 		);

--- a/tests/unit/MainRunScanSkipExecutionTest.php
+++ b/tests/unit/MainRunScanSkipExecutionTest.php
@@ -66,7 +66,7 @@ final class MainRunScanSkipExecutionTest extends TestCase {
 		 */
 		$printed_data_found = strpos(
 			$printed_data,
-			'Skipping scanning entirely, as determined by configuration;'
+			'"Skipping scanning entirely, as determined by configuration";'
 		);
 
 		$this->assertNotFalse(

--- a/tests/unit/ReportCreateScanDetailsSoftwareVersionsTest.php
+++ b/tests/unit/ReportCreateScanDetailsSoftwareVersionsTest.php
@@ -47,6 +47,7 @@ final class ReportCreateScanDetailsSoftwareVersionsTest extends TestCase {
 		$this->options['lint']         = false;
 		$this->options['phpcs']        = false;
 		$this->options['repo-options'] = false;
+		$this->options['svg-checks']   = false;
 
 		$actual_output = vipgoci_report_create_scan_details_software_versions(
 			$this->options
@@ -94,6 +95,13 @@ final class ReportCreateScanDetailsSoftwareVersionsTest extends TestCase {
 			)
 		);
 
+		$this->assertFalse(
+			strpos(
+				$actual_output,
+				'SVG scanner'
+			)
+		);
+
 		$this->assertNotFalse(
 			strpos(
 				$actual_output,
@@ -119,6 +127,8 @@ final class ReportCreateScanDetailsSoftwareVersionsTest extends TestCase {
 		$this->options['phpcs']                  = true;
 		$this->options['phpcs-path']             = '/usr/bin/phpcs';
 		$this->options['phpcs-php-path']         = '/usr/bin/php7.3';
+		$this->options['svg-checks']             = true;
+		$this->options['svg-php-path']           = '/usr/bin/php8.0';
 		$this->options['repo-options']           = true;
 		$this->options['repo-options-set']       = array(
 			'a' => 1,
@@ -197,6 +207,13 @@ final class ReportCreateScanDetailsSoftwareVersionsTest extends TestCase {
 			strpos(
 				$actual_output,
 				'<li>PHPCS version: <code>3.5.5</code></li>'
+			)
+		);
+
+		$this->assertNotFalse(
+			strpos(
+				$actual_output,
+				'<li>PHP runtime version for SVG scanner: <code>8.0.3</code></li>'
 			)
 		);
 

--- a/tests/unit/StatisticsRuntimeMeasureTest.php
+++ b/tests/unit/StatisticsRuntimeMeasureTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 // phpcs:disable PSR1.Files.SideEffects
 
-final class StatsRunTimeMeasureTest extends TestCase {
+final class StatisticsRuntimeMeasureTest extends TestCase {
 	/**
 	 * @covers ::vipgoci_runtime_measure
 	 */


### PR DESCRIPTION
This pull requests brings in a few updates to a number of areas, such as logging, garbage collection and retrying certain HTTP requests.

TODO:
- [x] Log URLs to pull requests implicated
- [x] Add logging for utility functions, PHP linting, PHPCS and more
- [x] Safer logging of message passed to `vipgoci_log()` 
- [x] Stop logging of auto-approvals to IRC
- [x] Move garbage collection to main.php
- [x] Rename test class to match file
- [x] Report PHP version used to execute SVG scanner
- [x] Retry HTTP requests to GitHub when the previous ones have failed due to 500 errors
- [x] Ensure all `vipgoci_sysexit()` calls have exit codes
- [x] Catch out of memory situations, log to IRC and post generic message
- [x] Add/update unit-tests
- [x] Changelog entry [ #259 ]
- [x] Check automated unit-tests
