### PR TITLE
Set exit code for vipgoci_sysexit() in vipgoci_runtime_measure_exec_with_retry()

### DIFF
--- a/statistics.php
+++ b/statistics.php
@@ -356,7 +356,8 @@ function vipgoci_runtime_measure_exec_with_retry(
 						'cmd_amended'        => $cmd_amended,
 						'exec_result_output' => $exec_result_output,
 						'exec_result_return' => $exec_result_return,
-					)
+					),
+					VIPGOCI_EXIT_SYSTEM_PROBLEM
 				);
 			}
 		}


### PR DESCRIPTION
One invocation of `vipgoci_sysexit()` was missing exit-code, so it was using fallback code. This pull request sets the exit code.

TODO:
- [x] Set exit code for `vipgoci_sysexit()` used in `vipgoci_runtime_measure_exec_with_retry()`.
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #262 ]
