### PR TITLE
Verify commit and access to repository on start up

### DIFF
--- a/main.php
+++ b/main.php
@@ -2352,6 +2352,57 @@ function vipgoci_run_scan_skip_execution( array &$options ) :void {
 }
 
 /**
+ * Ensure we have access to the commit and repository
+ * specified by fetching commit information from GitHub API.
+ * Will effectively exit if we do not have access to the commit
+ * or repository, or they do not exist.
+ *
+ * @param array $options Array of options.
+ *
+ * @return void
+ *
+ * @codeCoverageIgnore
+ */
+function vipgoci_run_verify_access_to_commit_and_repository(
+	array $options
+) :void {
+	/*
+	 * Try fetching the commit.
+	 */
+	$commit_info = vipgoci_github_fetch_commit_info(
+		$options['repo-owner'],
+		$options['repo-name'],
+		$options['commit'],
+		$options['token'],
+		null
+	);
+
+	if (
+		( empty( $commit_info->commit ) ) ||
+		( empty( $commit_info->url ) )
+	) {
+		vipgoci_sysexit(
+			'Unable to fetch information from GitHub API about commit, possibly the commit does not exist or the current user does not have sufficient privileges',
+			array(
+				'repo_owner' => $options['repo-owner'],
+				'repo_name'  => $options['repo-name'],
+				'commit'     => $options['commit'],
+			),
+			VIPGOCI_EXIT_GITHUB_PROBLEM
+		);
+	} else {
+		vipgoci_log(
+			'Validated access to git commit and repository via GitHub API',
+			array(
+				'repo_owner' => $options['repo-owner'],
+				'repo_name'  => $options['repo-name'],
+				'commit'     => $options['commit'],
+			)
+		);
+	}
+}
+
+/**
  * Find pull requests implicated by the commit specified in $options.
  *
  * @param array $options Array of options.
@@ -2748,6 +2799,9 @@ function vipgoci_run_scan(
 
 	// Enforce maximum execution time from now on.
 	vipgoci_run_scan_max_exec_time( $options, $startup_time );
+
+	// Ensure we have access to commit and repository.
+	vipgoci_run_verify_access_to_commit_and_repository( $options );
 
 	// Find PRs relating to the commit we are processing.
 	$prs_implicated = vipgoci_run_scan_find_prs( $options );

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -507,26 +507,6 @@ function vipgoci_phpcs_scan_commit(
 		)
 	);
 
-	/*
-	 * First, figure out if a .gitmodules
-	 * file was added or modified; if so,
-	 * we need to scan the relevant sub-module(s)
-	 * specifically.
-	 */
-	$commit_info = vipgoci_github_fetch_commit_info(
-		$repo_owner,
-		$repo_name,
-		$commit_id,
-		$github_token,
-		array(
-			'file_extensions'
-				=> array( 'gitmodules' ),
-
-			'status'
-				=> array( 'added', 'modified' ),
-		)
-	);
-
 	// Fetch list of all pull requests which the commit is a part of.
 	$prs_implicated = vipgoci_github_prs_implicated(
 		$repo_owner,

--- a/tests/integration/GitHubFetchCommitInfoTest.php
+++ b/tests/integration/GitHubFetchCommitInfoTest.php
@@ -1,22 +1,50 @@
 <?php
+/**
+ * Test vipgoci_github_fetch_commit_info() function.
+ *
+ * @package Automattic/vip-go-ci
+ */
 
-require_once( __DIR__ . '/IncludesForTests.php' );
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Integration;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class that implements the testing.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 final class GitHubFetchCommitInfoTest extends TestCase {
-	var $options_git_repo_tests = array(
-		'commit-test-repo-fetch-commit-info-1'	=> null,
+	/**
+	 * Variable for commit info.
+	 *
+	 * @var $options_git_repo_tests
+	 */
+	private array $options_git_repo_tests = array(
+		'commit-test-repo-fetch-commit-info-1' => null,
 	);
 
-	var $options_git = array(
-		'git-path'		=> null,
-		'github-repo-url'	=> null,
-		'repo-name'		=> null,
-		'repo-owner'		=> null,
+	/**
+	 * Variable for GitHub info.
+	 *
+	 * @var $options_git
+	 */
+	private array $options_git = array(
+		'repo-name'  => null,
+		'repo-owner' => null,
 	);
 
+	/**
+	 * Set up function. Require files, set variables, etc.
+	 *
+	 * @return void
+	 */
 	protected function setUp(): void {
+		require_once __DIR__ . '/IncludesForTests.php';
+
 		vipgoci_unittests_get_config_values(
 			'git-repo-tests',
 			$this->options_git_repo_tests
@@ -36,7 +64,7 @@ final class GitHubFetchCommitInfoTest extends TestCase {
 			vipgoci_unittests_get_config_value(
 				'git-secrets',
 				'github-token',
-				true // Fetch from secrets file
+				true // Fetch from secrets file.
 			);
 
 		if ( empty( $this->options['github-token'] ) ) {
@@ -50,22 +78,25 @@ final class GitHubFetchCommitInfoTest extends TestCase {
 		$this->options['branches-ignore'] = array();
 	}
 
+	/**
+	 * Tear down function, remove git repo, etc.
+	 *
+	 * @return void
+	 */
 	protected function tearDown(): void {
-		if ( false !== $this->options['local-git-repo'] ) {
-			vipgoci_unittests_remove_git_repo(
-				$this->options['local-git-repo']
-			);
-		}
-
-		$this->options_git_repo_tests = null;
-		$this->options_git = null;
-		$this->options = null;
+		unset( $this->options_git_repo_tests );
+		unset( $this->options_git );
+		unset( $this->options );
 	}
 
 	/**
+	 * Call the function, verify if correct information is returned.
+	 *
+	 * @return void
+	 *
 	 * @covers ::vipgoci_github_fetch_commit_info
 	 */
-	public function testFetchCommitInfo1() {
+	public function testFetchCommitInfo1() :void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array( 'github-token' ),
@@ -80,20 +111,6 @@ final class GitHubFetchCommitInfoTest extends TestCase {
 			$this->options['commit-test-repo-fetch-commit-info-1'];
 
 		vipgoci_unittests_output_suppress();
-
-		$this->options['local-git-repo'] =
-			vipgoci_unittests_setup_git_repo(
-				$this->options
-			);
-
-		if ( false === $this->options['local-git-repo'] ) {
-			$this->markTestSkipped(
-				'Could not set up git repository: ' .
-					vipgoci_unittests_output_get()
-			);
-
-			return;
-		}
 
 		$commit_info = vipgoci_github_fetch_commit_info(
 			$this->options['repo-owner'],
@@ -118,17 +135,16 @@ final class GitHubFetchCommitInfoTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'sha'		=> '524acfffa760fd0b8c1de7cf001f8dd348b399d8',
-				'filename'	=> 'test1.txt',
-				'status'	=> 'added',
-				'additions'	=> 1,
-				'deletions'	=> 0,
-				'changes'	=> 1,
-				'patch'		=> '@@ -0,0 +1 @@' . PHP_EOL . '+Test file',
+				'sha'       => '524acfffa760fd0b8c1de7cf001f8dd348b399d8',
+				'filename'  => 'test1.txt',
+				'status'    => 'added',
+				'additions' => 1,
+				'deletions' => 0,
+				'changes'   => 1,
+				'patch'     => '@@ -0,0 +1 @@' . PHP_EOL . '+Test file',
 			),
 			(array) $commit_info->files[0]
 		);
-
 
 		unset( $this->options['commit'] );
 	}


### PR DESCRIPTION

Verify that commit exists on GitHub and verify access to GitHub repository on start up using the `vipgoci_github_fetch_commit_info()` function. If the current access token does not grant access to the repository, it does not exist, or the commit does not exist, stop execution.

Removes usage of the `vipgoci_github_fetch_commit_info()` function from `phpcs-scan.php`, as it is not needed.

No further tests needed as the only additional function is a wrapper around a function already tested.

TODO:
- [x] Verify commit and access to repository on start up
- [x] Unit-tests
  - [x] Apply WP CS style for `vipgoci_github_fetch_commit_info()`.
- [x] Changelog entry [ #262 ]
- [x] Check automated unit-tests
