### PR TITLE
Apply WP CS to tests and other updates: GitHubPrGenericSupportCommentTest.php, PhpcsScanValidateSniffsInOptionAndReportTest.php, Skeleton.php

### DIFF
--- a/tests/integration/GitHubPrGenericSupportCommentTest.php
+++ b/tests/integration/GitHubPrGenericSupportCommentTest.php
@@ -1,24 +1,50 @@
 <?php
+/**
+ * Test vipgoci_report_submit_pr_generic_support_comment() function.
+ *
+ * @package Automattic/vip-go-ci
+ */
 
-require_once( __DIR__ . '/IncludesForTests.php' );
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Integration;
 
 use PHPUnit\Framework\TestCase;
 
 /**
+ * Class that implements the testing.
+ *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
 final class GitHubPrGenericSupportCommentTest extends TestCase {
-	var $options_git = array(
-		'repo-owner'	=> null,
-		'repo-name'	=> null,
+	/**
+	 * Git options.
+	 *
+	 * @var $options_git
+	 */
+	private array $options_git = array(
+		'repo-owner' => null,
+		'repo-name'  => null,
 	);
 
-	var $options_git_repo_tests = array(
-		'test-github-pr-generic-support-comment-1'	=> null,
+	/**
+	 * Git repo tests options.
+	 *
+	 * @var $options_git_repo_tests
+	 */
+	private array $options_git_repo_tests = array(
+		'test-github-pr-generic-support-comment-1' => null,
 	);
 
+	/**
+	 * Setup function. Require file, set up variables, etc.
+	 *
+	 * @return void
+	 */
 	protected function setUp(): void {
+		require_once __DIR__ . '/IncludesForTests.php';
+
 		/*
 		 * Many of the functions called
 		 * make use of caching, clear the cache
@@ -41,13 +67,14 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 
 		$this->options = array();
 
-		$this->options['token'] =
 		$this->options['github-token'] =
 			vipgoci_unittests_get_config_value(
 				'git-secrets',
 				'github-token',
-				true // Fetch from secrets file
+				true // Fetch from secrets file.
 			);
+
+		$this->options['token'] = $this->options['github-token'];
 
 		$this->options['post-generic-pr-support-comments'] = true;
 
@@ -60,7 +87,6 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			array(
 				2 => 'This is a generic support message from `vip-go-ci`. We hope this is useful.',
 			);
-				
 
 		$this->options['post-generic-pr-support-comments-branches'] =
 			array(
@@ -68,8 +94,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			);
 
 		$this->options['post-generic-pr-support-comments-repo-meta-match'] =
-			array(
-			);
+			array();
 
 		$this->options = array_merge(
 			$this->options_git,
@@ -105,10 +130,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		);
 
 		if ( -1 !== $options_test ) {
-			$this->_clearOldSupportComments();
+			$this->clearOldSupportComments();
 		}
 	}
 
+	/**
+	 * Tear down function. Remove variables, etc.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
@@ -117,18 +147,20 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		);
 
 		if ( -1 !== $options_test ) {
-			$this->_clearOldSupportComments();
+			$this->clearOldSupportComments();
 		}
 
-		$this->options = null;
-		$this->options_git = null;
-		$this->options_git_repo_tests = null;
+		unset( $this->options );
+		unset( $this->options_git );
+		unset( $this->options_git_repo_tests );
 	}
 
-	/*
-	 * Get Pull-Requests implicated.
+	/**
+	 * Get pull requests implicated.
+	 *
+	 * @return array Pull requests.
 	 */
-	protected function _getPrsImplicated() {
+	protected function getPrsImplicated() :array {
 		vipgoci_unittests_output_suppress();
 
 		$ret = vipgoci_github_prs_implicated(
@@ -144,16 +176,20 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		return $ret;
 	}
 
-	/*
+	/**
 	 * Get generic comments made to a Pull-Request
 	 * from GitHub, uncached.
+	 *
+	 * @param int $pr_number Pull request number.
+	 *
+	 * @return array Comments.
 	 */
-	protected function _getPrGenericComments(
-		$pr_number
-	) {
+	protected function getPrGenericComments(
+		int $pr_number
+	) :array {
 		$pr_comments_ret = array();
 
-		$page = 1;
+		$page     = 1;
 		$per_page = 100;
 
 		do {
@@ -163,10 +199,10 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				rawurlencode( $this->options['repo-owner'] ) . '/' .
 				rawurlencode( $this->options['repo-name'] ) . '/' .
 				'issues/' .
-				rawurlencode( $pr_number ) . '/' .
+				rawurlencode( (string) $pr_number ) . '/' .
 				'comments' .
-				'?page=' . rawurlencode( $page ) . '&' .
-				'per_page=' . rawurlencode( $per_page );
+				'?page=' . rawurlencode( (string) $page ) . '&' .
+				'per_page=' . rawurlencode( (string) $per_page );
 
 			$pr_comments_raw = json_decode(
 				vipgoci_http_api_fetch_url(
@@ -180,25 +216,29 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			}
 
 			$page++;
-		} while ( count( $pr_comments_raw ) >= $per_page );
+
+			$pr_comments_raw_cnt = count( $pr_comments_raw );
+		} while ( $pr_comments_raw_cnt >= $per_page );
 
 		return $pr_comments_ret;
 	}
 
-	/*
+	/**
 	 * Clear away any old support comments
 	 * left behind by us. Do this by looping
 	 * through any Pull-Requests implicated and
 	 * check if each one has any comments, then
 	 * remove them if they were made by us and
 	 * are support comments.
+	 *
+	 * @return void
 	 */
-	protected function _clearOldSupportComments() {
-		$prs_implicated = $this->_getPrsImplicated();
+	protected function clearOldSupportComments() :void {
+		$prs_implicated = $this->getPrsImplicated();
 
-		foreach( $prs_implicated as $pr_item ) {
-			// Check if any comments already exist
-			$pr_comments = $this->_getPrGenericComments(
+		foreach ( $prs_implicated as $pr_item ) {
+			// Check if any comments already exist.
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -207,14 +247,14 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 					continue;
 				}
 
-				// Look for a support-comment
-				foreach(
+				// Look for a support-comment.
+				foreach (
 					array_values(
 						$this->options['post-generic-pr-support-comments-string']
 					)
 					as $tmp_support_comment_string
 				) {
-					// Check if the comment contains the support-comment
+					// Check if the comment contains the support-comment.
 					if ( strpos(
 						$pr_comment->body,
 						$tmp_support_comment_string
@@ -234,33 +274,37 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		}
 	}
 
-	/*
+	/**
 	 * Count number of support comments posted
 	 * by the current token-holder.
+	 *
+	 * @param array $pr_comments Comments to inspect.
+	 *
+	 * @return int Number of comments posted by token-holder.
 	 */
-	protected function _countSupportCommentsFromUs(
-		$pr_comments
-	) {	
+	protected function countSupportCommentsFromUs(
+		array $pr_comments
+	) :int {
 		$valid_comments_found = 0;
 
-		foreach( $pr_comments as $pr_comment ) {
+		foreach ( $pr_comments as $pr_comment ) {
 			if ( $pr_comment->user->login !== $this->current_user_info->login ) {
 				continue;
 			}
 
-			// Check if the comment contains the support-comment
-			foreach(
+			// Check if the comment contains the support-comment.
+			foreach (
 				array_values(
 					$this->options['post-generic-pr-support-comments-string']
 				)
 				as $tmp_support_comment_string
 			) {
-				// Check if the comment contains the support-comment
+				// Check if the comment contains the support-comment.
 				if ( strpos(
 					$pr_comment->body,
 					$tmp_support_comment_string
 				) === 0 ) {
-					// We have found support comment posted by us
+					// We have found support comment posted by us.
 					$valid_comments_found++;
 					break;
 				}
@@ -271,9 +315,13 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 	}
 
 	/**
+	 * Should not post generic support comments.
+	 *
+	 * @return void
+	 *
 	 * @covers ::vipgoci_report_submit_pr_generic_support_comment
 	 */
-	public function testPostingNotConfigured() {
+	public function testPostingNotConfigured() :void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array(),
@@ -283,20 +331,20 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		if ( -1 === $options_test ) {
 			return;
 		}
-	
-		// Configure branches we can post against
+
+		// Configure branches we can post against.
 		$this->options['post-generic-pr-support-comments-branches'] =
 			array(
 				2 => array( 'any' ),
 			);
 
-		// Should not post generic support comments
+		// Should not post generic support comments.
 		$this->options['post-generic-pr-support-comments'] = false;
 
-		// Get Pull-Requests
-		$prs_implicated = $this->_getPrsImplicated();
+		// Get pull requests.
+		$prs_implicated = $this->getPrsImplicated();
 
-		// Check we have at least one PR
+		// Check we have at least one PR.
 		$this->assertTrue(
 			count( $prs_implicated ) > 0
 		);
@@ -313,15 +361,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			VIPGOCI_CACHE_CLEAR
 		);
 
-		// Try to submit support comment
+		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// Check if commenting succeeded
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// Check if commenting succeeded.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -331,21 +379,26 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 
 			$this->assertSame(
 				0,
-				$this->_countSupportCommentsFromUs(
+				$this->countSupportCommentsFromUs(
 					$pr_comments
 				)
 			);
 		}
-	
+
 		vipgoci_cache(
 			VIPGOCI_CACHE_CLEAR
 		);
 	}
 
 	/**
+	 * Should post generic support comments to all branches,
+	 * but not drafts.
+	 *
+	 * @return void
+	 *
 	 * @covers ::vipgoci_report_submit_pr_generic_support_comment
 	 */
-	public function testPostingWorksAnyBranch() {
+	public function testPostingWorksAnyBranch() :void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array(),
@@ -356,53 +409,51 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			return;
 		}
 
-		// Configure branches we can post against
+		// Configure branches we can post against.
 		$this->options['post-generic-pr-support-comments-branches'] =
 			array(
 				2 => array( 'any' ),
 			);
 
-		// Get Pull-Requests
-		$prs_implicated = $this->_getPrsImplicated();
+		// Get pull requests.
+		$prs_implicated = $this->getPrsImplicated();
 
-		// Check we have at least one PR
+		// Check we have at least one PR.
 		$this->assertTrue(
 			count( $prs_implicated ) > 0
 		);
 
-		// Try to submit support comment
+		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// Check if commenting succeeded
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// Check if commenting succeeded.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
-			if ( $pr_item->draft === true ) {
+			if ( true === $pr_item->draft ) {
 				$this->assertTrue(
 					count( $pr_comments ) === 0
 				);
 
 				$this->assertSame(
 					0,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
-			}
-
-			else {
+			} else {
 				$this->assertTrue(
 					count( $pr_comments ) > 0
 				);
 
 				$this->assertSame(
 					1,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
@@ -416,40 +467,38 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		vipgoci_cache(
 			VIPGOCI_CACHE_CLEAR
 		);
-		
-		// Try re-posting
+
+		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// And make sure it did not succeed
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// And make sure it did not succeed.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
-			if ( $pr_item->draft === true ) {
+			if ( true === $pr_item->draft ) {
 				$this->assertTrue(
 					count( $pr_comments ) === 0
 				);
 
 				$this->assertSame(
 					0,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
-			}
-
-			else {
+			} else {
 				$this->assertTrue(
 					count( $pr_comments ) > 0
 				);
 
 				$this->assertSame(
 					1,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
@@ -458,9 +507,13 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 	}
 
 	/**
+	 * Should post generic support comments to specific branches.
+	 *
+	 * @return void
+	 *
 	 * @covers ::vipgoci_report_submit_pr_generic_support_comment
 	 */
-	public function testPostingWorksSpecificBranch() {
+	public function testPostingWorksSpecificBranch() :void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array(),
@@ -471,53 +524,51 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			return;
 		}
 
-		// Configure branches we allow posting against
+		// Configure branches we allow posting against.
 		$this->options['post-generic-pr-support-comments-branches'] =
 			array(
 				2 => array( 'master' ),
 			);
 
-		// Get Pull-Requests
-		$prs_implicated = $this->_getPrsImplicated();
+		// Get pull requests.
+		$prs_implicated = $this->getPrsImplicated();
 
-		// Check we have at least one PR
+		// Check we have at least one PR.
 		$this->assertTrue(
 			count( $prs_implicated ) > 0
 		);
 
-		// Try to submit support comment
+		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// Check if commenting succeeded
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// Check if commenting succeeded.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
-			if ( $pr_item->draft === true ) {
+			if ( true === $pr_item->draft ) {
 				$this->assertTrue(
 					count( $pr_comments ) === 0
 				);
 
 				$this->assertSame(
 					0,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
-			}
-
-			else {
+			} else {
 				$this->assertTrue(
 					count( $pr_comments ) > 0
 				);
 
 				$this->assertSame(
 					1,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
@@ -531,40 +582,38 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		vipgoci_cache(
 			VIPGOCI_CACHE_CLEAR
 		);
-		
-		// Try re-posting
+
+		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// And make sure it did not succeed
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// And make sure it did not succeed.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
-			if ( $pr_item->draft === true ) {
+			if ( true === $pr_item->draft ) {
 				$this->assertTrue(
 					count( $pr_comments ) === 0
 				);
-	
+
 				$this->assertSame(
 					0,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
-			}
-
-			else {
+			} else {
 				$this->assertTrue(
 					count( $pr_comments ) > 0
 				);
 
 				$this->assertSame(
 					1,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
@@ -573,9 +622,13 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 	}
 
 	/**
+	 * Posting of support comment skipped, branch invalid.
+	 *
+	 * @return void
+	 *
 	 * @covers ::vipgoci_report_submit_pr_generic_support_comment
 	 */
-	public function testPostingSkippedInvalidBranch() {
+	public function testPostingSkippedInvalidBranch() :void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array(),
@@ -586,35 +639,35 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			return;
 		}
 
-		// Configure branches to post against
+		// Configure branches to post against.
 		$this->options['post-generic-pr-support-comments-branches'] =
 			array(
 				2 => array( 'myinvalidbranch0xfff' ),
 			);
 
-		// Get Pull-Requests
-		$prs_implicated = $this->_getPrsImplicated();
+		// Get pull requests.
+		$prs_implicated = $this->getPrsImplicated();
 
-		// Check we have at least one PR
+		// Check we have at least one PR.
 		$this->assertTrue(
 			count( $prs_implicated ) > 0
 		);
 
-		// Try to submit support comment
+		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// Check if commenting succeeded -- should not have, as branch is invalid
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// Check if commenting succeeded -- should not have, as branch is invalid.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
 			$this->assertSame(
 				0,
-				$this->_countSupportCommentsFromUs(
+				$this->countSupportCommentsFromUs(
 					$pr_comments
 				)
 			);
@@ -627,22 +680,22 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		vipgoci_cache(
 			VIPGOCI_CACHE_CLEAR
 		);
-		
-		// Try re-posting
+
+		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// And make sure it did not succeed the second time
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// And make sure it did not succeed the second time.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
 			$this->assertSame(
 				0,
-				$this->_countSupportCommentsFromUs(
+				$this->countSupportCommentsFromUs(
 					$pr_comments
 				)
 			);
@@ -650,9 +703,13 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 	}
 
 	/**
+	 * Posting of support comment succeeds with draft pull request.
+	 *
+	 * @return void
+	 *
 	 * @covers ::vipgoci_report_submit_pr_generic_support_comment
 	 */
-	public function testPostingWorksWithDraftPRs() {
+	public function testPostingWorksWithDraftPRs() :void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array(),
@@ -663,53 +720,51 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			return;
 		}
 
-		// Configure branches we can post against
+		// Configure branches we can post against.
 		$this->options['post-generic-pr-support-comments-branches'] =
 			array(
 				2 => array( 'any' ),
 			);
 
-		// Get Pull-Requests
-		$prs_implicated = $this->_getPrsImplicated();
+		// Get pull requests.
+		$prs_implicated = $this->getPrsImplicated();
 
-		// Check we have at least one PR
+		// Check we have at least one PR.
 		$this->assertTrue(
 			count( $prs_implicated ) > 0
 		);
 
-		// Try to submit support comment
+		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// Check if commenting succeeded
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// Check if commenting succeeded.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
-			if ( $pr_item->draft === true ) {
+			if ( true === $pr_item->draft ) {
 				$this->assertTrue(
 					count( $pr_comments ) === 0
 				);
-	
+
 				$this->assertSame(
 					0,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
-			}
-
-			else {
+			} else {
 				$this->assertTrue(
 					count( $pr_comments ) > 0
 				);
 
 				$this->assertSame(
 					1,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
@@ -723,40 +778,38 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		vipgoci_cache(
 			VIPGOCI_CACHE_CLEAR
 		);
-		
-		// Try re-posting
+
+		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// And make sure it did not succeed
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// And make sure it did not succeed.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
-			if ( $pr_item->draft === true ) {
+			if ( true === $pr_item->draft ) {
 				$this->assertTrue(
 					count( $pr_comments ) === 0
 				);
-	
+
 				$this->assertSame(
 					0,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
-			}
-
-			else {
+			} else {
 				$this->assertTrue(
 					count( $pr_comments ) > 0
 				);
 
 				$this->assertSame(
 					1,
-					$this->_countSupportCommentsFromUs(
+					$this->countSupportCommentsFromUs(
 						$pr_comments
 					)
 				);
@@ -771,20 +824,20 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			VIPGOCI_CACHE_CLEAR
 		);
 
-		// Post on draft PRs
+		// Post on draft PRs.
 		$this->options['post-generic-pr-support-comments-on-drafts'] = array(
 			2 => true,
 		);
 
-		// Try re-posting
+		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// And make sure it did succeed
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// And make sure it did succeed.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -794,7 +847,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 
 			$this->assertSame(
 				1,
-				$this->_countSupportCommentsFromUs(
+				$this->countSupportCommentsFromUs(
 					$pr_comments
 				)
 			);
@@ -802,9 +855,13 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 	}
 
 	/**
+	 * Should skip submitting support comment when label is in place.
+	 *
+	 * @return void
+	 *
 	 * @covers ::vipgoci_report_submit_pr_generic_support_comment
 	 */
-	public function testPostingWorksWithLabels() {
+	public function testPostingWorksWithLabels() :void {
 		$test_label = 'my-random-label-1596640824';
 
 		$options_test = vipgoci_unittests_options_test(
@@ -817,7 +874,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			return;
 		}
 
-		// Configure branches we can post against
+		// Configure branches we can post against.
 		$this->options['post-generic-pr-support-comments-branches'] =
 			array(
 				2 => array( 'any' ),
@@ -827,25 +884,25 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			2 => $test_label,
 		);
 
-		// Get Pull-Requests
-		$prs_implicated = $this->_getPrsImplicated();
+		// Get pull requests.
+		$prs_implicated = $this->getPrsImplicated();
 
-		// Check we have at least one PR
+		// Check we have at least one PR.
 		$this->assertTrue(
 			count( $prs_implicated ) > 0
 		);
 
-		foreach( $prs_implicated as $pr_item ) {
-			// Make sure there are no comments
-			$pr_comments = $this->_getPrGenericComments(
+		foreach ( $prs_implicated as $pr_item ) {
+			// Make sure there are no comments.
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
 			$this->assertTrue(
 				count( $pr_comments ) === 0
 			);
-	
-			// Add label to make sure no comment is posted
+
+			// Add label to make sure no comment is posted.
 			vipgoci_github_label_add_to_pr(
 				$this->options['repo-owner'],
 				$this->options['repo-name'],
@@ -855,25 +912,25 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			);
 		}
 
-		// Try to submit support comment
+		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// Make sure commenting did not succeed
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// Make sure commenting did not succeed.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
 			$this->assertTrue(
 				count( $pr_comments ) === 0
 			);
-	
+
 			$this->assertSame(
 				0,
-				$this->_countSupportCommentsFromUs(
+				$this->countSupportCommentsFromUs(
 					$pr_comments
 				)
 			);
@@ -886,16 +943,16 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		vipgoci_cache(
 			VIPGOCI_CACHE_CLEAR
 		);
-		
-		// Try re-posting
+
+		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// And make sure it did not succeed
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// And make sure it did not succeed.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -905,7 +962,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 
 			$this->assertSame(
 				0,
-				$this->_countSupportCommentsFromUs(
+				$this->countSupportCommentsFromUs(
 					$pr_comments
 				)
 			);
@@ -919,20 +976,20 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			VIPGOCI_CACHE_CLEAR
 		);
 
-		// Post on draft PRs
+		// Post on draft PRs.
 		$this->options['post-generic-pr-support-comments-on-drafts'] = array(
 			2 => true,
 		);
 
-		// Try re-posting
+		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
 
-		// And make sure it did not succeed
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		// And make sure it did not succeed.
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -942,7 +999,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 
 			$this->assertSame(
 				0,
-				$this->_countSupportCommentsFromUs(
+				$this->countSupportCommentsFromUs(
 					$pr_comments
 				)
 			);

--- a/tests/integration/GitHubPrGenericSupportCommentTest.php
+++ b/tests/integration/GitHubPrGenericSupportCommentTest.php
@@ -168,19 +168,18 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				'?page=' . rawurlencode( $page ) . '&' .
 				'per_page=' . rawurlencode( $per_page );
 
+			$pr_comments_raw = json_decode(
+				vipgoci_http_api_fetch_url(
+					$github_url,
+					$this->options['github-token']
+				)
+			);
 
-	                $pr_comments_raw = json_decode(
-	                        vipgoci_http_api_fetch_url(
-        	                        $github_url,
-                	                $this->options['github-token']
-                        	)
-	                );
+			foreach ( $pr_comments_raw as $pr_comment ) {
+				$pr_comments_ret[] = $pr_comment;
+			}
 
-	                foreach ( $pr_comments_raw as $pr_comment ) {
-	                        $pr_comments_ret[] = $pr_comment;
-        	        }
-
-	                $page++;
+			$page++;
 		} while ( count( $pr_comments_raw ) >= $per_page );
 
 		return $pr_comments_ret;
@@ -295,7 +294,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		$this->options['post-generic-pr-support-comments'] = false;
 
 		// Get Pull-Requests
-        	$prs_implicated = $this->_getPrsImplicated();
+		$prs_implicated = $this->_getPrsImplicated();
 
 		// Check we have at least one PR
 		$this->assertTrue(
@@ -364,7 +363,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			);
 
 		// Get Pull-Requests
-        	$prs_implicated = $this->_getPrsImplicated();
+		$prs_implicated = $this->_getPrsImplicated();
 
 		// Check we have at least one PR
 		$this->assertTrue(
@@ -479,7 +478,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			);
 
 		// Get Pull-Requests
-        	$prs_implicated = $this->_getPrsImplicated();
+		$prs_implicated = $this->_getPrsImplicated();
 
 		// Check we have at least one PR
 		$this->assertTrue(
@@ -594,7 +593,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			);
 
 		// Get Pull-Requests
-        	$prs_implicated = $this->_getPrsImplicated();
+		$prs_implicated = $this->_getPrsImplicated();
 
 		// Check we have at least one PR
 		$this->assertTrue(
@@ -671,7 +670,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			);
 
 		// Get Pull-Requests
-        	$prs_implicated = $this->_getPrsImplicated();
+		$prs_implicated = $this->_getPrsImplicated();
 
 		// Check we have at least one PR
 		$this->assertTrue(
@@ -829,7 +828,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		);
 
 		// Get Pull-Requests
-        	$prs_implicated = $this->_getPrsImplicated();
+		$prs_implicated = $this->_getPrsImplicated();
 
 		// Check we have at least one PR
 		$this->assertTrue(

--- a/tests/integration/PhpcsScanValidateSniffsInOptionAndReportTest.php
+++ b/tests/integration/PhpcsScanValidateSniffsInOptionAndReportTest.php
@@ -1,47 +1,65 @@
 <?php
+/**
+ * Test vipgoci_phpcs_validate_sniffs_in_options_and_report() function.
+ *
+ * @package Automattic/vip-go-ci
+ */
 
-require_once( __DIR__ . '/IncludesForTests.php' );
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Integration;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class that implements the testing.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
-	var $options_phpcs = array(
-		'phpcs-path'
-			=> null,
-
-		'phpcs-php-path'
-			=> null,
-
-		'phpcs-standard'
-			=> null,
-
-		'phpcs-validate-sniffs-and-report-include-commit'
-			=> null,
-
-		'phpcs-validate-sniffs-and-report-include-invalid'
-			=> null,
-
-		'phpcs-validate-sniffs-and-report-include-valid'
-			=> null,
-
-		'phpcs-validate-sniffs-and-report-exclude-commit'
-			=> null,
-
-		'phpcs-validate-sniffs-and-report-exclude-invalid'
-			=> null,
-
-		'phpcs-validate-sniffs-and-report-exclude-valid'
-			=> null,
+	/**
+	 * PHPCS options.
+	 *
+	 * @var $options_phpcs
+	 */
+	private array $options_phpcs = array(
+		'phpcs-path'                                       => null,
+		'phpcs-php-path'                                   => null,
+		'phpcs-standard'                                   => null,
+		'phpcs-validate-sniffs-and-report-include-commit'  => null,
+		'phpcs-validate-sniffs-and-report-include-invalid' => null,
+		'phpcs-validate-sniffs-and-report-include-valid'   => null,
+		'phpcs-validate-sniffs-and-report-exclude-commit'  => null,
+		'phpcs-validate-sniffs-and-report-exclude-invalid' => null,
+		'phpcs-validate-sniffs-and-report-exclude-valid'   => null,
 	);
 
-	var $options_git = array(
-		'repo-owner'	=> null,
-		'repo-name'	=> null,
+	/**
+	 * Git options.
+	 *
+	 * @var $options_git
+	 */
+	private array $options_git = array(
+		'repo-owner' => null,
+		'repo-name'  => null,
 	);
 
-	var $current_user_info = null;
+	/**
+	 * Information about current token holder.
+	 *
+	 * @var $current_user_info
+	 */
+	private null|object $current_user_info = null;
 
+	/**
+	 * Setup function. Require files, set variables, etc.
+	 *
+	 * @return void
+	 */
 	protected function setUp(): void {
+		require_once __DIR__ . '/IncludesForTests.php';
+
 		vipgoci_unittests_get_config_values(
 			'phpcs-scan',
 			$this->options_phpcs
@@ -57,11 +75,11 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			$this->options_git
 		);
 
-		$this->options[ 'github-token' ] =
+		$this->options['github-token'] =
 			vipgoci_unittests_get_config_value(
 				'git-secrets',
 				'github-token',
-				true // Fetch from secrets file
+				true // Fetch from secrets file.
 			);
 
 		$this->options['token'] =
@@ -74,7 +92,7 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		$this->options['phpcs-sniffs-include'] = array();
 		$this->options['phpcs-sniffs-exclude'] = array();
 
-		foreach(
+		foreach (
 			array(
 				'phpcs-validate-sniffs-and-report-include-valid',
 				'phpcs-validate-sniffs-and-report-include-invalid',
@@ -92,7 +110,7 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			$this->options['phpcs-validate-sniffs-and-report-include-valid'],
 			$this->options['phpcs-validate-sniffs-and-report-include-invalid']
 		);
-	
+
 		$this->options['phpcs-validate-sniffs-and-report-exclude-valid-and-invalid'] = array_merge(
 			$this->options['phpcs-validate-sniffs-and-report-exclude-valid'],
 			$this->options['phpcs-validate-sniffs-and-report-exclude-invalid']
@@ -117,16 +135,26 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		$this->options['skip-draft-prs'] = false;
 	}
 
+	/**
+	 * Tear down function, clean up.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
-		$this->options_phpcs = null;
-		$this->options_git = null;
-		$this->options = null;
+		unset( $this->options_phpcs );
+		unset( $this->options_git );
+		unset( $this->options );
 	}
 
 	/**
+	 * Test function with sniffs being included and verify
+	 * that errors are posted to pull request.
+	 *
+	 * @return void
+	 *
 	 * @covers ::vipgoci_phpcs_validate_sniffs_in_options_and_report
 	 */
-	public function testPhpcsValidateIncludeSniffsWithErrors() {
+	public function testPhpcsValidateIncludeSniffsWithErrors() :void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array(),
@@ -165,11 +193,11 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		);
 
 		/*
-		 * For each Pull-Request, check
+		 * For each pull request, check
 		 * that it has no comments.
 		 */
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -193,7 +221,7 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		/*
-		 * For each Pull-Request implicated,
+		 * For each pull request implicated,
 		 * there should be at least one generic
 		 * comment about invalid sniffs. Check
 		 * those are in place and remove.
@@ -204,8 +232,8 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			count( $prs_implicated )
 		);
 
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -217,12 +245,12 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			$removed_comments = 0;
 
 			foreach ( $pr_comments as $pr_comment ) {
-				// Make sure it is from the current token holder
+				// Make sure it is from the current token holder.
 				if ( $pr_comment->user->login !== $this->current_user_info->login ) {
 					continue;
 				}
 
-				// Check if the comment is about invalid sniffs
+				// Check if the comment is about invalid sniffs.
 				if ( strpos(
 					$pr_comment->body,
 					VIPGOCI_PHPCS_INVALID_SNIFFS
@@ -230,14 +258,13 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 					continue;
 				}
 
-				// Check if at least one invalid sniff-name is found in the comment
+				// Check if at least one invalid sniff-name is found in the comment.
 				if ( strpos(
 					$pr_comment->body,
 					$this->options['phpcs-validate-sniffs-and-report-include-invalid'][0]
 				) === false ) {
 					continue;
 				}
-
 
 				vipgoci_unittests_output_suppress();
 
@@ -254,7 +281,7 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 				$removed_comments++;
 			}
 
-			// Make sure we removed one comment
+			// Make sure we removed one comment.
 			$this->assertSame(
 				1,
 				$removed_comments
@@ -268,9 +295,14 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 	}
 
 	/**
+	 * Test function with sniffs being included and verify that
+	 * no errors are posted to pull request.
+	 *
+	 * @return void
+	 *
 	 * @covers ::vipgoci_phpcs_validate_sniffs_in_options_and_report
 	 */
-	public function testPhpcsValidateIncludeSniffsNoErrors() {
+	public function testPhpcsValidateIncludeSniffsNoErrors() :void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array(),
@@ -309,11 +341,11 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		);
 
 		/*
-		 * For each Pull-Request, check
+		 * For each pull request, check
 		 * that it has no comments.
 		 */
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -337,9 +369,9 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		/*
-		 * For each Pull-Request implicated,
+		 * For each pull request implicated,
 		 * there should be no generic comments
-		 * comment about invalid sniffs.
+		 * about invalid sniffs.
 		 */
 
 		$this->assertGreaterThanOrEqual(
@@ -347,8 +379,8 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			count( $prs_implicated )
 		);
 
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -365,9 +397,14 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 	}
 
 	/**
+	 * Test function with sniffs being excluded, some errors should
+	 * be posted to pull request.
+	 *
+	 * @return void
+	 *
 	 * @covers ::vipgoci_phpcs_validate_sniffs_in_options_and_report
 	 */
-	public function testPhpcsValidateExcludeSniffsWithErrors() {
+	public function testPhpcsValidateExcludeSniffsWithErrors() :void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array(),
@@ -406,11 +443,11 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		);
 
 		/*
-		 * For each Pull-Request, check
+		 * For each pull request, check
 		 * that it has no comments.
 		 */
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -434,7 +471,7 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		/*
-		 * For each Pull-Request implicated,
+		 * For each pull request implicated,
 		 * there should be at least one generic
 		 * comment about invalid sniffs. Check
 		 * those are in place and remove.
@@ -445,8 +482,8 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			count( $prs_implicated )
 		);
 
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -458,12 +495,12 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			$removed_comments = 0;
 
 			foreach ( $pr_comments as $pr_comment ) {
-				// Make sure it is from the current token holder
+				// Make sure it is from the current token holder.
 				if ( $pr_comment->user->login !== $this->current_user_info->login ) {
 					continue;
 				}
 
-				// Check if the comment is about invalid sniffs
+				// Check if the comment is about invalid sniffs.
 				if ( strpos(
 					$pr_comment->body,
 					VIPGOCI_PHPCS_INVALID_SNIFFS
@@ -471,14 +508,13 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 					continue;
 				}
 
-				// Check if at least one invalid sniff-name is found in the comment
+				// Check if at least one invalid sniff-name is found in the comment.
 				if ( strpos(
 					$pr_comment->body,
 					$this->options['phpcs-validate-sniffs-and-report-exclude-invalid'][0]
 				) === false ) {
 					continue;
 				}
-
 
 				vipgoci_unittests_output_suppress();
 
@@ -495,7 +531,7 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 				$removed_comments++;
 			}
 
-			// Make sure we removed one comment
+			// Make sure we removed one comment.
 			$this->assertSame(
 				1,
 				$removed_comments
@@ -509,9 +545,14 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 	}
 
 	/**
+	 * Test function with sniffs being excluded, no errors should be
+	 * posted to pull request.
+	 *
+	 * @return void
+	 *
 	 * @covers ::vipgoci_phpcs_validate_sniffs_in_options_and_report
 	 */
-	public function testPhpcsValidateExcludeSniffsNoErrors() {
+	public function testPhpcsValidateExcludeSniffsNoErrors() :void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array(),
@@ -550,11 +591,11 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		);
 
 		/*
-		 * For each Pull-Request, check
+		 * For each pull request, check
 		 * that it has no comments.
 		 */
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -578,7 +619,7 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		/*
-		 * For each Pull-Request implicated,
+		 * For each pull request implicated,
 		 * there should be no generic comments
 		 * comment about invalid sniffs.
 		 */
@@ -588,8 +629,8 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			count( $prs_implicated )
 		);
 
-		foreach( $prs_implicated as $pr_item ) {
-			$pr_comments = $this->_getPrGenericComments(
+		foreach ( $prs_implicated as $pr_item ) {
+			$pr_comments = $this->getPrGenericComments(
 				$pr_item->number
 			);
 
@@ -605,16 +646,18 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		);
 	}
 
-	/*
-	 * Get generic comments made to a Pull-Request
+	/**
+	 * Get generic comments made to a pull request
 	 * from GitHub, uncached.
+	 *
+	 * @param int $pr_number Pull request number.
+	 *
+	 * @return array Comments made to pull request.
 	 */
-	protected function _getPrGenericComments(
-		$pr_number
-	) {
+	protected function getPrGenericComments( $pr_number ) :array {
 		$pr_comments_ret = array();
 
-		$page = 1;
+		$page     = 1;
 		$per_page = 100;
 
 		do {
@@ -624,10 +667,10 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 				rawurlencode( $this->options['repo-owner'] ) . '/' .
 				rawurlencode( $this->options['repo-name'] ) . '/' .
 				'issues/' .
-				rawurlencode( $pr_number ) . '/' .
+				rawurlencode( (string) $pr_number ) . '/' .
 				'comments' .
-				'?page=' . rawurlencode( $page ) . '&' .
-				'per_page=' . rawurlencode( $per_page );
+				'?page=' . rawurlencode( (string) $page ) . '&' .
+				'per_page=' . rawurlencode( (string) $per_page );
 
 			$pr_comments_raw = json_decode(
 				vipgoci_http_api_fetch_url(
@@ -641,7 +684,9 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			}
 
 			$page++;
-		} while ( count( $pr_comments_raw ) >= $per_page );
+
+			$pr_comments_raw_cnt = count( $pr_comments_raw );
+		} while ( $pr_comments_raw_cnt >= $per_page );
 
 		return $pr_comments_ret;
 	}

--- a/tests/integration/Skeleton.php
+++ b/tests/integration/Skeleton.php
@@ -26,6 +26,8 @@ final class Skeleton extends TestCase {
 	 * Setup function. Require files, etc.
 	 *
 	 * All files should be required here. See README.md.
+	 *
+	 * @return void
 	 */
 	protected function setUp() :void {
 		require_once __DIR__ . '/IncludesForTests.php';
@@ -35,6 +37,8 @@ final class Skeleton extends TestCase {
 	 * Short description of the function.
 	 *
 	 * @covers ::
+	 *
+	 * @return void
 	 */
 	public function testName(): void {
 	}

--- a/tests/unit/Skeleton.php
+++ b/tests/unit/Skeleton.php
@@ -26,6 +26,8 @@ final class Skeleton extends TestCase {
 	 * Setup function. Require files, etc.
 	 *
 	 * All files should be required here. See README.md.
+	 *
+	 * @return void
 	 */
 	protected function setUp() :void {
 		require_once __DIR__ . '/../../FILE-TO-BE-TESTED';
@@ -35,6 +37,8 @@ final class Skeleton extends TestCase {
 	 * Short description of the function.
 	 *
 	 * @covers ::
+	 *
+	 * @return void
 	 */
 	public function testName(): void {
 	}


### PR DESCRIPTION
Update a few tests in relation to work in #260. 

TODO:
- [x] Apply WP CS:
   - [x] `GitHubPrGenericSupportCommentTest.php`
   - [x] `PhpcsScanValidateSniffsInOptionAndReportTest.php`
- [x] Rename functions due to changes in #260, etc.
- [x] Ensure `Skeleton.php` files specify `@return`
- [x] Check automated unit-tests
- [x] Changelog entry (for VIP) [ #262 ]

