### PR TITLE
Add allow list for file filtering function

### DIFF
--- a/misc.php
+++ b/misc.php
@@ -439,7 +439,7 @@ function vipgoci_filter_file_path(
 		( isset( $filter['include_folders'] ) )
 	) {
 		/*
-		 * Loop through all include-folders.
+		 * Loop through all include-folders specified.
 		 */
 		foreach (
 			$filter['include_folders'] as $tmp_include_folder_item
@@ -456,8 +456,7 @@ function vipgoci_filter_file_path(
 			);
 
 			/*
-			 * If it's a match, that folder is to be not skipped.
-			 * Otherwise, it's skipped.
+			 * If it's not a match, then that folder is to be skipped.
 			 *
 			 * There can only be 1 match with the filename so the
 			 * moment that happens, we break out.

--- a/misc.php
+++ b/misc.php
@@ -449,19 +449,26 @@ function vipgoci_filter_file_path(
 			 *
 			 * $filename we expect to be a relative path.
 			 */
-
 			$file_folders_match = strpos(
 				$filename,
 				$tmp_include_folder_item . '/'
 			);
 
 			/*
-			 * It's a match only if the path doesn't
-			 * contain the folder to include.
+			 * If it's a match, that folder is to be not skipped.
+			 * Otherwise, it's skipped.
+			 * 
+			 * There can only be 1 match with the filename so the
+			 * moment that happens, we break out.
 			 */
-			if ( false === $file_folders_match ) {
-				$file_folders_match = true;
+			if (
+				( false !== $file_folders_match ) &&
+				( is_numeric( $file_folders_match ) )
+			) {
+				$file_folders_match = false;
 				break;
+			} else {
+				$file_folders_match = true;
 			}
 		}
 	}

--- a/misc.php
+++ b/misc.php
@@ -433,6 +433,37 @@ function vipgoci_filter_file_path(
 				break;
 			}
 		}
+	} else if (
+		( null !== $filter ) &&
+		( isset( $filter['include_folders'] ) )
+	){
+		/*
+		 * Loop through all include-folders.
+		 */
+		foreach (
+			$filter['include_folders'] as $tmp_include_folder_item
+		) {
+			/*
+			 * Note: All 'include_folders' options should lack '/' at the
+			 * end and beginning.
+			 *
+			 * $filename we expect to be a relative path.
+			 */
+
+			$file_folders_match = strpos(
+				$filename,
+				$tmp_include_folder_item . '/'
+			);
+
+			/*
+			 * It's a match only if the path doesn't
+			 * contain the folder to include.
+			 */
+			if ( false === $file_folders_match ) {
+				$file_folders_match = true;
+				break;
+			}
+		}
 	}
 
 	/*

--- a/misc.php
+++ b/misc.php
@@ -354,8 +354,9 @@ function vipgoci_file_extension_get(
 
 /**
  * Determine if the presented file has an
- * allowable file-ending, and if the file presented
- * is in a directory that is can be scanned.
+ * allowable file-ending, if the file presented
+ * is in a directory that can be skipped or included
+ * for scanning.
  *
  * @param string     $filename File name; is expected to be a relative path to the git-repository root.
  * @param null|array $filter   Filter to apply.
@@ -433,10 +434,10 @@ function vipgoci_filter_file_path(
 				break;
 			}
 		}
-	} else if (
+	} elseif (
 		( null !== $filter ) &&
 		( isset( $filter['include_folders'] ) )
-	){
+	) {
 		/*
 		 * Loop through all include-folders.
 		 */
@@ -457,7 +458,7 @@ function vipgoci_filter_file_path(
 			/*
 			 * If it's a match, that folder is to be not skipped.
 			 * Otherwise, it's skipped.
-			 * 
+			 *
 			 * There can only be 1 match with the filename so the
 			 * moment that happens, we break out.
 			 */

--- a/tests/unit/MiscFilterFilePathTest.php
+++ b/tests/unit/MiscFilterFilePathTest.php
@@ -222,6 +222,100 @@ final class MiscFilterFilePathTest extends TestCase {
 
 	}
 
+	/**
+	  * @covers ::vipgoci_filter_file_path
+	  */
+	  public function testFilterFilePath6() {
+		$file_name = 'folder1/file1.txt';
 
+		$this->assertFalse(
+			vipgoci_filter_file_path(
+				$file_name,
+				array(
+					'include_folders' => array(
+						'folder2',
+					)
+				)
+			)
+		);
 
+		$this->assertTrue(
+			vipgoci_filter_file_path(
+				$file_name,
+				array(
+					'include_folders' => array(
+						'folder1',
+					)
+				)
+			)
+		);
+	}
+
+		/**
+	  * @covers ::vipgoci_filter_file_path
+	  */
+	  public function testFilterFilePath7() {
+		$file_name = 'my/unit-tests/folder1/subfolder/file1.txt';
+
+		$this->assertFalse(
+			vipgoci_filter_file_path(
+				$file_name,
+				array(
+					'include_folders' => array(
+						'folder200',
+						'folder3000',
+						'folder4000/folder5000/folder6000',
+						'SubFolder' // Note: capital 'F'
+					),
+				)
+			)
+		);
+
+		$this->assertTrue(
+			vipgoci_filter_file_path(
+				$file_name,
+				array(
+					'include_folders' => array(
+						'unit-tests/folder1/subfolder', // Note: Unlike skip_folders, this is allowed when it's not at root level
+					),
+				)
+			)
+		);
+
+		$this->assertTrue(
+			vipgoci_filter_file_path(
+				$file_name,
+				array(
+					'include_folders' => array(
+						'somefoldertesting/otherfolder/foobar123',
+						'somefoldertesting/otherfolder/foobar321',
+						'my/unit-tests/folder1/subfolder',
+					),
+				)
+			)
+		);
+
+		$this->assertTrue(
+			vipgoci_filter_file_path(
+				$file_name,
+				array(
+					'include_folders' => array(
+						'my/unit-tests',
+					),
+				)
+			)
+		);
+
+		$this->assertFalse(
+			vipgoci_filter_file_path(
+				$file_name,
+				array(
+					'include_folders' => array(
+						'test',
+					),
+				)
+			)
+		);
+
+	}
 }


### PR DESCRIPTION
This is meant to add the ability to pass an allow list for file filtering. This means that:

allow list -> node_modules

So any file that is NOT in the node_modules folder will be filtered. Only the node_modules files will be allowed.

This introduces a new option that has to be passed in called include_folders. There's no other change outside this function, so it's not exposed within the cli.

TODO:
- [x] Add/update tests -- unit and/or integrated
- [x] Check status of automated tests
- [x] Changelog entry [ #290 ]