### PR TITLE
Use local git repository when running integration tests using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,12 @@ jobs:
         env:
           fail-fast: 'true'
 
+      - name: Clone vip-go-ci-testing repository
+        run: |
+          git clone https://github.com/Automattic/vip-go-ci-testing.git /tmp/vip-go-ci-testing
+          git -C /tmp/vip-go-ci-testing checkout ap-file-types-test-1 # Need to check this out so branch is known
+          git -C /tmp/vip-go-ci-testing checkout master # Switch to default
+
       - name: Install tools
         run: |
           ./tools-init.sh
@@ -83,7 +89,7 @@ jobs:
 
       - name: Configure tools
         run: |
-          sed "s:/home/phpunit/:${HOME}/:; s:phpcs-php-path=/usr/bin/php:phpcs-php-path=/usr/bin/php7.4:g; s:svg-php-path=/usr/bin/php:svg-php-path=/usr/bin/php8.1:g" unittests.ini.dist > unittests.ini
+          sed "s:/home/phpunit/:${HOME}/:; s:phpcs-php-path=/usr/bin/php:phpcs-php-path=/usr/bin/php7.4:g; s:svg-php-path=/usr/bin/php:svg-php-path=/usr/bin/php8.1:g; s:github-repo-url=.*:github-repo-url=/tmp/vip-go-ci-testing:g;" unittests.ini.dist > unittests.ini
           touch unittests-secrets.ini
           sed "s:PROJECT_DIR:$(pwd):g" phpunit.xml.dist > phpunit.xml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,20 +76,20 @@ jobs:
         env:
           fail-fast: 'true'
 
-      - name: Clone vip-go-ci-testing repository
-        run: |
-          git clone https://github.com/Automattic/vip-go-ci-testing.git /tmp/vip-go-ci-testing
-          git -C /tmp/vip-go-ci-testing checkout ap-file-types-test-1 # Need to check this out so branch is known
-          git -C /tmp/vip-go-ci-testing checkout master # Switch to default
-
       - name: Install tools
         run: |
           ./tools-init.sh
           rm -rf ~/vip-go-ci-tools/vip-go-ci
 
+      - name: Clone vip-go-ci-testing repository
+        run: |
+          git clone https://github.com/Automattic/vip-go-ci-testing.git ~/vip-go-ci-tools/vip-go-ci-testing
+          git -C ~/vip-go-ci-tools/vip-go-ci-testing checkout ap-file-types-test-1 # Need to check this out so branch is known
+          git -C ~/vip-go-ci-tools/vip-go-ci-testing checkout master # Switch to default
+
       - name: Configure tools
         run: |
-          sed "s:/home/phpunit/:${HOME}/:; s:phpcs-php-path=/usr/bin/php:phpcs-php-path=/usr/bin/php7.4:g; s:svg-php-path=/usr/bin/php:svg-php-path=/usr/bin/php8.1:g; s:github-repo-url=.*:github-repo-url=/tmp/vip-go-ci-testing:g;" unittests.ini.dist > unittests.ini
+          sed "s:/home/phpunit/:${HOME}/:; s:phpcs-php-path=/usr/bin/php:phpcs-php-path=/usr/bin/php7.4:g; s:svg-php-path=/usr/bin/php:svg-php-path=/usr/bin/php8.1:g; s:github-repo-url=.*:github-repo-url=${HOME}/vip-go-ci-tools/vip-go-ci-testing:g;" unittests.ini.dist > unittests.ini
           touch unittests-secrets.ini
           sed "s:PROJECT_DIR:$(pwd):g" phpunit.xml.dist > phpunit.xml
 


### PR DESCRIPTION
This pull request alters how a git repository needed for integration tests is handled when they execute using GitHub Actions. Previously, the repository would be cloned from GitHub for every integration test needing it and then it would be removed after execution of each individual test. With this pull request applied, the repository is cloned during preparation stages for the tests and stored temporary during the test run, each integration test will then clone this temporary repository for its own use, and remove the cloned copy after the test has run. 

This has several advantages:

* Tests run faster.
* Less CPU and network I/O needed for cloning (needs only to fetch repository once per run).
* Less load on GitHub's infrastructure.

The change does not impact tests run locally.

TODO:
- [x] Update integration test preparation step
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #286 ]

