### PR TITLE
Rename test class to match file name

### DIFF
--- a/tests/unit/OptionsBoolHandleTest.php
+++ b/tests/unit/OptionsBoolHandleTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-final class VipgociOptionsBoolHandleTest extends TestCase {
+final class OptionsBoolHandleTest extends TestCase {
 	/**
 	 * Setup function. Require files.
 	 *


### PR DESCRIPTION
One unit-test class was not named after the file itself. Here the class is renamed.

TODO:
- [x] Rename class for `tests/unit/OptionsBoolHandleTest.php`
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #286 ]

