### PR TITLE
Utilize 'latest' branch in documentation and in scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For example:
 if [ -d ~/vip-go-ci-tools ] ; then
 	bash ~/vip-go-ci-tools/vip-go-ci/tools-init.sh
 else
-	wget https://raw.githubusercontent.com/Automattic/vip-go-ci/trunk/tools-init.sh -O tools-init.sh && \
+	wget https://raw.githubusercontent.com/Automattic/vip-go-ci/latest/tools-init.sh -O tools-init.sh && \
 	bash tools-init.sh && \
 	rm -f tools-init.sh
 fi

--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ If you have a feature request, please read the [file on contributing](CONTRIBUTI
 
 `vip-go-ci` comes with a small utility, `tools-init.sh`, that will install PHPCS and related tools in your home-directory upon execution. This utility will check if the tools required are installed, and if not, install them, or if they are, check if they are of the latest version, and upgrade them as needed. It is highly recommended to run this utility on a regular basis.
 
+For example:
+
+```
+#
+# If ~/vip-go-ci-tools does not exist, install it by 
+# fetching and running tools-init.sh. If it does exist, 
+# run tools-init.sh to check for updates.
+#
+
+if [ -d ~/vip-go-ci-tools ] ; then
+	bash ~/vip-go-ci-tools/vip-go-ci/tools-init.sh
+else
+	wget https://raw.githubusercontent.com/Automattic/vip-go-ci/trunk/tools-init.sh -O tools-init.sh && \
+	bash tools-init.sh && \
+	rm -f tools-init.sh
+fi
+```
+
 ### Running on the console, standalone
 
 `vip-go-ci` can be run standalone on the console. This is mainly useful for debugging purposes and to understand if everything is correctly configured, but for production purposes it should ideally be run via some kind of build management software (for instance TeamCity or GitHub Actions). To run `vip-go-ci` on the console, a few tools are required. The `tools-init.sh` script that is included will install the tools needed.

--- a/tools-init.sh
+++ b/tools-init.sh
@@ -111,7 +111,7 @@ if [ "$VIP_GO_CI_VER" == "" ] ; then
 	TMP_FILE=`mktemp /tmp/vip-go-ci-latest-release-XXXXX.php`
 
 	echo "$0: Trying to determine latest release of vip-go-ci, need to fetch latest-release.php first..."
-	wget -O "$TMP_FILE" https://raw.githubusercontent.com/Automattic/vip-go-ci/trunk/latest-release.php && \
+	wget -O "$TMP_FILE" https://raw.githubusercontent.com/Automattic/vip-go-ci/latest/latest-release.php && \
 	chmod u+x "$TMP_FILE" && \
 	export VIP_GO_CI_VER=`php $TMP_FILE` && \
 	rm "$TMP_FILE" && \

--- a/tools-init.sh
+++ b/tools-init.sh
@@ -90,7 +90,7 @@ if [ -d ~/vip-go-ci-tools ] ; then
 	export TMP_RAND=`seq 1 3 | sort -R | head -n 1`
 
 	if [ "$TMP_RAND" -ne "1" ] ; then
-		echo "$0: Not due to update anything, exiting"
+		echo "$0: Will not check for updates at this time, exiting"
 		lock_remove
 		exit 1
 	fi


### PR DESCRIPTION
Utilize the `latest` tag in documentation and scripts to ensure that only the latest released editions of `tools-init.sh` and `latest-release.php` – released as a part of `vip-go-ci` – are used when installing utilities and checking for latest `vip-go-ci` version number. 

TODO:
- [x] Add `latest` tag to repository.
- [x] Switch from `trunk` to `latest` in `tools-init.sh` in README.md and add example.
- [x] Switch from `trunk` to `latest` in `tools-init.sh`.
- [x] Document how to add `latest` tag when a new version is released.
- [x] Check status of automated tests.
- [x] Changelog entry (for VIP) [ #275 ]

Note that support for these tools may be removed in the future, see #194. 
