### PR TITLE
Filter IRC log messages, removing strings to ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,8 @@ This feature can be used in this fashion:
 
 At this time, only certain messages are posted to IRC, all indicated by a special parameter to the `vipgoci_log()` function. See the code for implementation details.
 
+Using the `VIPGOCI_IRC_IGNORE_STRING_START` and `VIPGOCI_IRC_IGNORE_STRING_END` constants, it is possible to designate parts of strings that should not be logged to the IRC API. Simply place any string not to be logged to IRC between these two constants and it will be filtered away before submisssion. Multiple constants can be used in one log message.
+
 
 ## Updating tools-init.sh with new versions
 

--- a/defines.php
+++ b/defines.php
@@ -131,12 +131,12 @@ define(
  */
 define(
 	'VIPGOCI_IRC_IGNORE_STRING_START',
-	'<!-- vip-go-ci-irc-ignore-start -->'
+	PHP_EOL . '<!-- vip-go-ci-irc-ignore-start -->' . PHP_EOL
 );
 
 define(
 	'VIPGOCI_IRC_IGNORE_STRING_END',
-	'<!-- vip-go-ci-irc-ignore-end -->'
+	PHP_EOL . '<!-- vip-go-ci-irc-ignore-end -->' . PHP_EOL
 );
 
 /*

--- a/defines.php
+++ b/defines.php
@@ -131,12 +131,12 @@ define(
  */
 define(
 	'VIPGOCI_IRC_IGNORE_STRING_START',
-	PHP_EOL . '<!-- vip-go-ci-irc-ignore-start -->' . PHP_EOL
+	'<!-- vip-go-ci-irc-ignore-start -->'
 );
 
 define(
 	'VIPGOCI_IRC_IGNORE_STRING_END',
-	PHP_EOL . '<!-- vip-go-ci-irc-ignore-end -->' . PHP_EOL
+	'<!-- vip-go-ci-irc-ignore-end -->'
 );
 
 /*

--- a/defines.php
+++ b/defines.php
@@ -126,6 +126,20 @@ define(
 );
 
 /*
+ * Indicates which sections of log
+ * messages should not be logged to IRC.
+ */
+define(
+	'VIPGOCI_IRC_IGNORE_STRING_START',
+	'<!-- vip-go-ci-irc-ignore-start -->'
+);
+
+define(
+	'VIPGOCI_IRC_IGNORE_STRING_END',
+	'<!-- vip-go-ci-irc-ignore-end -->'
+);
+
+/*
  * Define exit-codes
  */
 define( 'VIPGOCI_EXIT_NORMAL', 0 );

--- a/github-api.php
+++ b/github-api.php
@@ -740,8 +740,11 @@ function vipgoci_github_pr_comments_generic_submit(
 
 
 	$github_postfields = array();
-	$github_postfields['body'] =
-		$message;
+
+	// Add body to postfields. Ensure to remove IRC ignore constants first.
+	$github_postfields['body'] = vipgoci_irc_api_clean_ignorable_constants(
+		$message
+	);
 
 	if ( ! empty( $commit_id ) ) {
 		$github_postfields['body'] .=
@@ -1274,7 +1277,10 @@ function vipgoci_github_approve_pr(
 		'comments' => array()
 	);
 
-	$github_postfields['body'] = $message;
+	// Add body to postfields. Ensure to remove IRC ignore constants first.
+	$github_postfields['body'] = vipgoci_irc_api_clean_ignorable_constants(
+		$message
+	);
 
 	vipgoci_log(
 		'Sending request to GitHub to approve pull request',

--- a/log.php
+++ b/log.php
@@ -115,7 +115,8 @@ function vipgoci_sysexit(
 			( vipgoci_unittests_check_indication_for_test_id( 'MainRunScanSkipExecutionTest' ) ) ||
 			( vipgoci_unittests_check_indication_for_test_id( 'MainRunScanMaxExecTimeTest' ) ) ||
 			( vipgoci_unittests_check_indication_for_test_id( 'MainRunInitGithubTokenOptionTest' ) ) ||
-			( vipgoci_unittests_check_indication_for_test_id( 'MainRunInitOptionsAutoapproveHashesOverlapTest' ) )
+			( vipgoci_unittests_check_indication_for_test_id( 'MainRunInitOptionsAutoapproveHashesOverlapTest' ) ) ||
+			( vipgoci_unittests_check_indication_for_test_id( 'OtherWebServicesIrcApiFilterIgnorableStringsTest' ) )
 		)
 	) {
 		return $exit_status;

--- a/main.php
+++ b/main.php
@@ -1036,6 +1036,16 @@ function vipgoci_run_init_options_reviews( array &$options ) :void {
 	);
 
 	/*
+	 * Process --informational-msg. Add the IRC ignore strings.
+	 */
+	if ( ! empty( $options['informational-msg'] ) ) {
+		$options['informational-msg'] =
+			VIPGOCI_IRC_IGNORE_STRING_START . PHP_EOL .
+			$options['informational-msg'] . PHP_EOL .
+			VIPGOCI_IRC_IGNORE_STRING_END . PHP_EOL;
+	}
+
+	/*
 	 * Process --scan-details-msg-include
 	 */
 	vipgoci_option_bool_handle(

--- a/main.php
+++ b/main.php
@@ -1040,9 +1040,9 @@ function vipgoci_run_init_options_reviews( array &$options ) :void {
 	 */
 	if ( ! empty( $options['informational-msg'] ) ) {
 		$options['informational-msg'] =
-			VIPGOCI_IRC_IGNORE_STRING_START .
+			PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_START . PHP_EOL .
 			$options['informational-msg'] .
-			VIPGOCI_IRC_IGNORE_STRING_END;
+			PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_END . PHP_EOL;
 	}
 
 	/*

--- a/main.php
+++ b/main.php
@@ -1040,9 +1040,9 @@ function vipgoci_run_init_options_reviews( array &$options ) :void {
 	 */
 	if ( ! empty( $options['informational-msg'] ) ) {
 		$options['informational-msg'] =
-			VIPGOCI_IRC_IGNORE_STRING_START . PHP_EOL .
-			$options['informational-msg'] . PHP_EOL .
-			VIPGOCI_IRC_IGNORE_STRING_END . PHP_EOL;
+			VIPGOCI_IRC_IGNORE_STRING_START .
+			$options['informational-msg'] .
+			VIPGOCI_IRC_IGNORE_STRING_END;
 	}
 
 	/*

--- a/other-web-services.php
+++ b/other-web-services.php
@@ -35,34 +35,34 @@ function vipgoci_irc_api_filter_ignorable_strings(
 	string $message
 ) :string {
 	do {
-		$ignore_section_start = strpos( $message, VIPGOCI_IRC_IGNORE_STRING_START );
+		$ignore_section_start_pos = strpos( $message, VIPGOCI_IRC_IGNORE_STRING_START );
 
-		if ( false !== $ignore_section_start ) {
-			$ignore_section_end = strpos(
+		if ( false !== $ignore_section_start_pos ) {
+			$ignore_section_end_pos = strpos(
 				$message,
 				VIPGOCI_IRC_IGNORE_STRING_END,
 				0 // From string start; needed for check below.
 			);
 
-			$ignore_section_start_2 = strpos(
+			$ignore_section_start_pos_2 = strpos(
 				$message,
 				VIPGOCI_IRC_IGNORE_STRING_START,
-				$ignore_section_start + strlen( VIPGOCI_IRC_IGNORE_STRING_START ) // Needed for check below.
+				$ignore_section_start_pos + strlen( VIPGOCI_IRC_IGNORE_STRING_START ) // Needed for check below.
 			);
 		} else {
-			$ignore_section_end     = false;
-			$ignore_section_start_2 = false;
+			$ignore_section_end_pos     = false;
+			$ignore_section_start_pos_2 = false;
 		}
 
 		if (
-			( false === $ignore_section_start ) ||
-			( false === $ignore_section_end )
+			( false === $ignore_section_start_pos ) ||
+			( false === $ignore_section_end_pos )
 		) {
 			// Neither string was found, stop processing here.
 			continue;
 		}
 
-		if ( $ignore_section_end <= $ignore_section_start ) {
+		if ( $ignore_section_end_pos <= $ignore_section_start_pos ) {
 			// Invalid usage.
 			vipgoci_log(
 				'Incorrect usage of VIPGOCI_IRC_IGNORE_STRING_START and VIPGOCI_IRC_IGNORE_STRING_END; former should be placed before the latter',
@@ -74,8 +74,8 @@ function vipgoci_irc_api_filter_ignorable_strings(
 
 			break;
 		} elseif (
-			( false !== $ignore_section_start_2 ) &&
-			( $ignore_section_end > $ignore_section_start_2 )
+			( false !== $ignore_section_start_pos_2 ) &&
+			( $ignore_section_end_pos > $ignore_section_start_pos_2 )
 		) {
 			// Invalid usage.
 			vipgoci_log(
@@ -87,19 +87,19 @@ function vipgoci_irc_api_filter_ignorable_strings(
 			);
 
 			break;
-		} elseif ( $ignore_section_end > $ignore_section_start ) {
+		} elseif ( $ignore_section_end_pos > $ignore_section_start_pos ) {
 			// Correct usage; end constant should always come after start constant.
 			$message = substr_replace(
 				$message,
 				'',
-				$ignore_section_start,
-				( $ignore_section_end + strlen( VIPGOCI_IRC_IGNORE_STRING_END ) ) -
-					$ignore_section_start
+				$ignore_section_start_pos,
+				( $ignore_section_end_pos + strlen( VIPGOCI_IRC_IGNORE_STRING_END ) ) -
+					$ignore_section_start_pos
 			);
 		}
 	} while (
-		( false !== $ignore_section_start ) &&
-		( false !== $ignore_section_end )
+		( false !== $ignore_section_start_pos ) &&
+		( false !== $ignore_section_end_pos )
 	);
 
 	return $message;

--- a/other-web-services.php
+++ b/other-web-services.php
@@ -64,28 +64,29 @@ function vipgoci_irc_api_filter_ignorable_strings(
 
 		if ( $ignore_section_end <= $ignore_section_start ) {
 			// Invalid usage.
-			$ignore_section_end = false; // For unit testing, to ensure loop ends.
-
-			vipgoci_sysexit(
+			vipgoci_log(
 				'Incorrect usage of VIPGOCI_IRC_IGNORE_STRING_START and VIPGOCI_IRC_IGNORE_STRING_END; former should be placed before the latter',
 				array(
 					'message' => $message,
-				)
+				),
+				0
 			);
 
+			break;
 		} elseif (
 			( false !== $ignore_section_start_2 ) &&
 			( $ignore_section_end > $ignore_section_start_2 )
 		) {
-			$ignore_section_end = false; // For unit testing, to ensure loop ends.
-
 			// Invalid usage.
-			vipgoci_sysexit(
+			vipgoci_log(
 				'Incorrect usage of VIPGOCI_IRC_IGNORE_STRING_START and VIPGOCI_IRC_IGNORE_STRING_END; embedding one ignore string within another is not allowed',
 				array(
 					'message' => $message,
-				)
+				),
+				0
 			);
+
+			break;
 		} elseif ( $ignore_section_end > $ignore_section_start ) {
 			// Correct usage; end constant should always come after start constant.
 			$message = substr_replace(

--- a/other-web-services.php
+++ b/other-web-services.php
@@ -23,9 +23,9 @@ function vipgoci_irc_api_alert_queue(
 }
 
 /**
- * Remove any string sections found in string bounded between the
+ * Remove any sections found in $message string bounded between the
  * VIPGOCI_IRC_IGNORE_STRING_START and VIPGOCI_IRC_IGNORE_STRING_END
- * string constants.
+ * constants.
  *
  * @param string $message Message string to filter.
  *

--- a/reports.php
+++ b/reports.php
@@ -436,7 +436,7 @@ function vipgoci_report_create_scan_details_auto_approve_configuration(
 function vipgoci_report_create_scan_details(
 	array $options_copy
 ) :string {
-	$details = VIPGOCI_IRC_IGNORE_STRING_START;
+	$details = PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_START . PHP_EOL;
 
 	$details .= '<details>' . PHP_EOL;
 	$details .= '<hr />' . PHP_EOL;
@@ -464,7 +464,7 @@ function vipgoci_report_create_scan_details(
 
 	$details .= '</details>' . PHP_EOL;
 
-	$details .= VIPGOCI_IRC_IGNORE_STRING_END;
+	$details .= PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_END . PHP_EOL;
 
 	return $details;
 }

--- a/reports.php
+++ b/reports.php
@@ -436,7 +436,7 @@ function vipgoci_report_create_scan_details_auto_approve_configuration(
 function vipgoci_report_create_scan_details(
 	array $options_copy
 ) :string {
-	$details .= VIPGOCI_IRC_IGNORE_STRING_START;
+	$details = VIPGOCI_IRC_IGNORE_STRING_START;
 
 	$details .= '<details>' . PHP_EOL;
 	$details .= '<hr />' . PHP_EOL;

--- a/reports.php
+++ b/reports.php
@@ -436,7 +436,9 @@ function vipgoci_report_create_scan_details_auto_approve_configuration(
 function vipgoci_report_create_scan_details(
 	array $options_copy
 ) :string {
-	$details  = '<details>' . PHP_EOL;
+	$details .= VIPGOCI_IRC_IGNORE_STRING_START . PHP_EOL;
+
+	$details .= '<details>' . PHP_EOL;
 	$details .= '<hr />' . PHP_EOL;
 	$details .= '<summary>Scan run detail</summary>' . PHP_EOL;
 
@@ -461,6 +463,8 @@ function vipgoci_report_create_scan_details(
 	$details .= '</table>' . PHP_EOL;
 
 	$details .= '</details>' . PHP_EOL;
+
+	$details .= VIPGOCI_IRC_IGNORE_STRING_END . PHP_EOL;
 
 	return $details;
 }

--- a/reports.php
+++ b/reports.php
@@ -436,7 +436,7 @@ function vipgoci_report_create_scan_details_auto_approve_configuration(
 function vipgoci_report_create_scan_details(
 	array $options_copy
 ) :string {
-	$details .= VIPGOCI_IRC_IGNORE_STRING_START . PHP_EOL;
+	$details .= VIPGOCI_IRC_IGNORE_STRING_START;
 
 	$details .= '<details>' . PHP_EOL;
 	$details .= '<hr />' . PHP_EOL;
@@ -464,7 +464,7 @@ function vipgoci_report_create_scan_details(
 
 	$details .= '</details>' . PHP_EOL;
 
-	$details .= VIPGOCI_IRC_IGNORE_STRING_END . PHP_EOL;
+	$details .= VIPGOCI_IRC_IGNORE_STRING_END;
 
 	return $details;
 }

--- a/reports.php
+++ b/reports.php
@@ -1205,6 +1205,11 @@ function vipgoci_report_submit_pr_review_from_results(
 			$github_postfields['body'] .= $scan_details_msg;
 		}
 
+		// Remove IRC constants from postfields body before submitting.
+		$github_postfields['body'] = vipgoci_irc_api_clean_ignorable_constants(
+			$github_postfields['body']
+		);
+
 		/*
 		 * Only submit a specific number of comments in one go.
 		 *

--- a/tests/integration/MainRunInitOptionsReviewsTest.php
+++ b/tests/integration/MainRunInitOptionsReviewsTest.php
@@ -90,7 +90,7 @@ final class MainRunInitOptionsReviewsTest extends TestCase {
 				'dismiss-stale-reviews'             => true,
 
 				'dismissed-reviews-repost-comments' => false,
-				'informational-msg'                 => VIPGOCI_IRC_IGNORE_STRING_START . 'message-string-123' . VIPGOCI_IRC_IGNORE_STRING_END,
+				'informational-msg'                 => PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_START . PHP_EOL. 'message-string-123' . PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_END . PHP_EOL,
 				'scan-details-msg-include'          => true,
 				'dismissed-reviews-exclude-reviews-from-team' => array(),
 			),

--- a/tests/integration/MainRunInitOptionsReviewsTest.php
+++ b/tests/integration/MainRunInitOptionsReviewsTest.php
@@ -71,6 +71,7 @@ final class MainRunInitOptionsReviewsTest extends TestCase {
 			'review-comments-ignore'            => '  comment1.|||CoMMENt2  ',
 			'dismiss-stale-reviews'             => 'true',
 			'dismissed-reviews-repost-comments' => 'false',
+			'informational-msg'                 => 'message-string-123',
 			'scan-details-msg-include'          => 'true',
 		);
 
@@ -87,7 +88,9 @@ final class MainRunInitOptionsReviewsTest extends TestCase {
 				'review-comments-total-max'         => 100,
 				'review-comments-ignore'            => array( 'comment1', 'comment2' ),
 				'dismiss-stale-reviews'             => true,
+
 				'dismissed-reviews-repost-comments' => false,
+				'informational-msg'                 => VIPGOCI_IRC_IGNORE_STRING_START . PHP_EOL . 'message-string-123' . PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_END . PHP_EOL,
 				'scan-details-msg-include'          => true,
 				'dismissed-reviews-exclude-reviews-from-team' => array(),
 			),

--- a/tests/integration/MainRunInitOptionsReviewsTest.php
+++ b/tests/integration/MainRunInitOptionsReviewsTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Test vipgoci_run_init_options_reviews() function.
+ *
+ * @package Automattic/vip-go-ci
+ */
 
 declare(strict_types=1);
 
@@ -90,7 +95,7 @@ final class MainRunInitOptionsReviewsTest extends TestCase {
 				'dismiss-stale-reviews'             => true,
 
 				'dismissed-reviews-repost-comments' => false,
-				'informational-msg'                 => PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_START . PHP_EOL. 'message-string-123' . PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_END . PHP_EOL,
+				'informational-msg'                 => PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_START . PHP_EOL . 'message-string-123' . PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_END . PHP_EOL,
 				'scan-details-msg-include'          => true,
 				'dismissed-reviews-exclude-reviews-from-team' => array(),
 			),

--- a/tests/integration/MainRunInitOptionsReviewsTest.php
+++ b/tests/integration/MainRunInitOptionsReviewsTest.php
@@ -90,7 +90,7 @@ final class MainRunInitOptionsReviewsTest extends TestCase {
 				'dismiss-stale-reviews'             => true,
 
 				'dismissed-reviews-repost-comments' => false,
-				'informational-msg'                 => VIPGOCI_IRC_IGNORE_STRING_START . PHP_EOL . 'message-string-123' . PHP_EOL . VIPGOCI_IRC_IGNORE_STRING_END . PHP_EOL,
+				'informational-msg'                 => VIPGOCI_IRC_IGNORE_STRING_START . 'message-string-123' . VIPGOCI_IRC_IGNORE_STRING_END,
 				'scan-details-msg-include'          => true,
 				'dismissed-reviews-exclude-reviews-from-team' => array(),
 			),

--- a/tests/unit/OtherWebServicesIrcApiCleanIgnorableConstantsTests.php
+++ b/tests/unit/OtherWebServicesIrcApiCleanIgnorableConstantsTests.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Test vipgoci_irc_api_clean_ignorable_constants() function.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class that implements the testing.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class OtherWebServicesIrcApiCleanIgnorableConstantsTests extends TestCase {
+	/**
+	 * Setup function. Require files.
+	 *
+	 * @return void
+	 */
+	protected function setUp() :void {
+		require_once __DIR__ . '/../../defines.php';
+		require_once __DIR__ . '/../../other-web-services.php';
+	}
+
+	/**
+	 * Test usage of the function.
+	 *
+	 * @covers ::vipgoci_irc_api_clean_ignorable_constants
+	 *
+	 * @return void
+	 */
+	public function testIrcApiCleanIgnorableStrings(): void {
+		$this->assertSame(
+			'abcdefghi',
+			vipgoci_irc_api_clean_ignorable_constants(
+				'abc' . VIPGOCI_IRC_IGNORE_STRING_START . 'def' . VIPGOCI_IRC_IGNORE_STRING_END . 'ghi'
+			)
+		);
+	}
+}

--- a/tests/unit/OtherWebServicesIrcApiFilterIgnorableStringsTest.php
+++ b/tests/unit/OtherWebServicesIrcApiFilterIgnorableStringsTest.php
@@ -59,6 +59,23 @@ final class OtherWebServicesIrcApiFilterIgnorableStringsTest extends TestCase {
 	}
 
 	/**
+	 * Test usage with JSON encoded string.
+	 *
+	 * @covers ::vipgoci_irc_api_filter_ignorable_strings
+	 *
+	 * @return void
+	 */
+	public function testFilterIgnorableStringsJsonUsage(): void {
+		$this->assertSame(
+			'"abcghi"',
+			vipgoci_irc_api_filter_ignorable_strings(
+				json_encode( 'abc' . VIPGOCI_IRC_IGNORE_STRING_START . 'def' . VIPGOCI_IRC_IGNORE_STRING_END . 'ghi' )
+			)
+		);
+	}
+
+
+	/**
 	 * Test more complex usage of the function.
 	 *
 	 * @covers ::vipgoci_irc_api_filter_ignorable_strings

--- a/tests/unit/OtherWebServicesIrcApiFilterIgnorableStringsTest.php
+++ b/tests/unit/OtherWebServicesIrcApiFilterIgnorableStringsTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Test vipgoci_irc_api_filter_ignorable_strings() function.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class that implements the testing.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class OtherWebServicesIrcApiFilterIgnorableStringsTest extends TestCase {
+	/**
+	 * Setup function. Require files, set up indication.
+	 *
+	 * @return void
+	 */
+	protected function setUp() :void {
+		require_once __DIR__ . '/../../defines.php';
+		require_once __DIR__ . '/../../other-web-services.php';
+		require_once __DIR__ . '/../../log.php';
+
+		require_once __DIR__ . '/helper/IndicateTestId.php';
+
+		vipgoci_unittests_indicate_test_id( 'OtherWebServicesIrcApiFilterIgnorableStringsTest' );
+	}
+
+	/**
+	 * Tear down function. Remove indication.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		vipgoci_unittests_remove_indication_for_test_id( 'OtherWebServicesIrcApiFilterIgnorableStringsTest' );
+	}
+
+	/**
+	 * Test simple usage of the function.
+	 *
+	 * @covers ::vipgoci_irc_api_filter_ignorable_strings
+	 *
+	 * @return void
+	 */
+	public function testFilterIgnorableStringsSimpleUsage(): void {
+		$this->assertSame(
+			'abcghi',
+			vipgoci_irc_api_filter_ignorable_strings(
+				'abc' . VIPGOCI_IRC_IGNORE_STRING_START . 'def' . VIPGOCI_IRC_IGNORE_STRING_END . 'ghi'
+			)
+		);
+	}
+
+	/**
+	 * Test more complex usage of the function.
+	 *
+	 * @covers ::vipgoci_irc_api_filter_ignorable_strings
+	 *
+	 * @return void
+	 */
+	public function testFilterIgnorableStringsComplexUsage(): void {
+		$this->assertSame(
+			'abcghi123789',
+			vipgoci_irc_api_filter_ignorable_strings(
+				'abc' . VIPGOCI_IRC_IGNORE_STRING_START . 'def' . VIPGOCI_IRC_IGNORE_STRING_END . 'ghi' .
+				'123' . VIPGOCI_IRC_IGNORE_STRING_START . '456' . VIPGOCI_IRC_IGNORE_STRING_END . '789'
+			)
+		);
+	}
+
+	/**
+	 * Test invalid usage of the function.
+	 *
+	 * @covers ::vipgoci_irc_api_filter_ignorable_strings
+	 *
+	 * @return void
+	 */
+	public function testFilterIgnorableStringsInvalidUsage1(): void {
+		ob_start();
+
+		vipgoci_irc_api_filter_ignorable_strings(
+			'ab' . VIPGOCI_IRC_IGNORE_STRING_END . 'cd' . VIPGOCI_IRC_IGNORE_STRING_START . 'ef'
+		);
+
+		$printed_data = ob_get_contents();
+
+		ob_end_clean();
+
+		$this->assertTrue(
+			str_contains(
+				$printed_data,
+				'Incorrect usage of VIPGOCI_IRC_IGNORE_STRING_START and VIPGOCI_IRC_IGNORE_STRING_END; former should be placed before the latter'
+			),
+			'Should have printed message about invalid usage of IRC ignore constants'
+		);
+	}
+
+	/**
+	 * Test invalid usage of the function.
+	 *
+	 * @covers ::vipgoci_irc_api_filter_ignorable_strings
+	 *
+	 * @return void
+	 */
+	public function testFilterIgnorableStringsInvalidUsage2(): void {
+		ob_start();
+
+		vipgoci_irc_api_filter_ignorable_strings(
+			'ab' . VIPGOCI_IRC_IGNORE_STRING_START . 'cd' . VIPGOCI_IRC_IGNORE_STRING_START .
+			'ef' . VIPGOCI_IRC_IGNORE_STRING_END . 'hi' . VIPGOCI_IRC_IGNORE_STRING_END .
+			'jk'
+		);
+
+		$printed_data = ob_get_contents();
+
+		ob_end_clean();
+
+		$this->assertTrue(
+			str_contains(
+				$printed_data,
+				'Usage: Incorrect usage of VIPGOCI_IRC_IGNORE_STRING_START and VIPGOCI_IRC_IGNORE_STRING_END; embedding one ignore string within another is not allowed'
+			),
+			'Should have printed message about invalid usage of IRC ignore constants'
+		);
+	}
+}

--- a/tests/unit/OtherWebServicesIrcApiFilterIgnorableStringsTest.php
+++ b/tests/unit/OtherWebServicesIrcApiFilterIgnorableStringsTest.php
@@ -125,7 +125,7 @@ final class OtherWebServicesIrcApiFilterIgnorableStringsTest extends TestCase {
 		$this->assertTrue(
 			str_contains(
 				$printed_data,
-				'Usage: Incorrect usage of VIPGOCI_IRC_IGNORE_STRING_START and VIPGOCI_IRC_IGNORE_STRING_END; embedding one ignore string within another is not allowed'
+				'Incorrect usage of VIPGOCI_IRC_IGNORE_STRING_START and VIPGOCI_IRC_IGNORE_STRING_END; embedding one ignore string within another is not allowed'
 			),
 			'Should have printed message about invalid usage of IRC ignore constants'
 		);

--- a/tests/unit/OtherWebServicesIrcApiFilterIgnorableStringsTest.php
+++ b/tests/unit/OtherWebServicesIrcApiFilterIgnorableStringsTest.php
@@ -74,7 +74,6 @@ final class OtherWebServicesIrcApiFilterIgnorableStringsTest extends TestCase {
 		);
 	}
 
-
 	/**
 	 * Test more complex usage of the function.
 	 *
@@ -88,6 +87,22 @@ final class OtherWebServicesIrcApiFilterIgnorableStringsTest extends TestCase {
 			vipgoci_irc_api_filter_ignorable_strings(
 				'abc' . VIPGOCI_IRC_IGNORE_STRING_START . 'def' . VIPGOCI_IRC_IGNORE_STRING_END . 'ghi' .
 				'123' . VIPGOCI_IRC_IGNORE_STRING_START . '456' . VIPGOCI_IRC_IGNORE_STRING_END . '789'
+			)
+		);
+	}
+
+	/**
+	 * Test with no strings to remove.
+	 *
+	 * @covers ::vipgoci_irc_api_filter_ignorable_strings
+	 *
+	 * @return void
+	 */
+	public function testFilterIgnorableStringsNotFound(): void {
+		$this->assertSame(
+			'abcdef',
+			vipgoci_irc_api_filter_ignorable_strings(
+				'abcdef'
 			)
 		);
 	}


### PR DESCRIPTION
Filter IRC log messages before submitting to IRC API, remove any strings that should not be logged to the API. Uses constants to indicate which sections should be removed.

TODO:
- [x] Add constants to `defines.php`  (`VIPGOCI_IRC_IGNORE_STRING_START`, `VIPGOCI_IRC_IGNORE_STRING_END`).
- [x] Apply constants to `vipgoci_report_create_scan_details()` and to informational message in `main.php`.
- [x] Filter IRC log messages before submitting to IRC API.
- [x] Clean strings before submitting to GitHub API, removing the constants if found.
- [x] Add unit-tests:
  - [x] for function to filter IRC log messages.
  - [x] for function to clean messages before submitting to GitHub API.
  - [x] for informational-messages processing in `main.php`
- [x] Update README
- [x] Changelog entry [ #262 ]
- [x] Check automated unit-tests

