### PR TITLE
Re-enable auto-approval of removed SVG files

### DIFF
--- a/ap-svg-files.php
+++ b/ap-svg-files.php
@@ -54,7 +54,7 @@ function vipgoci_ap_svg_files(
 			$pr_item->base->sha,
 			$options['commit'],
 			true, // Include renamed files.
-			false, // Exclude removed files.
+			true, // Include removed files.
 			true // Include permission changes.
 		);
 
@@ -106,6 +106,20 @@ function vipgoci_ap_svg_files(
 
 				$auto_approved_files_arr[ $pr_diff_file_name ]
 					= 'ap-svg-files';
+			} elseif ( 'removed' === $pr_diff['files_status'][ $pr_diff_file_name ] ) {
+				vipgoci_log(
+					'Adding SVG file to list of ' .
+						'approved files, as it was ' .
+						'removed',
+					array(
+						'file_name' =>
+							$pr_diff_file_name,
+					)
+				);
+
+				$auto_approved_files_arr[ $pr_diff_file_name ] =
+					'ap-svg-files';
+				continue;
 			}
 
 			/*

--- a/git-repo.php
+++ b/git-repo.php
@@ -1652,14 +1652,15 @@ function vipgoci_git_diffs_fetch(
 	 */
 
 	$results = array(
-		'statistics'  => array(
+		'statistics'   => array(
 			VIPGOCI_GIT_DIFF_CALC_CHANGES['+'] => 0,
 			VIPGOCI_GIT_DIFF_CALC_CHANGES['-'] => 0,
 			'changes'                          => 0,
 		),
 
-		'files'       => array(),
-		'data_source' => $diff_results_data_source,
+		'files'        => array(),
+		'files_status' => array(),
+		'data_source'  => $diff_results_data_source,
 	);
 
 	foreach ( $diff_results['files'] as $file_item ) {
@@ -1721,6 +1722,12 @@ function vipgoci_git_diffs_fetch(
 
 		$results['files'][ $file_item['filename'] ] =
 			$file_item['patch'];
+
+		/*
+		 * Add status information for file.
+		 */
+		$results['files_status'][ $file_item['filename'] ] =
+			$file_item['status'];
 
 		/*
 		 * Add this file to statistics

--- a/tests/integration/ApSvgFilesTest.php
+++ b/tests/integration/ApSvgFilesTest.php
@@ -247,6 +247,7 @@ final class ApSvgFilesTest extends TestCase {
 				'auto-approvable-2-renamed.svg' => 'ap-svg-files',
 				'auto-approvable-7.svg'         => 'ap-svg-files',
 				'auto-approvable3.svg'          => 'ap-svg-files',
+				'auto-approvable4.svg'          => 'ap-svg-files',
 			),
 			$auto_approved_files_arr
 		);

--- a/tests/integration/GitDiffsFetchTest.php
+++ b/tests/integration/GitDiffsFetchTest.php
@@ -126,15 +126,18 @@ final class GitDiffsFetchTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'statistics' => array(
-					'additions'	=> 1,
-					'deletions'	=> 0,
-					'changes'	=> 1,
+				'statistics'   => array(
+					'additions' => 1,
+					'deletions' => 0,
+					'changes'   => 1,
 				),
-				'files' => array(
-					'content-changed-file.txt'	=> '@@ -0,0 +1 @@' . PHP_EOL . '+Test file',
+				'files'        => array(
+					'content-changed-file.txt' => '@@ -0,0 +1 @@' . PHP_EOL . '+Test file',
 				),
-				'data_source'	=> VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
+				'files_status' => array(
+					'content-changed-file.txt' => 'added',
+				),
+				'data_source'  => VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
 			),
 			$diff
 		);
@@ -190,16 +193,20 @@ final class GitDiffsFetchTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'statistics'	=> array(
+				'statistics'   => array(
 					'additions'	=> 1,
 					'deletions'	=> 0,
 					'changes'	=> 1,
 				),
-				'files'	=> array(
-					'README.md'			=> '',
-					'content-changed-file.txt'	=> '@@ -0,0 +1 @@' . PHP_EOL . '+Test file',
+				'files'        => array(
+					'README.md'                => '',
+					'content-changed-file.txt' => '@@ -0,0 +1 @@' . PHP_EOL . '+Test file',
 				),
-				'data_source'	=> VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
+				'files_status' => array(
+					'README.md'                => 'modified',
+					'content-changed-file.txt' => 'added',
+				),
+				'data_source'  => VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
 			),
 			$diff
 		);
@@ -255,15 +262,18 @@ final class GitDiffsFetchTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'statistics'	=> array(
-					'additions'	=> 0,
-					'deletions'	=> 0,
-					'changes'	=> 0,
+				'statistics'   => array(
+					'additions' => 0,
+					'deletions' => 0,
+					'changes'   => 0,
 				),
-				'files'		=> array(
-					'renamed-file2.txt'			=> '',
+				'files'        => array(
+					'renamed-file2.txt' => '',
 				),
-				'data_source'	=> VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
+				'files_status' => array(
+					'renamed-file2.txt' => 'renamed',
+				),
+				'data_source'  => VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
 			),
 			$diff
 		);
@@ -319,14 +329,14 @@ final class GitDiffsFetchTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'statistics'	=> array(
-					'additions'	=> 0,
-					'deletions'	=> 0,
-					'changes'	=> 0,
+				'statistics'   => array(
+					'additions' => 0,
+					'deletions' => 0,
+					'changes'   => 0,
 				),
-				'files'		=> array(
-				),
-				'data_source'	=> VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
+				'files'        => array(),
+				'files_status' => array(),
+				'data_source'  => VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
 			),
 			$diff
 		);
@@ -382,18 +392,21 @@ final class GitDiffsFetchTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'statistics'	=> array(
-					'additions'	=> 0,
-					'deletions'	=> 2,
-					'changes'	=> 2,
+				'statistics'   => array(
+					'additions' => 0,
+					'deletions' => 2,
+					'changes'   => 2,
 				),
-				'files'		=> array(
-					'renamed-file2.txt'	=>
+				'files'        => array(
+					'renamed-file2.txt' =>
 						'@@ -1,2 +0,0 @@' . PHP_EOL .
 						'-# vip-go-ci-testing' . PHP_EOL .
 						'-Pull-Requests, commits and data to test <a href="https://github.com/automattic/vip-go-ci/">vip-go-ci</a>\'s functionality. Please do not remove or alter unless you\'ve contacted the VIP Team first. ',
 				),
-				'data_source'	=> VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
+				'files_status' => array(
+					'renamed-file2.txt' => 'removed',
+				),
+				'data_source'  => VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
 			),
 			$diff
 		);
@@ -449,14 +462,14 @@ final class GitDiffsFetchTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'statistics'	=> array(
-					'additions'	=> 0,
-					'deletions'	=> 0,
-					'changes'	=> 0,
+				'statistics'   => array(
+					'additions' => 0,
+					'deletions' => 0,
+					'changes'   => 0,
 				),
-				'files'		=> array(
-				),
-				'data_source'	=> VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
+				'files'        => array(),
+				'files_status' => array(),
+				'data_source'  => VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
 			),
 			$diff
 		);
@@ -512,16 +525,20 @@ final class GitDiffsFetchTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'statistics'	=> array(
-					'additions'	=> 1,
-					'deletions'	=> 0,
-					'changes'	=> 1,
+				'statistics'   => array(
+					'additions' => 1,
+					'deletions' => 0,
+					'changes'   => 1,
 				),
-				'files'		=> array(
+				'files'        => array(
 					'content-changed-file.txt' => '@@ -0,0 +1 @@' . PHP_EOL . '+Test file',
-					'renamed-file2.txt' => '',
+					'renamed-file2.txt'        => '',
 				),
-				'data_source'	=> VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
+				'files_status' => array(
+					'content-changed-file.txt' => 'added',
+					'renamed-file2.txt'        => 'renamed',
+				),
+				'data_source'  => VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
 			),
 			$diff
 		);
@@ -582,14 +599,14 @@ final class GitDiffsFetchTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'statistics'	=> array(
-					'additions'	=> 0,
-					'deletions'	=> 0,
-					'changes'	=> 0,
+				'statistics'   => array(
+					'additions' => 0,
+					'deletions' => 0,
+					'changes'   => 0,
 				),
-				'files'		=> array(
-				),
-				'data_source'	=> VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
+				'files'        => array(),
+				'files_status' => array(),
+				'data_source'  => VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
 			),
 			$diff
 		);
@@ -650,16 +667,20 @@ final class GitDiffsFetchTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'statistics'	=> array(
-					'additions'	=> 1,
-					'deletions'	=> 0,
-					'changes'	=> 1,
+				'statistics'   => array(
+					'additions' => 1,
+					'deletions' => 0,
+					'changes'   => 1,
 				),
-				'files'		=> array(
-					'content-changed-file.txt'	=> '@@ -0,0 +1 @@' . PHP_EOL . '+Test file',
-					'renamed-file2.txt'		=> '',
+				'files'        => array(
+					'content-changed-file.txt' => '@@ -0,0 +1 @@' . PHP_EOL . '+Test file',
+					'renamed-file2.txt'        => '',
 				),
-				'data_source'	=> VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
+				'files_status' => array(
+					'content-changed-file.txt' => 'added',
+					'renamed-file2.txt'        => 'renamed',
+				),
+				'data_source'  => VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
 			),
 			$diff
 		);
@@ -721,15 +742,18 @@ final class GitDiffsFetchTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'statistics'	=> array(
-					'additions'	=> 1,
-					'deletions'	=> 0,
-					'changes'	=> 1,
+				'statistics'   => array(
+					'additions' => 1,
+					'deletions' => 0,
+					'changes'   => 1,
 				),
-				'files'		=> array(
+				'files'        => array(
 					'content-changed-file.txt' => '@@ -0,0 +1 @@' . PHP_EOL . '+Test file',
 				),
-				'data_source'	=> VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
+				'files_status' => array(
+					'content-changed-file.txt' => 'added',
+				),
+				'data_source'  => VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO,
 			),
 			$diff
 		);
@@ -790,17 +814,21 @@ final class GitDiffsFetchTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'statistics'	=> array(
-					'additions'	=> 5,
-					'deletions'	=> 0,
-					'changes'	=> 5,
+				'statistics'   => array(
+					'additions' => 5,
+					'deletions' => 0,
+					'changes'   => 5,
 				),
-				'files'		=> array(
+				'files'        => array(
 					'test1.php' => '@@ -0,0 +1,4 @@' . PHP_EOL . '+<?php' . PHP_EOL . '+' . PHP_EOL . '+echo \'time: \' . time() . PHP_EOL;' . PHP_EOL . '+',
-					'test2.txt' => '@@ -0,0 +1 @@' . PHP_EOL . '+Testing!'
+					'test2.txt' => '@@ -0,0 +1 @@' . PHP_EOL . '+Testing!',
 
 				),
-				'data_source'	=> VIPGOCI_GIT_DIFF_DATA_SOURCE_GITHUB_API,
+				'files_status' => array(
+					'test1.php' => 'added',
+					'test2.txt' => 'added',
+				),
+				'data_source'  => VIPGOCI_GIT_DIFF_DATA_SOURCE_GITHUB_API,
 			),
 			$diff
 		);

--- a/tests/integration/MainRunScanTotalCommentsMaxWarningPostTest.php
+++ b/tests/integration/MainRunScanTotalCommentsMaxWarningPostTest.php
@@ -66,7 +66,7 @@ final class MainRunScanTotalCommentsMaxWarningPostTest extends TestCase {
 
 		$this->options['commit'] = $this->options['commit-test-run-scan-total-comments-max-warning-post'];
 
-		$this->options['pr_number'] = $this->options['pr-test-run-scan-total-comments-max-warning-post'];
+		$this->options['pr_number'] = (int) $this->options['pr-test-run-scan-total-comments-max-warning-post'];
 
 		if ( ! empty( $this->options['github-token'] ) ) {
 			$this->options['token'] = $this->options['github-token'];

--- a/tests/integration/MainRunScanTotalCommentsMaxWarningPostTest.php
+++ b/tests/integration/MainRunScanTotalCommentsMaxWarningPostTest.php
@@ -66,7 +66,7 @@ final class MainRunScanTotalCommentsMaxWarningPostTest extends TestCase {
 
 		$this->options['commit'] = $this->options['commit-test-run-scan-total-comments-max-warning-post'];
 
-		$this->options['pr_number'] = (int) $this->options['pr-test-run-scan-total-comments-max-warning-post'];
+		$this->options['pr_number'] = $this->options['pr-test-run-scan-total-comments-max-warning-post'];
 
 		if ( ! empty( $this->options['github-token'] ) ) {
 			$this->options['token'] = $this->options['github-token'];


### PR DESCRIPTION
Re-enables auto-approval of SVG files removed from pull requests. The functionality was disabled temporarily in #272. 

TODO:
- [x] Add `files_status` field to results from `vipgoci_git_diffs_fetch()`.
- [x] Use `files_status` field in `vipgoci_ap_svg_files()` to auto-approve removed SVG files, include removed files in diff.
- [x] Update test `tests/integration/GitDiffsFetchTest.php` to assume `files_status` field.
- [x] Update test `tests/integration/ApSvgFilesTest.php` to assume removed SVG file as auto-approved.
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #275 ]
