### PR TITLE
Update files to reflect that "main" branch is now named "trunk"

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -2,7 +2,7 @@
 
 <!-- Also note: This issue tracker is only intended for problems that relate to vip-go-ci it self -- any issues that relate to PHPCS rulesets (for instance) should be filed against the project that houses them. -->
 
-<!-- If you are filing a feature request, please have a look at the document on contributing first: https://github.com/Automattic/vip-go-ci/blob/main/CONTRIBUTING.md -->
+<!-- If you are filing a feature request, please have a look at the document on contributing first: https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md -->
 
 <!-- Please use the following template when filing a bug report: -->
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,6 +1,6 @@
 <!-- ATTENTION: :wave: Just a quick reminder that this is a PUBLIC repository. Please do not include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask! -->
 
-<!-- Please have a look at the document on contributing before submitting a pull request: https://github.com/Automattic/vip-go-ci/blob/main/CONTRIBUTING.md -->
+<!-- Please have a look at the document on contributing before submitting a pull request: https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md -->
 
 <!--
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vip-go-ci
 
-[![Release Date of the Latest Version](https://img.shields.io/github/release-date/Automattic/vip-go-ci.svg?maxAge=1800)](https://github.com/Automattic/vip-go-ci/releases) [![CircleCI](https://circleci.com/gh/Automattic/vip-go-ci/tree/main.svg?style=shield)](https://circleci.com/gh/Automattic/vip-go-ci/tree/main) [![Number of Contributors](https://img.shields.io/github/contributors/Automattic/vip-go-ci.svg?maxAge=3600)](https://github.com/Automattic/vip-go-ci/graphs/contributors)
+[![Release Date of the Latest Version](https://img.shields.io/github/release-date/Automattic/vip-go-ci.svg?maxAge=1800)](https://github.com/Automattic/vip-go-ci/releases) [![CircleCI](https://circleci.com/gh/Automattic/vip-go-ci/tree/trunk.svg?style=shield)](https://circleci.com/gh/Automattic/vip-go-ci/tree/trunk) [![Number of Contributors](https://img.shields.io/github/contributors/Automattic/vip-go-ci.svg?maxAge=3600)](https://github.com/Automattic/vip-go-ci/graphs/contributors)
 
 Continuous integration for VIP Go repositories.
 
@@ -227,7 +227,7 @@ You can set up `vip-go-ci` with TeamCity, so that when a commit gets pushed to G
 
 This flowchart shows how `vip-go-ci` interacts with TeamCity, git, GitHub, and the utilities it uses:
 
-![Flowchart](https://raw.githubusercontent.com/Automattic/vip-go-ci/main/docs/vipgoci-flow.png)
+![Flowchart](https://raw.githubusercontent.com/Automattic/vip-go-ci/trunk/docs/vipgoci-flow.png)
 
 To get `vip-go-ci` working, follow these steps:
 
@@ -252,7 +252,7 @@ To get `vip-go-ci` working, follow these steps:
 if [ -d ~/vip-go-ci-tools ] ; then
 	bash ~/vip-go-ci-tools/vip-go-ci/tools-init.sh
 else
-	wget https://raw.githubusercontent.com/Automattic/vip-go-ci/main/tools-init.sh -O tools-init.sh && \
+	wget https://raw.githubusercontent.com/Automattic/vip-go-ci/trunk/tools-init.sh -O tools-init.sh && \
 	bash tools-init.sh && \
 	rm -f tools-init.sh
 fi
@@ -634,7 +634,7 @@ There are further parameters for more advanced usage:
 
 The feature can be used in the following fashion:
 
-> ./vip-go-ci.php --post-generic-pr-support-comments=true --post-generic-pr-support-comments-string="This is a generic support message from `vip-go-ci`. We hope this is useful." --post-generic-pr-support-comments-branches="main" --post-generic-pr-support-comments-skip-if-label-exists="requesting-review"
+> ./vip-go-ci.php --post-generic-pr-support-comments=true --post-generic-pr-support-comments-string="This is a generic support message from `vip-go-ci`. We hope this is useful." --post-generic-pr-support-comments-branches="trunk" --post-generic-pr-support-comments-skip-if-label-exists="requesting-review"
 
 The `--post-generic-pr-support-comments-branches` parameter can be specified as 'any' to allow posting to any branch. With the `--post-generic-pr-support-comments-skip-if-label-exists` parameter posting of the generic support message is not performed if the label specified in the parameter is already attached to the pull request.
 
@@ -642,7 +642,7 @@ You can limit what pull requests the generic support message are posted to, give
 
 For example:
 
-> ./vip-go-ci.php --post-generic-pr-support-comments=true --post-generic-pr-support-comments-string="This ..." --post-generic-pr-support-comments-branches="main" --post-generic-pr-support-comments-repo-meta-match="support_message=true,support_plan=true" 
+> ./vip-go-ci.php --post-generic-pr-support-comments=true --post-generic-pr-support-comments-string="This ..." --post-generic-pr-support-comments-branches="trunk" --post-generic-pr-support-comments-repo-meta-match="support_message=true,support_plan=true" 
 
 With the `--post-generic-pr-support-comments-repo-meta-match` parameter added, `vip-go-ci` will look at the data returned by the repo-meta API, and check if these fields and their values are found in there for at least one entry. If so, the generic support message will be posted, and not otherwise.
 

--- a/tools-init.sh
+++ b/tools-init.sh
@@ -111,7 +111,7 @@ if [ "$VIP_GO_CI_VER" == "" ] ; then
 	TMP_FILE=`mktemp /tmp/vip-go-ci-latest-release-XXXXX.php`
 
 	echo "$0: Trying to determine latest release of vip-go-ci, need to fetch latest-release.php first..."
-	wget -O "$TMP_FILE" https://raw.githubusercontent.com/Automattic/vip-go-ci/main/latest-release.php && \
+	wget -O "$TMP_FILE" https://raw.githubusercontent.com/Automattic/vip-go-ci/trunk/latest-release.php && \
 	chmod u+x "$TMP_FILE" && \
 	export VIP_GO_CI_VER=`php $TMP_FILE` && \
 	rm "$TMP_FILE" && \


### PR DESCRIPTION
Updates `README.md` file, template files in `.github` and `tools-init.sh` to reflect that the `main` branch is now named `trunk`.

TODO:
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #275 ]

