### PR TITLE
Use vipgoci_cached_indication_str() function 

### DIFF
--- a/git-repo.php
+++ b/git-repo.php
@@ -378,8 +378,7 @@ function vipgoci_gitrepo_fetch_tree(
 	$cached_data = vipgoci_cache( $cached_id );
 
 	vipgoci_log(
-		'Fetching tree info' .
-			( $cached_data ? ' (cached)' : '' ),
+		'Fetching tree info' . vipgoci_cached_indication_str( $cached_data ),
 		array(
 			'repo_owner' => $options['repo-owner'],
 			'repo_name'  => $options['repo-name'],


### PR DESCRIPTION
This pull request implements the usage of `vipgoci_cached_indication_str()` function for the last instance were it applies but was missing. This increases consistency in the code.

TODO:
- [x] Use `vipgoci_cached_indication_str()` in `vipgoci_gitrepo_fetch_tree()`.
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #286 ]

