### PR TITLE
Fix re-posted comments that contain "/**"

### DIFF
--- a/results.php
+++ b/results.php
@@ -844,8 +844,8 @@ function vipgoci_results_comment_match(
 		 * Handle special case (/**) so that it is preserved.
 		 */
 		$comment_made_body = str_replace(
-			array( '/**', '**', 'Warning', 'Error', 'Info', ':no_entry_sign:', ':warning:', ':information_source:', '/\*\*', ),
-			array( '/\*\*', '', '', '', '', '', '', '', '/**', ),
+			array( '/**', '**', 'Warning', 'Error', 'Info', ':no_entry_sign:', ':warning:', ':information_source:', '/\*\*' ),
+			array( '/\*\*', '', '', '', '', '', '', '', '/**' ),
 			$comment_made->body
 		);
 

--- a/results.php
+++ b/results.php
@@ -794,6 +794,8 @@ function vipgoci_results_sort_by_severity(
  * this is used to understand if the specific
  * comment has already been submitted earlier.
  *
+ * Handles special case as well.
+ *
  * @param string $file_issue_path    Path to file.
  * @param int    $file_issue_line    Line number in file.
  * @param string $file_issue_comment Comment to look for.
@@ -838,10 +840,12 @@ function vipgoci_results_comment_match(
 		/*
 		 * The comment might contain formatting, such
 		 * as "Warning: ..." -- remove all of that.
+		 *
+		 * Handle special case (/**) so that it is preserved.
 		 */
 		$comment_made_body = str_replace(
-			array( '**', 'Warning', 'Error', 'Info', ':no_entry_sign:', ':warning:', ':information_source:' ),
-			array( '', '', '', '', '' ),
+			array( '/**', '**', 'Warning', 'Error', 'Info', ':no_entry_sign:', ':warning:', ':information_source:', '/\*\*', ),
+			array( '/\*\*', '', '', '', '', '', '', '', '/**', ),
 			$comment_made->body
 		);
 

--- a/results.php
+++ b/results.php
@@ -841,7 +841,9 @@ function vipgoci_results_comment_match(
 		 * The comment might contain formatting, such
 		 * as "Warning: ..." -- remove all of that.
 		 *
-		 * Handle special case (/**) so that it is preserved.
+		 * Handle special case when "/**" is included in comments.
+		 * Ensure to preserve comments with this pattern, as otherwise
+		 * strings that include them will be re-posted during re-runs.
 		 */
 		$comment_made_body = str_replace(
 			array( '/**', '**', 'Warning', 'Error', 'Info', ':no_entry_sign:', ':warning:', ':information_source:', '/\*\*' ),

--- a/tests/unit/ResultsCommentMatchTest.php
+++ b/tests/unit/ResultsCommentMatchTest.php
@@ -35,45 +35,45 @@ final class ResultsCommentMatchTest extends TestCase {
 	public function testCommentMatch1() :void {
 		$prs_comments = array(
 			'file-8.php:3'   => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: All output should be ..., found \'mysql_query\'."}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: All output should be ..., found \'mysql_query\'.',
 				),
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
 				),
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped (*WordPressVIPMinimum.JS.InnerHTML.innerHTML*)."}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped (*WordPressVIPMinimum.JS.InnerHTML.innerHTML*).',
 				),
 			),
 
 			'file-10.php:3'  => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
 				),
 			),
 
 			'file-11.php:5'  => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error( severity 11 )**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error( severity 11 )**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
 				),
 			),
 
 			'file-12.php:70' => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error( severity 11 )**: /** cannot be used"}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error( severity 11 )**: /** cannot be used',
 				),
 			),
 
 			// Do not test against these; they are here to make sure nothing bogus is matched.
 			'file-8.php:90'  => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: All output should be run ..., found \'mysql_query\'."}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: All output should be run ..., found \'mysql_query\'.',
 				),
 			),
 
 			'file-9.php:90'  => array(
-				json_decode(
-					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
+				(object) array(
+					'body' => ':no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
 				),
 			),
 		);

--- a/tests/unit/ResultsCommentMatchTest.php
+++ b/tests/unit/ResultsCommentMatchTest.php
@@ -1,63 +1,86 @@
 <?php
+/**
+ * Test vipgoci_results_comment_match().
+ *
+ * @package Automattic/vip-go-ci
+ */
 
 declare(strict_types=1);
 
 namespace Vipgoci\Tests\Unit;
 
-require_once __DIR__ . '/../../results.php';
-
 use PHPUnit\Framework\TestCase;
 
-// phpcs:disable PSR1.Files.SideEffects
-
+/**
+ * Class that implements the testing.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 final class ResultsCommentMatchTest extends TestCase {
 	/**
+	 * Setup function. Require file.
+	 *
+	 * @return void
+	 */
+	protected function setUp() :void {
+		require_once __DIR__ . '/../../results.php';
+	}
+
+	/**
+	 * Test common usage of the function.
+	 *
 	 * @covers ::vipgoci_results_comment_match
 	 */
-	public function testCommentMatch1() {
+	public function testCommentMatch1() :void {
 		$prs_comments = array(
-			'bla-8.php:3' => array(
+			'file-8.php:3'   => array(
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/249878202","pull_request_review_id":195129115,"id":249878202,"node_id":"MDI0Ol123","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"34cbe527fee864dcbaca26649a6613cb2a4b5eeb","user":{},"body":":no_entry_sign: **Error**: All output should be run tttter Handbooks), found \'mysql_query\'.","created_at":"2019-01-22T17:14:24Z","updated_at":"2019-02-11T11:40:43Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r249878202","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/249878202"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r249878202"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error**: All output should be ..., found \'mysql_query\'."}'
 				),
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
 				),
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error**: Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped (*WordPressVIPMinimum.JS.InnerHTML.innerHTML*).","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
-				)
-			),
-
-			// Do not test against these; they are here to make sure nothing bogus is matched
-			'bla-8.php:90' => array(
-				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/249878202","pull_request_review_id":195129115,"id":249878202,"node_id":"MDI0Ol123","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"34cbe527fee864dcbaca26649a6613cb2a4b5eeb","user":{},"body":":no_entry_sign: **Error**: All output should be run tttter Handbooks), found \'mysql_query\'.","created_at":"2019-01-22T17:14:24Z","updated_at":"2019-02-11T11:40:43Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r249878202","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/249878202"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r249878202"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error**: Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped (*WordPressVIPMinimum.JS.InnerHTML.innerHTML*)."}'
 				),
 			),
 
