### PR TITLE
Configuring debug mode in test-suite via environmental variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ commands:
       # Move to project directory
       - run: cd ~/project
       # Run unit tests
-      - run: ./vendor/bin/phpunit --testsuite=unit-tests -vv
+      - run: VIPGOCI_TESTING_DEBUG_MODE=true ./vendor/bin/phpunit --testsuite=unit-tests
       # Run integration tests
-      - run: ./vendor/bin/phpunit --testsuite=integration-tests -vv
+      - run: VIPGOCI_TESTING_DEBUG_MODE=true ./vendor/bin/phpunit --testsuite=integration-tests
       # Run PHPCS, check for PHP compatibility issues
       - run: ~/vip-go-ci-tools/phpcs/bin/phpcs --runtime-set 'testVersion' '8.1-'  --standard=PHPCompatibility,PHPCompatibilityParagonieRandomCompat,PHPCompatibilityParagonieSodiumCompat --ignore="vendor/*"  ~/project
 

--- a/README.md
+++ b/README.md
@@ -777,7 +777,7 @@ This file is not included, and needs to be configured manually.
 
 The unit test suite can be run using the following command:
 
-> phpunit --testsuite=unit-tests -vv
+> VIPGOCI_TESTING_DEBUG_MODE=true phpunit --testsuite=unit-tests
 
 By running this command, you will run the tests that do not depend on external calls. 
 
@@ -785,7 +785,7 @@ By running this command, you will run the tests that do not depend on external c
 
 The integration tests can be run using the following command:
 
-> phpunit --testsuite=integration-tests -vv
+> VIPGOCI_TESTING_DEBUG_MODE=true phpunit --testsuite=integration-tests
 
 Integration tests will execute the scanning utilities — PHPCS, SVG scanner and PHP Lint — and so paths to these, and a PHP interpreter, need to be configured. See the `unittests.ini` file.
 

--- a/tests/integration/IncludesForTestsOutputControl.php
+++ b/tests/integration/IncludesForTestsOutputControl.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Functions to control output during testing.
+ *
+ * @package Automattic/vip-go-ci
+ */
 
 declare( strict_types=1 );
 
@@ -13,16 +18,9 @@ function vipgoci_unittests_debug_mode_on() :bool {
 	 * Detect if phpunit was started with
 	 * debug-mode on.
 	 */
-	if ( ! isset( $_SERVER['argv'] ) ) {
-		return false;
-	}
+	$debug_mode = getenv( 'VIPGOCI_TESTING_DEBUG_MODE' );
 
-	if (
-		( in_array( '-v', $_SERVER['argv'], true ) ) ||
-		( in_array( '-vv', $_SERVER['argv'], true ) ) ||
-		( in_array( '-vvv', $_SERVER['argv'], true ) ) ||
-		( in_array( '--debug', $_SERVER['argv'], true ) )
-	) {
+	if ( 'true' === $debug_mode ) {
 		return true;
 	}
 


### PR DESCRIPTION
This pull request introduces a new way to configure debug mode for the test-suite. Before, debug mode was set via parameter (`-vv`, or smilar). However, that is no longer reliable as often the parameter is not present in `$_SERVER['argv']` on all platforms. A more reliable way is to use environmental variables and this patch accomplishes that.

TODO:
- [x] Introduce logic to check for debug mode during testing via environmental variable (`VIPGOCI_TESTING_DEBUG_MODE=true`)
- [x] Update CircleCI configuration
- [x] Update README
- [x] Check automated unit-tests
- [x] Changelog entry (for VIP) [ #262 ]
