### PR TITLE
Use exec() instead of shell_exec(), use result code

### DIFF
--- a/file-validation.php
+++ b/file-validation.php
@@ -69,12 +69,18 @@ function vipgoci_is_number_of_lines_valid( string $temp_file_name, string $file_
 	 * if it is > than the default limit (defined at defined)
 	 * the bot won't scan it
 	 */
-	$cmd = sprintf( 'wc -l %s | awk \'{print $1;}\' 2>&1', escapeshellcmd( $temp_file_name ) );
+	$cmd = sprintf( 'wc -l %s | awk \'{print $1;}\'', escapeshellcmd( $temp_file_name ) );
 
+	$output_2        = '';
+	$output_res_code = -255;
 
-	$output = vipgoci_runtime_measure_shell_exec_with_retry(
+	$output = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'file_validation'
+		array( 0 ),
+		$output_2,
+		$output_res_code,
+		'file_validation',
+		true
 	);
 
 	vipgoci_log(

--- a/git-repo.php
+++ b/git-repo.php
@@ -139,14 +139,14 @@ function vipgoci_gitrepo_get_head( $local_git_repo ) {
 	/*
 	 * Actually execute
 	 */
-	$result_output      = '';
-	$result_status_code = -255;
+	$result_output = '';
+	$result_code   = -255;
 
 	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
 		array( 0 ),
 		$result_output,
-		$result_status_code,
+		$result_code,
 		'git_cli',
 		false
 	);
@@ -633,14 +633,14 @@ function vipgoci_gitrepo_get_file_at_commit(
 	/*
 	 * Actually execute
 	 */
-	$result_output      = '';
-	$result_status_code = -255;
+	$result_output = '';
+	$result_code   = -255;
 
 	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
 		array( 0, 128 ),
 		$result_output,
-		$result_status_code,
+		$result_code,
 		'git_cli',
 		true
 	);
@@ -687,14 +687,14 @@ function vipgoci_gitrepo_submodules_setup( $local_git_repo ) {
 	/*
 	 * Actually execute
 	 */
-	$result_output      = '';
-	$result_status_code = -255;
+	$result_output = '';
+	$result_code   = -255;
 
 	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
 		array( 0 ),
 		$result_output,
-		$result_status_code,
+		$result_code,
 		'git_cli',
 		true
 	);
@@ -743,14 +743,14 @@ function vipgoci_gitrepo_submodules_list( $local_git_repo ) {
 	/*
 	 * Actually execute
 	 */
-	$result_output      = '';
-	$result_status_code = -255;
+	$result_output = '';
+	$result_code   = -255;
 
 	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
 		array( 0 ),
 		$result_output,
-		$result_status_code,
+		$result_code,
 		'git_cli',
 		true
 	);
@@ -999,14 +999,14 @@ function vipgoci_gitrepo_diffs_fetch_unfiltered(
 	/*
 	 * Actually execute.
 	 */
-	$git_diff_results_output      = '';
-	$git_diff_results_status_code = -255;
+	$git_diff_results_output = '';
+	$git_diff_results_code   = -255;
 
 	$git_diff_results = vipgoci_runtime_measure_exec_with_retry(
 		$git_diff_cmd,
 		array( 0 ),
 		$git_diff_results_output,
-		$git_diff_results_status_code,
+		$git_diff_results_code,
 		'git_cli',
 		true
 	);

--- a/git-repo.php
+++ b/git-repo.php
@@ -139,7 +139,7 @@ function vipgoci_gitrepo_get_head( $local_git_repo ) {
 	/*
 	 * Actually execute
 	 */
-	$result_output    = '';
+	$result_output      = '';
 	$result_status_code = -255;
 
 	$result = vipgoci_runtime_measure_exec_with_retry(

--- a/git-repo.php
+++ b/git-repo.php
@@ -12,7 +12,7 @@ function vipgoci_git_version(): ?string {
 	}
 
 	$git_version_cmd = sprintf(
-		'%s %s 2>&1',
+		'%s %s',
 		escapeshellcmd( 'git' ),
 		escapeshellarg( '--version' )
 	);
@@ -24,10 +24,19 @@ function vipgoci_git_version(): ?string {
 		)
 	);
 
-	/* Actually execute */
-	$git_version_results = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute
+	 */
+	$git_output      = '';
+	$git_result_code = -255;
+
+	$git_version_results = vipgoci_runtime_measure_exec_with_retry(
 		$git_version_cmd,
-		'git_cli'
+		array( 0 ),
+		$git_output,
+		$git_result_code,
+		'git_cli',
+		false
 	);
 
 	if ( null === $git_version_results ) {
@@ -120,17 +129,26 @@ function vipgoci_gitrepo_get_head( $local_git_repo ) {
 	 */
 
 	$cmd = sprintf(
-		'%s -C %s log -n %s --pretty=format:"%s" 2>&1',
+		'%s -C %s log -n %s --pretty=format:"%s"',
 		escapeshellcmd( 'git' ),
 		escapeshellarg( $local_git_repo ),
 		escapeshellarg( 1 ),
 		escapeshellarg( '%H' )
 	);
 
-	/* Actually execute */
-	$result = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute
+	 */
+	$result_output    = '';
+	$result_status_code = -255;
+
+	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'git_cli'
+		array( 0 ),
+		$result_output,
+		$result_status_code,
+		'git_cli',
+		false
 	);
 
 	if ( null === $result ) {
@@ -167,15 +185,24 @@ function vipgoci_gitrepo_get_head( $local_git_repo ) {
 
 function vipgoci_gitrepo_branch_current_get( $local_git_repo ) {
 	$cmd = sprintf(
-		'%s -C %s branch 2>&1',
+		'%s -C %s branch',
 		escapeshellcmd( 'git' ),
 		escapeshellarg( $local_git_repo ),
 	);
 
-	/* Actually execute */
-	$results = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute
+	 */
+	$results_output      = '';
+	$results_result_code = -255;
+
+	$results = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'git_cli'
+		array( 0 ),
+		$results_output,
+		$results_result_code,
+		'git_cli',
+		true
 	);
 
 	if ( null === $results ) {
@@ -400,16 +427,25 @@ function vipgoci_gitrepo_blame_for_file(
 	 */
 
 	$cmd = sprintf(
-		'%s -C %s blame --line-porcelain %s 2>&1',
+		'%s -C %s blame --line-porcelain %s',
 		escapeshellcmd( 'git' ),
 		escapeshellarg( $local_git_repo ),
 		escapeshellarg( $file_name )
 	);
 
-	/* Actually execute */
-	$result = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute
+	 */
+	$result_output = '';
+	$result_code   = -255;
+
+	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'git_cli'
+		array( 0 ),
+		$result_output,
+		$result_code,
+		'git_cli',
+		true
 	);
 
 	if ( null === $result ) {
@@ -587,17 +623,26 @@ function vipgoci_gitrepo_get_file_at_commit(
 	 */
 
 	$cmd = sprintf(
-		'%s -C %s show %s:%s 2>&1',
+		'%s -C %s show %s:%s',
 		escapeshellcmd( 'git' ),
 		escapeshellarg( $local_git_repo ),
 		escapeshellarg( $commit_id ),
 		escapeshellarg( $file_name )
 	);
 
-	/* Actually execute */
-	$result = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute
+	 */
+	$result_output      = '';
+	$result_status_code = -255;
+
+	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'git_cli'
+		array( 0, 128 ),
+		$result_output,
+		$result_status_code,
+		'git_cli',
+		true
 	);
 
 	if ( null === $result ) {
@@ -618,8 +663,8 @@ function vipgoci_gitrepo_get_file_at_commit(
 	 * this revision, return null.
 	 */
 	if ( strpos(
-		$result,
-		'fatal: Path '
+		strtolower( $result ),
+		'fatal: path '
 	) === 0 ) {
 		return null;
 	}
@@ -632,17 +677,26 @@ function vipgoci_gitrepo_get_file_at_commit(
  */
 function vipgoci_gitrepo_submodules_setup( $local_git_repo ) {
 	$cmd = sprintf(
-		'%s -C %s submodule init && %s -C %s submodule update 2>&1',
+		'%s -C %s submodule init && %s -C %s submodule update',
 		escapeshellcmd( 'git' ),
 		escapeshellarg( $local_git_repo ),
 		escapeshellcmd( 'git' ),
 		escapeshellarg( $local_git_repo )
 	);
 
-	/* Actually execute */
-	$result = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute
+	 */
+	$result_output      = '';
+	$result_status_code = -255;
+
+	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'git_cli'
+		array( 0 ),
+		$result_output,
+		$result_status_code,
+		'git_cli',
+		true
 	);
 
 	if ( null === $result ) {
@@ -681,15 +735,24 @@ function vipgoci_gitrepo_submodules_list( $local_git_repo ) {
 	 */
 
 	$cmd = sprintf(
-		'%s -C %s submodule 2>&1',
+		'%s -C %s submodule',
 		escapeshellcmd( 'git' ),
 		escapeshellarg( $local_git_repo ),
 	);
 
-	/* Actually execute */
-	$result = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute
+	 */
+	$result_output      = '';
+	$result_status_code = -255;
+
+	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'git_cli'
+		array( 0 ),
+		$result_output,
+		$result_status_code,
+		'git_cli',
+		true
 	);
 
 	if ( null === $result ) {
@@ -920,7 +983,7 @@ function vipgoci_gitrepo_diffs_fetch_unfiltered(
 	 * as that is what GitHub uses: https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons
 	 */
 	$git_diff_cmd = sprintf(
-		'%s -C %s diff %s 2>&1',
+		'%s -C %s diff %s',
 		escapeshellcmd( 'git' ),
 		escapeshellarg( $local_git_repo ),
 		escapeshellarg( $commit_id_a . '...'. $commit_id_b )
@@ -933,10 +996,19 @@ function vipgoci_gitrepo_diffs_fetch_unfiltered(
 		)
 	);
 
-	/* Actually execute */
-	$git_diff_results = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute.
+	 */
+	$git_diff_results_output      = '';
+	$git_diff_results_status_code = -255;
+
+	$git_diff_results = vipgoci_runtime_measure_exec_with_retry(
 		$git_diff_cmd,
-		'git_cli'
+		array( 0 ),
+		$git_diff_results_output,
+		$git_diff_results_status_code,
+		'git_cli',
+		true
 	);
 
 	if ( null === $git_diff_results ) {

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -46,13 +46,13 @@ function vipgoci_lint_do_scan_file(
 	 * measure how long time it took.
 	 */
 	$tmp_output      = '';
-	$tmp_status_code = -255;
+	$tmp_result_code = -255;
 
 	$file_issues_str = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
 		array( 0, 255 ),
 		$tmp_output,
-		$tmp_status_code,
+		$tmp_result_code,
 		'php_lint_cli',
 		true
 	);

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -31,7 +31,7 @@ function vipgoci_lint_do_scan_file(
 	 */
 
 	$cmd = sprintf(
-		'( %s -d %s -d %s -d %s -l %s 2>&1 )',
+		'%s -d %s -d %s -d %s -l %s',
 		escapeshellcmd( $php_path ),
 		escapeshellarg( 'error_reporting=24575' ),
 		escapeshellarg( 'error_log=null' ),
@@ -45,10 +45,16 @@ function vipgoci_lint_do_scan_file(
 	 * Execute linter, grab issues in array,
 	 * measure how long time it took.
 	 */
+	$tmp_output      = '';
+	$tmp_status_code = -255;
 
-	$file_issues_str = vipgoci_runtime_measure_shell_exec_with_retry(
+	$file_issues_str = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'php_lint_cli'
+		array( 0, 255 ),
+		$tmp_output,
+		$tmp_status_code,
+		'php_lint_cli',
+		true
 	);
 
 	/*

--- a/other-utilities.php
+++ b/other-utilities.php
@@ -28,14 +28,21 @@ function vipgoci_util_php_interpreter_get_version(
 	}
 
 	$php_cmd = sprintf(
-		'( %s %s 2>&1 )',
+		'%s %s',
 		escapeshellcmd( $php_path ),
 		escapeshellarg( '-v' )
 	);
 
-	$php_output = vipgoci_runtime_measure_shell_exec_with_retry(
+	$php_output_2    = '';
+	$php_result_code = -255;
+
+	$php_output = vipgoci_runtime_measure_exec_with_retry(
 		$php_cmd,
-		'php_cli'
+		array( 0 ),
+		$php_output_2,
+		$php_result_code,
+		'php_cli',
+		false
 	);
 
 	if ( null === $php_output ) {

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -39,13 +39,13 @@ function vipgoci_phpcs_get_version(
 	);
 
 	$phpcs_output_2    = '';
-	$phpcs_status_code = -255;
+	$phpcs_result_code = -255;
 
 	$phpcs_output = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
 		array( 0 ),
 		$phpcs_output_2,
-		$phpcs_status_code,
+		$phpcs_result_code,
 		'phpcs_cli',
 		false
 	);
@@ -209,14 +209,14 @@ function vipgoci_phpcs_do_scan(
 	/*
 	 * Actually execute
 	 */
-	$result_output      = '';
-	$result_status_code = -255;
+	$result_output = '';
+	$result_code   = -255;
 
 	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
 		array( 0, 1, 2 ),
 		$result_output,
-		$result_status_code,
+		$result_code,
 		'phpcs_cli',
 		true
 	);

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -38,9 +38,16 @@ function vipgoci_phpcs_get_version(
 		escapeshellarg( '--version' )
 	);
 
-	$phpcs_output = vipgoci_runtime_measure_shell_exec_with_retry(
+	$phpcs_output_2    = '';
+	$phpcs_status_code = -255;
+
+	$phpcs_output = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'phpcs_cli'
+		array( 0 ),
+		$phpcs_output_2,
+		$phpcs_status_code,
+		'phpcs_cli',
+		false
 	);
 
 	if ( null === $phpcs_output ) {
@@ -191,8 +198,6 @@ function vipgoci_phpcs_do_scan(
 		escapeshellarg( $filename_tmp )
 	);
 
-	$cmd .= ' 2>&1';
-
 	vipgoci_log(
 		'Running PHPCS now',
 		array(
@@ -201,10 +206,19 @@ function vipgoci_phpcs_do_scan(
 		0
 	);
 
-	/* Actually execute */
-	$result = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute
+	 */
+	$result_output      = '';
+	$result_status_code = -255;
+
+	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'phpcs_cli'
+		array( 0, 1, 2 ),
+		$result_output,
+		$result_status_code,
+		'phpcs_cli',
+		true
 	);
 
 	return $result;
@@ -1141,10 +1155,19 @@ function vipgoci_phpcs_get_all_standards(
 		0
 	);
 
-	/* Actually execute */
-	$result = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute
+	 */
+	$result_output = '';
+	$result_code   = -255;
+
+	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'phpcs_cli'
+		array( 0 ),
+		$result_output,
+		$result_code,
+		'phpcs_cli',
+		false
 	);
 
 	if ( null === $result ) {
@@ -1231,10 +1254,19 @@ function vipgoci_phpcs_get_sniffs_for_standard(
 		0
 	);
 
-	/* Actually execute */
-	$result = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute
+	 */
+	$result_output = '';
+	$result_code   = -255;
+
+	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'phpcs_cli'
+		array( 0 ),
+		$result_output,
+		$result_code,
+		'phpcs_cli',
+		false
 	);
 
 	if ( null === $result ) {

--- a/statistics.php
+++ b/statistics.php
@@ -174,7 +174,7 @@ function vipgoci_runtime_measure(
 function vipgoci_runtime_measure_exec_with_retry(
 	string $cmd,
 	array $expected_result_code,
-	string &$res_output,
+	string|null &$res_output,
 	int &$res_result_code,
 	string $runtime_measure_type,
 	bool $catch_stderr = false,
@@ -306,7 +306,30 @@ function vipgoci_runtime_measure_exec_with_retry(
 			} else {
 				$exec_retry_stop = false;
 			}
+
+			/*
+			 * Read output from command and store.
+			 *
+			 * Do not change $exec_result_return as that
+			 * should be null, indicating failure.
+			 */
+			$res_output = file_get_contents(
+				$output_file
+			);
+
+			if ( false === $res_output ) {
+				vipgoci_log(
+					'Unable to read file with results from executing command',
+					array(
+						'exec_result_return' => $exec_result_return,
+						'output_file'        => $output_file,
+					)
+				);
+
+				$res_output = null;
+			}
 		} else {
+			// Read output and store.
 			$exec_result_return = file_get_contents(
 				$output_file
 			);
@@ -321,6 +344,8 @@ function vipgoci_runtime_measure_exec_with_retry(
 				);
 
 				$exec_result_return = null;
+			} else {
+				$res_output = $exec_result_return;
 			}
 
 			if ( ! empty( $exec_result_output ) ) {
@@ -334,8 +359,6 @@ function vipgoci_runtime_measure_exec_with_retry(
 					)
 				);
 			}
-
-			$res_output = $exec_result_return;
 		}
 
 		unlink( $output_file );

--- a/statistics.php
+++ b/statistics.php
@@ -174,7 +174,7 @@ function vipgoci_runtime_measure(
 function vipgoci_runtime_measure_exec_with_retry(
 	string $cmd,
 	array $expected_result_code,
-	string|null &$res_output,
+	string &$res_output,
 	int &$res_result_code,
 	string $runtime_measure_type,
 	bool $catch_stderr = false,

--- a/svg-scan.php
+++ b/svg-scan.php
@@ -44,14 +44,14 @@ function vipgoci_svg_do_scan_with_scanner(
 	/*
 	 * Actually execute
 	 */
-	$result_output      = '';
-	$result_status_code = -255;
+	$result_output = '';
+	$result_code   = -255;
 
 	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
 		array( 0, 1 ),
 		$result_output,
-		$result_status_code,
+		$result_code,
 		'svg_scanner_cli',
 		true
 	);

--- a/svg-scan.php
+++ b/svg-scan.php
@@ -33,8 +33,6 @@ function vipgoci_svg_do_scan_with_scanner(
 		escapeshellarg( $temp_file_name )
 	);
 
-	$cmd .= ' 2>&1';
-
 	vipgoci_log(
 		'Running SVG scanner now',
 		array(
@@ -43,10 +41,19 @@ function vipgoci_svg_do_scan_with_scanner(
 		2
 	);
 
-	/* Actually execute */
-	$result = vipgoci_runtime_measure_shell_exec_with_retry(
+	/*
+	 * Actually execute
+	 */
+	$result_output      = '';
+	$result_status_code = -255;
+
+	$result = vipgoci_runtime_measure_exec_with_retry(
 		$cmd,
-		'svg_scanner_cli'
+		array( 0, 1 ),
+		$result_output,
+		$result_status_code,
+		'svg_scanner_cli',
+		true
 	);
 
 	return $result;

--- a/tests/integration/StatisticsRuntimeMeasureExecWithRetryTest.php
+++ b/tests/integration/StatisticsRuntimeMeasureExecWithRetryTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-final class StatisticsRuntimeMeasureShellExecWithRetryTest extends TestCase {
+final class StatisticsRuntimeMeasureExecWithRetryTest extends TestCase {
 	/**
 	 * Setup function. Require files.
 	 *

--- a/tests/integration/StatisticsRuntimeMeasureShellExecWithRetryTest.php
+++ b/tests/integration/StatisticsRuntimeMeasureShellExecWithRetryTest.php
@@ -40,13 +40,13 @@ final class StatisticsRuntimeMeasureShellExecWithRetryTest extends TestCase {
 		vipgoci_unittests_output_suppress();
 
 		$output_2    = '';
-		$status_code = -255;
+		$result_code = -255;
 
 		$output = vipgoci_runtime_measure_exec_with_retry(
 			'sleep 1 ; echo -n "test_string"',
 			array( 0 ),
 			$output_2,
-			$status_code,
+			$result_code,
 			'mytimer10'
 		);
 
@@ -64,7 +64,7 @@ final class StatisticsRuntimeMeasureShellExecWithRetryTest extends TestCase {
 
 		$this->assertSame(
 			0,
-			$status_code
+			$result_code
 		);
 
 		$runtime_stats = vipgoci_runtime_measure(
@@ -125,7 +125,7 @@ final class StatisticsRuntimeMeasureShellExecWithRetryTest extends TestCase {
 		vipgoci_unittests_output_suppress();
 
 		$output_2    = '';
-		$status_code = -255;
+		$result_code = -255;
 
 		$output = vipgoci_runtime_measure_exec_with_retry(
 			escapeshellcmd( 'php' ) . ' ' .
@@ -133,7 +133,7 @@ final class StatisticsRuntimeMeasureShellExecWithRetryTest extends TestCase {
 				escapeshellarg( $path_to_temp_for_cli ) . ' 2>/dev/null',
 			array( 0 ),
 			$output_2,
-			$status_code,
+			$result_code,
 			'mytimer20',
 			false,
 			true, // Retry when status code does not match expected ones.
@@ -154,7 +154,7 @@ final class StatisticsRuntimeMeasureShellExecWithRetryTest extends TestCase {
 
 		$this->assertSame(
 			0,
-			$status_code
+			$result_code
 		);
 
 		/*

--- a/tests/integration/StatisticsRuntimeMeasureShellExecWithRetryTest.php
+++ b/tests/integration/StatisticsRuntimeMeasureShellExecWithRetryTest.php
@@ -34,13 +34,19 @@ final class StatisticsRuntimeMeasureShellExecWithRetryTest extends TestCase {
 	 * and that output returned is correct
 	 * as well.
 	 *
-	 * @covers ::vipgoci_runtime_measure_shell_exec_with_retry
+	 * @covers ::vipgoci_runtime_measure_exec_with_retry
 	 */
 	public function testShellExecRuntimeMeasure() :void {
 		vipgoci_unittests_output_suppress();
 
-		$output = vipgoci_runtime_measure_shell_exec_with_retry(
+		$output_2    = '';
+		$status_code = -255;
+
+		$output = vipgoci_runtime_measure_exec_with_retry(
 			'sleep 1 ; echo -n "test_string"',
+			array( 0 ),
+			$output_2,
+			$status_code,
 			'mytimer10'
 		);
 
@@ -49,6 +55,16 @@ final class StatisticsRuntimeMeasureShellExecWithRetryTest extends TestCase {
 		$this->assertSame(
 			'test_string',
 			$output
+		);
+
+		$this->assertSame(
+			'test_string',
+			$output_2
+		);
+
+		$this->assertSame(
+			0,
+			$status_code
 		);
 
 		$runtime_stats = vipgoci_runtime_measure(
@@ -66,7 +82,7 @@ final class StatisticsRuntimeMeasureShellExecWithRetryTest extends TestCase {
 	 * and if the output is correct when that occurs. Will also
 	 * check if the function really attempts retries.
 	 *
-	 * @covers ::vipgoci_runtime_measure_shell_exec_with_retry
+	 * @covers ::vipgoci_runtime_measure_exec_with_retry
 	 */
 	public function testShellExecRetry() :void {
 		$path_to_cli = tempnam(
@@ -108,11 +124,19 @@ final class StatisticsRuntimeMeasureShellExecWithRetryTest extends TestCase {
 
 		vipgoci_unittests_output_suppress();
 
-		$output = vipgoci_runtime_measure_shell_exec_with_retry(
+		$output_2    = '';
+		$status_code = -255;
+
+		$output = vipgoci_runtime_measure_exec_with_retry(
 			escapeshellcmd( 'php' ) . ' ' .
 				escapeshellcmd( $path_to_cli ) . ' ' .
 				escapeshellarg( $path_to_temp_for_cli ) . ' 2>/dev/null',
+			array( 0 ),
+			$output_2,
+			$status_code,
 			'mytimer20',
+			false,
+			true, // Retry when status code does not match expected ones.
 			2 // Retry twice (three times in total).
 		);
 
@@ -121,6 +145,16 @@ final class StatisticsRuntimeMeasureShellExecWithRetryTest extends TestCase {
 		$this->assertSame(
 			'Success' . PHP_EOL,
 			$output
+		);
+
+		$this->assertSame(
+			'Success' . PHP_EOL,
+			$output_2
+		);
+
+		$this->assertSame(
+			0,
+			$status_code
 		);
 
 		/*

--- a/tests/integration/helper-scripts/cli-prints-and-exits.php
+++ b/tests/integration/helper-scripts/cli-prints-and-exits.php
@@ -1,0 +1,16 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Helper script. Print to standard output and standard error, exit
+ * with code 125.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+fprintf( STDOUT, 'test123' );
+fprintf( STDERR, 'test456' );
+
+exit( 125 );
+


### PR DESCRIPTION
Use `exec()` instead of `shell_exec()`, as `exec()` will provide result code of program run. Use the result code to evaluate if the program returned with status provided by caller. This allows us to accurately detect if utilities are run successfully or not.

TODO:
- [x] Add/update unit-tests (if needed)
  - [x] Update test `integration/StatisticsRuntimeMeasureExecWithRetryTest.php` (for `vipgoci_runtime_measure_exec_with_retry()`).
- [x] Check automated unit-tests
- [x] Changelog entry (for VIP) [ #262 ]