-			'bla-9.php:90' => array(
+			'file-10.php:3'  => array(
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
 				),
 			),
 
-			'bla-10.php:3' => array(
+			'file-11.php:5'  => array(
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-8.php","position":3,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error( severity 11 )**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
 				),
 			),
 
-			'bla-11.php:5' => array(
+			'file-12.php:70' => array(
 				json_decode(
-					'{"url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011","pull_request_review_id":202053661,"id":255465011,"node_id":"MDI0O01245","diff_hunk":"@@ -0,0 +1,3 @@\n+<?php\n+\n+echo mysql_query(\"test\");","path":"bla-11.php","position":5,"original_position":3,"commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","original_commit_id":"aec27de5f13a5495577ca7ba27fc8b10a04ac89f","user":{},"body":":no_entry_sign: **Error( severity 11 )**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","created_at":"2019-02-11T11:19:21Z","updated_at":"2019-02-11T11:19:21Z","html_url":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011","pull_request_url":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32","author_association":"OWNER","_links":{"self":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/comments\/255465011"},"html":{"href":"https:\/\/github.com\/gudmdharalds-a8c\/testing123\/pull\/32#discussion_r255465011"},"pull_request":{"href":"https:\/\/api.github.com\/repos\/gudmdharalds-a8c\/testing123\/pulls\/32"}}}'
+					'{"body":":no_entry_sign: **Error( severity 11 )**: /** cannot be used"}'
+				),
+			),
+
+			// Do not test against these; they are here to make sure nothing bogus is matched.
+			'file-8.php:90'  => array(
+				json_decode(
+					'{"body":":no_entry_sign: **Error**: All output should be run ..., found \'mysql_query\'."}'
+				),
+			),
+
+			'file-9.php:90'  => array(
+				json_decode(
+					'{"body":":no_entry_sign: **Error**: Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead"}'
 				),
 			),
 		);
 
-
 		$this->assertTrue(
 			vipgoci_results_comment_match(
-				'bla-8.php',
+				'file-8.php',
 				3,
 				'Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
 				$prs_comments
@@ -66,7 +89,7 @@ final class ResultsCommentMatchTest extends TestCase {
 
 		$this->assertTrue(
 			vipgoci_results_comment_match(
-				'bla-8.php',
+				'file-8.php',
 				3,
 				'Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped',
 				$prs_comments
@@ -75,63 +98,77 @@ final class ResultsCommentMatchTest extends TestCase {
 
 		$this->assertFalse(
 			vipgoci_results_comment_match(
-				'bla-8.php',
+				'file-8.php',
 				3,
 				'The extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
-				$prs_comments	
+				$prs_comments
 			)
 		);
 
 		$this->assertFalse(
 			vipgoci_results_comment_match(
-				'bla-8.php',
+				'file-8.php',
 				4,
 				'Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
-				$prs_comments	
+				$prs_comments
 			)
 		);
 
 		$this->assertFalse(
 			vipgoci_results_comment_match(
-				'bla-8.php',
+				'file-8.php',
 				4,
 				'Any HTML passed to `innerHTML` gets executed. Consider using `.textContent` or make sure that used variables are properly escaped',
 				$prs_comments
 			)
 		);
 
-
 		$this->assertFalse(
 			vipgoci_results_comment_match(
-				'bla-9.php',
+				'file-9.php',
 				3,
 				'Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
-				$prs_comments	
+				$prs_comments
 			)
 		);
-
 
 		/*
 		 * Test with severity level
 		 */
 		$this->assertTrue(
 			vipgoci_results_comment_match(
-				'bla-11.php',
+				'file-11.php',
 				5,
 				'Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
-				$prs_comments	
+				$prs_comments
 			)
 		);
 
 		$this->assertFalse(
 			vipgoci_results_comment_match(
-				'bla-11.php',
+				'file-11.php',
 				5,
 				'Extension \'mysql_\' is deprecated since PHP 300 and removed since PHP 700; Use mysqli instead',
-				$prs_comments	
+				$prs_comments
 			)
 		);
 
+		$this->assertTrue(
+			vipgoci_results_comment_match(
+				'file-12.php',
+				70,
+				'/** cannot be used',
+				$prs_comments
+			)
+		);
 
+		$this->assertFalse(
+			vipgoci_results_comment_match(
+				'file-12.php',
+				70,
+				'/*** cannot be used',
+				$prs_comments
+			)
+		);
 	}
 }


### PR DESCRIPTION
This pull request fixes a problem with comments that are re-posted during re-runs of `vip-go-ci`. This problem only arises when comments include `/**`.

TODO:
- [x] Update `vipgoci_results_comment_match()` so that `/**` is preserved in comments. 
- [x] Update test `tests/unit/ResultsCommentMatchTest.php`
  - [x] Test comments that include `/**`.
  - [x] Remove `json_decode()` calls, declare objects directly.
  - [x] Apply WP CS to file.
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #286 ]
