### PR TITLE
Fix problem with removed files in non-functional auto-approvals and add sanity checks elsewhere

### DIFF
--- a/ap-nonfunctional-changes.php
+++ b/ap-nonfunctional-changes.php
@@ -57,7 +57,7 @@ function vipgoci_ap_nonfunctional_changes(
 			$pr_item->base->sha,
 			$options['commit'],
 			true, // Renamed files included.
-			true, // Removed files included.
+			false, // Removed files excluded.
 			true, // Permission changes included.
 			null
 		);
@@ -154,7 +154,7 @@ function vipgoci_ap_nonfunctional_changes(
 				$options['local-git-repo']
 			);
 
-			if ( null === $pr_diff_file_new_contents ) {
+			if ( false === $pr_diff_file_new_contents ) {
 				/*
 				 * If we could not find the file
 				 * in this commit, skip and continue.

--- a/lint-scan.php
+++ b/lint-scan.php
@@ -358,6 +358,16 @@ function vipgoci_lint_scan_multiple_files(
 			$options['local-git-repo']
 		);
 
+		if ( false === $file_contents ) {
+			vipgoci_sysexit(
+				'Unable to fetch file from repository',
+				array(
+					'filename' => $filename,
+				),
+				VIPGOCI_EXIT_SYSTEM_PROBLEM
+			);
+		}
+
 		// Save file contents in a temporary-file.
 		$temp_file_name = vipgoci_save_temp_file(
 			'vipgoci-lint-scan-',

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -319,6 +319,16 @@ function vipgoci_phpcs_scan_single_file(
 		$options['local-git-repo']
 	);
 
+	if ( false === $file_contents ) {
+		vipgoci_sysexit(
+			'Unable to fetch file from repository',
+			array(
+				'file_name' => $file_name,
+			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
+		);
+	}
+
 	$file_extension = vipgoci_file_extension_get(
 		$file_name
 	);

--- a/svg-scan.php
+++ b/svg-scan.php
@@ -213,6 +213,16 @@ function vipgoci_svg_scan_single_file(
 		$options['local-git-repo']
 	);
 
+	if ( false === $file_contents ) {
+		vipgoci_sysexit(
+			'Unable to fetch file from repository',
+			array(
+				'file_name' => $file_name,
+			),
+			VIPGOCI_EXIT_SYSTEM_PROBLEM
+		);
+	}
+
 	/*
 	 * Determine file-ending of the file,
 	 * then save it into temporary file

--- a/tests/integration/ApNonfunctionalChangesTest.php
+++ b/tests/integration/ApNonfunctionalChangesTest.php
@@ -13,7 +13,8 @@ final class ApNonfunctionalChangesTest extends TestCase {
 	);
 
 	var $options_auto_approvals_nonfunc = array(
-		'commit-test-ap-nonfunctionalchanges-1b'	=> null,
+		'commit-test-ap-nonfunctionalchanges-1b' => null,
+		'commit-test-ap-nonfunctionalchanges-2'  => null,
 	);
 
 	protected function setUp(): void {
@@ -47,18 +48,12 @@ final class ApNonfunctionalChangesTest extends TestCase {
 			$this->options['github-token'];
 
 		unset( $this->options['github-token'] );
-	
-		$this->options['commit'] =
-			$this->options['commit-test-ap-nonfunctionalchanges-1b'];
-	
+
+		$this->options['local-git-repo'] = false;
+
 		$this->options['autoapprove'] = true;
 
 		$this->options['branches-ignore'] = array();
-
-		$this->options['local-git-repo'] =
-			vipgoci_unittests_setup_git_repo(
-				$this->options
-			);
 
 		$this->options['skip-draft-prs'] = false;
 	}
@@ -76,11 +71,21 @@ final class ApNonfunctionalChangesTest extends TestCase {
 	}
 
 	/**
+	 * Test pull request in which multiple files are altered but
+	 * only two are auto-approvable.
+	 *
 	 * @covers ::vipgoci_ap_nonfunctional_changes
 	 */
 	public function testNonFunctionalChanges1() {
-
 		$auto_approved_files_arr = array();
+
+		$this->options['commit'] =
+			$this->options['commit-test-ap-nonfunctionalchanges-1b'];
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
 
 		vipgoci_unittests_output_suppress();
 
@@ -93,12 +98,51 @@ final class ApNonfunctionalChangesTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'file1.php'	=> 'autoapprove-nonfunctional-changes',
-				'file2.php'	=> 'autoapprove-nonfunctional-changes',
+				'file1.php' => 'autoapprove-nonfunctional-changes',
+				'file2.php' => 'autoapprove-nonfunctional-changes',
+
 				/*
 				 * - file3.php is not approved, has changed functionally
 				 * - file100.txt is not approvable by this function
 				 * - file101.png, same.
+				 */
+			),
+			$auto_approved_files_arr
+		);
+	}
+
+	/**
+	 * Test pull request in which on file is removed
+	 * and another one is altered.
+	 *
+	 * @covers ::vipgoci_ap_nonfunctional_changes
+	 */
+	public function testNonFunctionalChanges2() {
+		$auto_approved_files_arr = array();
+
+		$this->options['commit'] =
+			$this->options['commit-test-ap-nonfunctionalchanges-2'];
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
+
+		vipgoci_unittests_output_suppress();
+
+		vipgoci_ap_nonfunctional_changes(
+			$this->options,
+			$auto_approved_files_arr
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertSame(
+			array(
+				'file1.php' => 'autoapprove-nonfunctional-changes',
+
+				/*
+				 * - file2.php is not approved, has been removed.
 				 */
 			),
 			$auto_approved_files_arr

--- a/unittests.ini.dist
+++ b/unittests.ini.dist
@@ -61,6 +61,7 @@ commit-test-ap-auto-approval-1=5a891b161ec88bd885cd09e3fd370399921508d8
 pr-test-ap-auto-approval-1=46
 
 commit-test-ap-nonfunctionalchanges-1b=c4a3fe05f67f329cdf884392df29e55f5b8d4498
+commit-test-ap-nonfunctionalchanges-2=57e7dbf5103048e4c4633e8dbd22cce0b422184b
 
 [git-repo-tests]
 commit-test-repo-ok-1=14f69e021aa814eeaa62566cc8cfa2b426d25b5c


### PR DESCRIPTION
This pull request fixes a problem with non-functional auto-approvals were files are removed. Previously, these could result in an unexpected exit. A sanity check is added to ensure this will not happen. Similar checks are added throughout the code were similar situation could arise.

Also with this patch, the non-functional changes mechanism no longer will consider removed files for auto-approvals.

TODO:
- [x] Check status of automated tests
- [x] Add test for situation were PHP file is removed.
- [x] Changelog entry (for VIP) [#288]
