### PR TITLE
Call htmlentities() with PHP 8.1 defaults

### DIFF
--- a/reports.php
+++ b/reports.php
@@ -956,12 +956,14 @@ function vipgoci_report_submit_pr_review_from_results(
 						rtrim(
 							$commit_issue['issue']['message'],
 							'.'
-						)
+						),
+						ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 // PHP 8.1 default.
 					)
 
 					. ' (*' .
 					htmlentities(
-						$commit_issue['issue']['source']
+						$commit_issue['issue']['source'],
+						ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 // PHP 8.1 default.
 					)
 					. '*).',
 

--- a/results.php
+++ b/results.php
@@ -923,7 +923,10 @@ function vipgoci_results_comment_match(
 			)
 			||
 			(
-				htmlentities( $file_issue_comment ) ===
+				htmlentities(
+					$file_issue_comment,
+					ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 // PHP 8.1 default.
+				) ===
 				$comment_made_body
 			)
 		) {

--- a/tests/integration/PhpcsScanScanCommitTest.php
+++ b/tests/integration/PhpcsScanScanCommitTest.php
@@ -272,6 +272,10 @@ final class PhpcsScanScanCommitTest extends TestCase {
 		 */
 		$this->assertSame(
 			array(
+				56 => array(
+					'error' => 0,
+				),
+
 				22 => array(
 					'error' => 0,
 				),


### PR DESCRIPTION
This pull request ensures that all calls to `htmlentities()` are made with default PHP 8.1 parameters. In PHP 8.1, the `$flags` parameter is by default `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401`, while in PHP 8.0 it is by default `ENT_COMPAT` ([see documentation](https://www.php.net/manual/en/function.htmlentities.php)). This project aims to support  both PHP 8.0 and 8.1, and so to ensure the code behaves the same with both PHP versions, this change is needed.

The incompatibility was discovered while resolving #297.

TODO:
- [x] Ensure all calls to `htmlentities()` are made with PHP 8.1 defaults.
- [x] Update tests due to integration-data change.
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #286 ]
