### PR TITLE
Fix two problems with local git diffs

### DIFF
--- a/git-repo.php
+++ b/git-repo.php
@@ -1386,7 +1386,14 @@ function vipgoci_gitrepo_diffs_fetch_unfiltered(
 					 */
 
 					$cur_file        = $cur_file_plus;
-					$cur_file_status = 'renamed';
+
+					/*
+					 * Avoid resetting status if determined
+					 * that content has been modified elsewhere.
+					 */
+					if ( 'modified' !== $cur_file_status ) {
+						$cur_file_status = 'renamed';
+					}
 				}
 			}
 		}
@@ -1478,6 +1485,19 @@ function vipgoci_gitrepo_diffs_fetch_unfiltered(
 			$diff_results['statistics'][ VIPGOCI_GIT_DIFF_CALC_CHANGES[ $git_result_item[0] ] ]++;
 
 			$diff_results['statistics']['changes']++;
+
+			/*
+			 * Avoid incorrect status for file when file has been
+			 * renamed and modified.
+			 */
+			if (
+				( $diff_results['files'][ $cur_file ]['changes'] > 0 ) &&
+				( 'renamed' === $cur_file_status )
+			) {
+				$cur_file_status = 'modified';
+
+				$diff_results['files'][ $cur_file ]['status'] = $cur_file_status;
+			}
 		}
 
 		/*

--- a/git-repo.php
+++ b/git-repo.php
@@ -1488,7 +1488,8 @@ function vipgoci_gitrepo_diffs_fetch_unfiltered(
 
 			/*
 			 * Avoid incorrect status for file when file has been
-			 * renamed and modified.
+			 * renamed and modified. See similar logic in
+			 * vipgoci_github_diffs_fetch_unfiltered().
 			 */
 			if (
 				( $diff_results['files'][ $cur_file ]['changes'] > 0 ) &&

--- a/git-repo.php
+++ b/git-repo.php
@@ -1382,10 +1382,10 @@ function vipgoci_gitrepo_diffs_fetch_unfiltered(
 				} else {
 					/*
 					 * No match and no mention of /dev/null,
-					 * so the file must have been renamed.
+					 * so the file must have been renamed
+					 * (with exceptions, see below).
 					 */
-
-					$cur_file        = $cur_file_plus;
+					$cur_file = $cur_file_plus;
 
 					/*
 					 * Avoid resetting status if determined

--- a/github-api.php
+++ b/github-api.php
@@ -122,6 +122,20 @@ function vipgoci_github_diffs_fetch_unfiltered(
 	);
 
 	foreach ( array_values( $resp_raw['files'] ) as $file_item ) {
+		/*
+		 * If there are content modifications to the file,
+		 * and GitHub indiciates file status is 'renamed',
+		 * override status as 'modified'. This is in line
+		 * with expectations elsewhere in the code. See
+		 * similar logic in vipgoci_gitrepo_diffs_fetch_unfiltered().
+		 */
+		if (
+			( $file_item['changes'] > 0 ) &&
+			( 'renamed' === $file_item['status'] )
+		) {
+			$file_item['status'] = 'modified';
+		}
+
 		$diff_results['files'][ $file_item['filename'] ] = array(
 			'filename'  => $file_item['filename'],
 			'patch'     => (

--- a/github-api.php
+++ b/github-api.php
@@ -124,7 +124,7 @@ function vipgoci_github_diffs_fetch_unfiltered(
 	foreach ( array_values( $resp_raw['files'] ) as $file_item ) {
 		/*
 		 * If there are content modifications to the file,
-		 * and GitHub indiciates file status is 'renamed',
+		 * and GitHub indicates file status is 'renamed',
 		 * override status as 'modified'. This is in line
 		 * with expectations elsewhere in the code. See
 		 * similar logic in vipgoci_gitrepo_diffs_fetch_unfiltered().

--- a/results.php
+++ b/results.php
@@ -844,8 +844,8 @@ function vipgoci_results_comment_match(
 		 * Handle special case (/**) so that it is preserved.
 		 */
 		$comment_made_body = str_replace(
-			array( '/**', '**', 'Warning', 'Error', 'Info', ':no_entry_sign:', ':warning:', ':information_source:', '/\*\*', ),
-			array( '/\*\*', '', '', '', '', '', '', '', '/**', ),
+			array( '/**', '**', 'Warning', 'Error', 'Info', ':no_entry_sign:', ':warning:', ':information_source:', '/\*\*' ),
+			array( '/\*\*', '', '', '', '', '', '', '', '/**' ),
 			$comment_made->body
 		);
 

--- a/results.php
+++ b/results.php
@@ -794,6 +794,8 @@ function vipgoci_results_sort_by_severity(
  * this is used to understand if the specific
  * comment has already been submitted earlier.
  *
+ * Handles special case as well.
+ *
  * @param string $file_issue_path    Path to file.
  * @param int    $file_issue_line    Line number in file.
  * @param string $file_issue_comment Comment to look for.
@@ -838,10 +840,12 @@ function vipgoci_results_comment_match(
 		/*
 		 * The comment might contain formatting, such
 		 * as "Warning: ..." -- remove all of that.
+		 *
+		 * Handle special case (/**) so that it is preserved.
 		 */
 		$comment_made_body = str_replace(
-			array( '**', 'Warning', 'Error', 'Info', ':no_entry_sign:', ':warning:', ':information_source:' ),
-			array( '', '', '', '', '' ),
+			array( '/**', '**', 'Warning', 'Error', 'Info', ':no_entry_sign:', ':warning:', ':information_source:', '/\*\*', ),
+			array( '/\*\*', '', '', '', '', '', '', '', '/**', ),
 			$comment_made->body
 		);
 

--- a/results.php
+++ b/results.php
@@ -841,7 +841,9 @@ function vipgoci_results_comment_match(
 		 * The comment might contain formatting, such
 		 * as "Warning: ..." -- remove all of that.
 		 *
-		 * Handle special case (/**) so that it is preserved.
+		 * Handle special case when "/**" is included in comments.
+		 * Ensure to preserve comments with this pattern, as otherwise
+		 * strings that include them will be re-posted during re-runs.
 		 */
 		$comment_made_body = str_replace(
 			array( '/**', '**', 'Warning', 'Error', 'Info', ':no_entry_sign:', ':warning:', ':information_source:', '/\*\*' ),

--- a/tests/integration/GitDiffsFetchUnfilteredTrait.php
+++ b/tests/integration/GitDiffsFetchUnfilteredTrait.php
@@ -271,9 +271,9 @@ trait GitDiffsFetchUnfilteredTrait {
 			),
 	
 			'statistics' => array(
-				'additions'	=> 20,
-				'deletions'	=> 6,
-				'changes'	=> 26,
+				'additions' => 20,
+				'deletions' => 6,
+				'changes'   => 26,
 			)
 		);
 	}

--- a/tests/integration/GitDiffsFetchUnfilteredTrait.php
+++ b/tests/integration/GitDiffsFetchUnfilteredTrait.php
@@ -145,6 +145,19 @@ trait GitDiffsFetchUnfilteredTrait {
 	private function _dataGitDiffsAssert6() {
 		return array(
 			'files' => array(
+				/* File renamed, content added */
+				'README file.md'                   => array(
+					'filename'          => 'README file.md',
+					'patch'             => "@@ -1,2 +1,5 @@\n" .
+						' # vip-go-ci-testing' . PHP_EOL .
+						' Pull-Requests, commits and data to test <a href="https://github.com/automattic/vip-go-ci/">vip-go-ci</a>\'s functionality. Please do not remove or alter unless you\'ve contacted the VIP Team first. ' . PHP_EOL . '+' . PHP_EOL . '+' . PHP_EOL . '+',
+					'status'            => 'modified',
+					'additions'         => 3,
+					'deletions'         => 0,
+					'changes'           => 3,
+					'previous_filename' => 'README.md',
+				),
+
 				'a/new-file.txt'		=> array(
 					/* File added, starting with name 'a/' */
 					'filename'	=> 'a/new-file.txt',
@@ -155,6 +168,16 @@ trait GitDiffsFetchUnfilteredTrait {
 					'changes'	=> 2,
 				),
 
+				'b/new file 2.txt'                 => array(
+					/* File added, starting with name 'b/', with spaces in file name */
+					'filename'  => 'b/new file 2.txt',
+					'patch'     => '@@ -0,0 +1 @@' . PHP_EOL . '+This is a new file.',
+					'status'    => 'added',
+					'additions' => 1,
+					'deletions' => 0,
+					'changes'   => 1,
+				),
+
 				'b/new-file.txt'		=> array(
 					/* File added, starting with name 'b/' */
 					'filename'	=> 'b/new-file.txt',
@@ -163,6 +186,16 @@ trait GitDiffsFetchUnfilteredTrait {
 					'additions'	=> 3,
 					'deletions'	=> 0,
 					'changes'	=> 3,
+				),
+
+				'new file 2.txt'                   => array(
+					/* File added, starting with name 'b/', with spaces in file name */
+					'filename'  => 'new file 2.txt',
+					'patch'     => '@@ -0,0 +1 @@' . PHP_EOL . '+This is a new test file.',
+					'status'    => 'added',
+					'additions' => 1,
+					'deletions' => 0,
+					'changes'   => 1,
 				),
 
 				'new-file-permissions-changed.txt'	=> array(
@@ -238,9 +271,9 @@ trait GitDiffsFetchUnfilteredTrait {
 			),
 	
 			'statistics' => array(
-				'additions'	=> 15,
+				'additions'	=> 20,
 				'deletions'	=> 6,
-				'changes'	=> 21,
+				'changes'	=> 26,
 			)
 		);
 	}

--- a/tests/integration/GitDiffsFetchUnfilteredTrait.php
+++ b/tests/integration/GitDiffsFetchUnfilteredTrait.php
@@ -189,7 +189,6 @@ trait GitDiffsFetchUnfilteredTrait {
 				),
 
 				'new file 2.txt'                   => array(
-					/* File added, starting with name 'b/', with spaces in file name */
 					'filename'  => 'new file 2.txt',
 					'patch'     => '@@ -0,0 +1 @@' . PHP_EOL . '+This is a new test file.',
 					'status'    => 'added',

--- a/tests/integration/GitHubDiffsFetchUnfilteredTest.php
+++ b/tests/integration/GitHubDiffsFetchUnfilteredTest.php
@@ -284,10 +284,12 @@ final class GitHubDiffsFetchUnfilteredTest extends TestCase {
 			$this->_dataGitDiffsAssert6(),
 			$diff
 		);
-	
+
 		/*
 		 * As an additional check, verify that caching is OK.
 		 */
+		vipgoci_unittests_output_suppress();
+
 		$diff_same = vipgoci_github_diffs_fetch_unfiltered(
 			$this->options['repo-owner'],
 			$this->options['repo-name'],
@@ -295,6 +297,8 @@ final class GitHubDiffsFetchUnfilteredTest extends TestCase {
 			$this->options['commit-test-repo-pr-diffs-2-a'],
 			$this->options['commit-test-repo-pr-diffs-2-b']
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			$diff,

--- a/tests/unit/GitRepoDiffsCleanExtraWhitespaceTest.php
+++ b/tests/unit/GitRepoDiffsCleanExtraWhitespaceTest.php
@@ -38,7 +38,7 @@ final class GitRepoDiffsCleanExtraWhitespaceTest extends TestCase {
 		$this->assertSame(
 			array( "a\t" ),
 			vipgoci_gitrepo_diffs_clean_extra_whitespace(
-				array( "a\t")
+				array( "a\t" )
 			)
 		);
 	}
@@ -52,9 +52,9 @@ final class GitRepoDiffsCleanExtraWhitespaceTest extends TestCase {
 	 */
 	public function testCleanExtraWhitespace2(): void {
 		$this->assertSame(
-			array( "a\t", "b\t", "c.php" ),
+			array( "a\t", "b\t", 'c.php' ),
 			vipgoci_gitrepo_diffs_clean_extra_whitespace(
-				array( "a\t", "b\t", "c.php\t")
+				array( "a\t", "b\t", "c.php\t" )
 			)
 		);
 	}

--- a/tests/unit/GitRepoDiffsCleanExtraWhitespaceTest.php
+++ b/tests/unit/GitRepoDiffsCleanExtraWhitespaceTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Test vipgoci_gitrepo_diffs_clean_extra_whitespace() function.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class that implements the testing.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class GitRepoDiffsCleanExtraWhitespaceTest extends TestCase {
+	/**
+	 * Setup function. Require files, etc.
+	 *
+	 * @return void
+	 */
+	protected function setUp() :void {
+		require_once __DIR__ . '/../../git-repo.php';
+	}
+
+	/**
+	 * Test common usage of the function.
+	 *
+	 * @covers ::vipgoci_gitrepo_diffs_clean_extra_whitespace
+	 *
+	 * @return void
+	 */
+	public function testCleanExtraWhitespace(): void {
+		$this->assertSame(
+			array( "a\t" ),
+			vipgoci_gitrepo_diffs_clean_extra_whitespace(
+				array( "a\t")
+			)
+		);
+
+		$this->assertSame(
+			array( "a\t", "b\t", "c.php" ),
+			vipgoci_gitrepo_diffs_clean_extra_whitespace(
+				array( "a\t", "b\t", "c.php\t")
+			)
+		);
+	}
+}

--- a/tests/unit/GitRepoDiffsCleanExtraWhitespaceTest.php
+++ b/tests/unit/GitRepoDiffsCleanExtraWhitespaceTest.php
@@ -34,14 +34,23 @@ final class GitRepoDiffsCleanExtraWhitespaceTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function testCleanExtraWhitespace(): void {
+	public function testCleanExtraWhitespace1(): void {
 		$this->assertSame(
 			array( "a\t" ),
 			vipgoci_gitrepo_diffs_clean_extra_whitespace(
 				array( "a\t")
 			)
 		);
+	}
 
+	/**
+	 * Test common usage of the function.
+	 *
+	 * @covers ::vipgoci_gitrepo_diffs_clean_extra_whitespace
+	 *
+	 * @return void
+	 */
+	public function testCleanExtraWhitespace2(): void {
 		$this->assertSame(
 			array( "a\t", "b\t", "c.php" ),
 			vipgoci_gitrepo_diffs_clean_extra_whitespace(

--- a/tests/unit/GitRepoGetFilePathFromDiffTest.php
+++ b/tests/unit/GitRepoGetFilePathFromDiffTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Test vipgoci_gitrepo_get_file_path_from_diff() function.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class that implements the testing.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class GitRepoGetFilePathFromDiffTest extends TestCase {
+	/**
+	 * Setup function. Require files, etc.
+	 *
+	 * @return void
+	 */
+	protected function setUp() :void {
+		require_once __DIR__ . '/../../git-repo.php';
+	}
+
+	/**
+	 * Test common usage of the function.
+	 *
+	 * @covers ::vipgoci_gitrepo_get_file_path_from_diff
+	 *
+	 * @return void
+	 */
+	public function testGetFilePathFromDiff(): void {
+		$this->assertSame(
+			'b/file 30  test   b.php',
+			vipgoci_gitrepo_get_file_path_from_diff(
+				array( '+++', 'b/file', '30', '', 'test', '', '', 'b.php' ),
+				1
+			)
+		);
+	}
+}

--- a/tests/unit/ResultsCommentMatchTest.php
+++ b/tests/unit/ResultsCommentMatchTest.php
@@ -35,45 +35,45 @@ final class ResultsCommentMatchTest extends TestCase {
 	public function testCommentMatch1() :void {
 		$prs_comments = array(
 			'file-8.php:3'   => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: All output should be ..., found \'mysql_query\'."}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: All output should be ..., found \'mysql_query\'.',
 				),
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
 				),
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped (*WordPressVIPMinimum.JS.InnerHTML.innerHTML*)."}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped (*WordPressVIPMinimum.JS.InnerHTML.innerHTML*).',
 				),
 			),
 
 			'file-10.php:3'  => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
 				),
 			),
 
 			'file-11.php:5'  => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error( severity 11 )**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error( severity 11 )**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
 				),
 			),
 
 			'file-12.php:70' => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error( severity 11 )**: /** cannot be used"}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error( severity 11 )**: /** cannot be used',
 				),
 			),
 
 			// Do not test against these; they are here to make sure nothing bogus is matched.
 			'file-8.php:90'  => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: All output should be run ..., found \'mysql_query\'."}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: All output should be run ..., found \'mysql_query\'.',
 				),
 			),
 
 			'file-9.php:90'  => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
 				),
 			),
 		);

--- a/tests/unit/ResultsCommentMatchTest.php
+++ b/tests/unit/ResultsCommentMatchTest.php
@@ -1,63 +1,86 @@
 <?php
+/**
+ * Test vipgoci_results_comment_match().
+ *
+ * @package Automattic/vip-go-ci
+ */
 
 declare(strict_types=1);
 
 namespace Vipgoci\Tests\Unit;
 
-require_once __DIR__ . '/../../results.php';
-
 use PHPUnit\Framework\TestCase;
 
-// phpcs:disable PSR1.Files.SideEffects
-
+/**
+ * Class that implements the testing.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 final class ResultsCommentMatchTest extends TestCase {
 	/**
+	 * Setup function. Require file.
+	 *
+	 * @return void
+	 */
+	protected function setUp() :void {
+		require_once __DIR__ . '/../../results.php';
+	}
+
+	/**
+	 * Test common usage of the function.
+	 *
 	 * @covers ::vipgoci_results_comment_match
 	 */
-	public function testCommentMatch1() {
+	public function testCommentMatch1() :void {
 		$prs_comments = array(
-			'bla-8.php:3' => array(
+			'file-8.php:3'   => array(
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/249878202","pull_request_review_id":195129115,"id":249878202,"node_id":"MDI0Ol123","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"34cbe527fee864dcbaca26649a6613cb2a4b5eeb","user":{},"body":":no_entry_sign: **Error**: All output should be run tttter Handbooks), found \'mysql_query\'.","created_at":"2019-01-22T17:14:24Z","updated_at":"2019-02-11T11:40:43Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r249878202","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/249878202"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r249878202"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error**: All output should be ..., found \'mysql_query\'."}'
 				),
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
 				),
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error**: Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped (*WordPressVIPMinimum.JS.InnerHTML.innerHTML*).","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
-				)
-			),
-
-			// Do not test against these; they are here to make sure nothing bogus is matched
-			'bla-8.php:90' => array(
-				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/249878202","pull_request_review_id":195129115,"id":249878202,"node_id":"MDI0Ol123","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"34cbe527fee864dcbaca26649a6613cb2a4b5eeb","user":{},"body":":no_entry_sign: **Error**: All output should be run tttter Handbooks), found \'mysql_query\'.","created_at":"2019-01-22T17:14:24Z","updated_at":"2019-02-11T11:40:43Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r249878202","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/249878202"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r249878202"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error**: Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped (*WordPressVIPMinimum.JS.InnerHTML.innerHTML*)."}'
 				),
 			),
 
-			'bla-9.php:90' => array(
+			'file-10.php:3'  => array(
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
 				),
 			),
 
-			'bla-10.php:3' => array(
+			'file-11.php:5'  => array(
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error( severity 11 )**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
 				),
 			),
 
-			'bla-11.php:5' => array(
+			'file-12.php:70' => array(
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-11.php","position":5,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error( severity 11 )**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error( severity 11 )**: /** cannot be used"}'
+				),
+			),
+
+			// Do not test against these; they are here to make sure nothing bogus is matched.
+			'file-8.php:90'  => array(
+				json_decode(
+					'{"body":":no_entry_sign: **Error**: All output should be run ..., found \'mysql_query\'."}'
+				),
+			),
+
+			'file-9.php:90'  => array(
+				json_decode(
+					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
 				),
 			),
 		);
 
-
 		$this->assertTrue(
 			vipgoci_results_comment_match(
-				'bla-8.php',
+				'file-8.php',
 				3,
 				'Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
 				$prs_comments
@@ -66,7 +89,7 @@ final class ResultsCommentMatchTest extends TestCase {
 
 		$this->assertTrue(
 			vipgoci_results_comment_match(
-				'bla-8.php',
+				'file-8.php',
 				3,
 				'Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped',
 				$prs_comments
@@ -75,63 +98,77 @@ final class ResultsCommentMatchTest extends TestCase {
 
 		$this->assertFalse(
 			vipgoci_results_comment_match(
-				'bla-8.php',
+				'file-8.php',
 				3,
 				'The extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
-				$prs_comments	
+				$prs_comments
 			)
 		);
 
 		$this->assertFalse(
 			vipgoci_results_comment_match(
-				'bla-8.php',
+				'file-8.php',
 				4,
 				'Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
-				$prs_comments	
+				$prs_comments
 			)
 		);
 
 		$this->assertFalse(
 			vipgoci_results_comment_match(
-				'bla-8.php',
+				'file-8.php',
 				4,
 				'Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped',
 				$prs_comments
 			)
 		);
 
-
 		$this->assertFalse(
 			vipgoci_results_comment_match(
-				'bla-9.php',
+				'file-9.php',
 				3,
 				'Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
-				$prs_comments	
+				$prs_comments
 			)
 		);
-
 
 		/*
 		 * Test with severity level
 		 */
 		$this->assertTrue(
 			vipgoci_results_comment_match(
-				'bla-11.php',
+				'file-11.php',
 				5,
 				'Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
-				$prs_comments	
+				$prs_comments
 			)
 		);
 
 		$this->assertFalse(
 			vipgoci_results_comment_match(
-				'bla-11.php',
+				'file-11.php',
 				5,
 				'Extension \'mysql_\' is deprecated since PHP 300 and removed since PHP 700; Use mysqli instead',
-				$prs_comments	
+				$prs_comments
 			)
 		);
 
+		$this->assertTrue(
+			vipgoci_results_comment_match(
+				'file-12.php',
+				70,
+				'/** cannot be used',
+				$prs_comments
+			)
+		);
 
+		$this->assertFalse(
+			vipgoci_results_comment_match(
+				'file-12.php',
+				70,
+				'/*** cannot be used',
+				$prs_comments
+			)
+		);
 	}
 }

--- a/unittests.ini.dist
+++ b/unittests.ini.dist
@@ -86,7 +86,7 @@ commit-test-repo-pr-diffs-1-e=26227c626b265a5256bedfb7a0edb068dcfc8014
 commit-test-repo-pr-diffs-1-f=12fed31bf1758113cecb01e309c03286bbe2bcf0
 commit-test-repo-pr-diffs-1-g=6148a7b4193dfa42bcc9d3cce0d4a09221fb8a6b
 commit-test-repo-pr-diffs-2-a=1efcdedefa1dbdbb067e7aca56f1458da0026a65
-commit-test-repo-pr-diffs-2-b=3b27c4267c23846c20030d91531bfe2ec71e95d2
+commit-test-repo-pr-diffs-2-b=f3545e389e8ef569ca0eb28061b293d4d4b8ef75
 commit-test-repo-pr-diffs-3-a=ac10d1f29e64504d7741cd8ca22981c426c26e9a
 
 ; The following commit is from outside of the repository,


### PR DESCRIPTION
This patch fixes two problems with git diffs from local repository:

* Fix a problem with spaces in filenames. Previously, spaces were not handled correctly leading to execution errors. This patch ensures spaces are handled correctly.
* Fix how status of renamed and modified files is determined. Previously, a file both modified and renamed would have been considered renamed, but is now considered modified. This is in line with expectations elsewhere in the codebase.

This patch also brings in a workaround to resolve a problem with tabs being appended to paths in git diffs (cause unknown, see code comments).

TODO:
- [x] Add tests:
  - [x] `tests/unit/GitRepoDiffsCleanExtraWhitespaceTest.php`
  - [x] `tests/unit/GitRepoGetFilePathFromDiffTest.php`
- [x] Update test `tests/integration/GitRepoDiffsFetchUnfilteredTest.php`
    - [x] Test file with space in file name.
      - [x] Test adding file with space in file name.
      - [x] Test file being renamed to have space in file name and content added also.
- [x] Add `PHPDoc` comments for new functions
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #286 ]

