### PR TITLE
Fix: Do not report latest plugin/theme as obsolete

### DIFF
--- a/tests/integration/WpscanScanDirsAlteredTest.php
+++ b/tests/integration/WpscanScanDirsAlteredTest.php
@@ -136,7 +136,7 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function testFindDirsAltered(): void {
+	public function testFindDirsAlteredWithResultsFound(): void {
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array( 'github-token', 'token' ),

--- a/tests/integration/WpscanScanDirsAlteredTest.php
+++ b/tests/integration/WpscanScanDirsAlteredTest.php
@@ -81,12 +81,12 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 				true // Fetch from secrets file.
 			);
 
-		$this->options['commit'] =
-			$this->options['wpscan-pr-1-commit-id'];
-
 		if ( empty( $this->options['github-token'] ) ) {
 			$this->options['github-token'] = '';
 		}
+
+		$this->options['commit'] =
+			$this->options['wpscan-pr-1-commit-id'];
 
 		$this->options['token'] =
 			$this->options['github-token'];

--- a/tests/integration/WpscanScanDirsAlteredTest.php
+++ b/tests/integration/WpscanScanDirsAlteredTest.php
@@ -33,6 +33,8 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 		'wpscan-pr-1-theme-dir'    => null,
 		'wpscan-pr-1-theme-key'    => null,
 		'wpscan-pr-1-theme-name'   => null,
+		'wpscan-pr-4-commit-id'    => null,
+		'wpscan-pr-4-dirs-altered' => null,
 	);
 
 	/**
@@ -69,9 +71,6 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 			$this->options_wpscan_api_scan,
 			$this->options_git
 		);
-
-		$this->options['commit'] =
-			$this->options['wpscan-pr-1-commit-id'];
 
 		$this->options['github-token'] =
 			vipgoci_unittests_get_config_value(
@@ -146,6 +145,9 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 		if ( -1 === $options_test ) {
 			return;
 		}
+
+		$this->options['commit'] =
+			$this->options['wpscan-pr-1-commit-id'];
 
 		vipgoci_unittests_output_suppress();
 
@@ -274,6 +276,58 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 			);
 		}
 	}
+
+	/**
+	 * Test common usage of the function. No results expected
+	 * as plugin and theme is not obsolete or vulnerable.
+	 *
+	 * @covers ::vipgoci_wpscan_scan_dirs_altered
+	 *
+	 * @return void
+	 */
+	public function testFindDirsAlteredWithNoResultsFound(): void {
+		$options_test = vipgoci_unittests_options_test(
+			$this->options,
+			array( 'github-token', 'token' ),
+			$this
+		);
+
+		if ( -1 === $options_test ) {
+			return;
+		}
+
+		$this->options['commit'] =
+			$this->options['wpscan-pr-4-commit-id'];
+
+		vipgoci_unittests_output_suppress();
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
+
+		if ( false === $this->options['local-git-repo'] ) {
+			$this->markTestSkipped(
+				'Could not set up git repository: ' .
+				vipgoci_unittests_output_get()
+			);
+
+			return;
+		}
+
+		vipgoci_unittests_output_unsuppress();
+
+		$results_actual = vipgoci_wpscan_scan_dirs_altered(
+			$this->options,
+			explode(
+				',',
+				$this->options['wpscan-pr-4-dirs-altered']
+			)
+		);
+
+		$this->assertSame(
+			array(),
+			$results_actual
+		);
+	}
 }
-
-

--- a/tests/integration/WpscanScanDirsAlteredTest.php
+++ b/tests/integration/WpscanScanDirsAlteredTest.php
@@ -81,12 +81,12 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 				true // Fetch from secrets file.
 			);
 
+		$this->options['commit'] =
+			$this->options['wpscan-pr-1-commit-id'];
+
 		if ( empty( $this->options['github-token'] ) ) {
 			$this->options['github-token'] = '';
 		}
-
-		$this->options['commit'] =
-			$this->options['wpscan-pr-1-commit-id'];
 
 		$this->options['token'] =
 			$this->options['github-token'];

--- a/tests/integration/WpscanScanDirsAlteredTest.php
+++ b/tests/integration/WpscanScanDirsAlteredTest.php
@@ -357,11 +357,6 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 
 		vipgoci_unittests_output_suppress();
 
-		$this->options['local-git-repo'] =
-			vipgoci_unittests_setup_git_repo(
-				$this->options
-			);
-
 		if ( false === $this->options['local-git-repo'] ) {
 			$this->markTestSkipped(
 				'Could not set up git repository: ' .
@@ -370,6 +365,11 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 
 			return;
 		}
+
+		$this->options['local-git-repo'] =
+			vipgoci_unittests_setup_git_repo(
+				$this->options
+			);
 
 		vipgoci_unittests_output_unsuppress();
 

--- a/tests/integration/WpscanScanDirsAlteredTest.php
+++ b/tests/integration/WpscanScanDirsAlteredTest.php
@@ -74,15 +74,15 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 			$this->options_git
 		);
 
+		$this->options['commit'] =
+			$this->options['wpscan-pr-1-commit-id'];
+
 		$this->options['github-token'] =
 			vipgoci_unittests_get_config_value(
 				'git-secrets',
 				'github-token',
 				true // Fetch from secrets file.
 			);
-
-		$this->options['commit'] =
-			$this->options['wpscan-pr-1-commit-id'];
 
 		if ( empty( $this->options['github-token'] ) ) {
 			$this->options['github-token'] = '';

--- a/unittests.ini.dist
+++ b/unittests.ini.dist
@@ -80,6 +80,8 @@ wpscan-pr-2-commit-id=5dd9e528b02c294683812f49c10ec97f6cbeb706
 wpscan-pr-2-dirs-scan=plugins,mu-plugins,themes
 wpscan-pr-3-commit-id=fa1546344701b53ef4cb81e3b77584e6c2b8bb5f
 wpscan-pr-3-dirs-scan=plugins,mu-plugins,themes
+wpscan-pr-4-commit-id=f2fc632ed26ff50aa671264d6dfae7a1e7f4deef
+wpscan-pr-4-dirs-altered=plugins/hello,plugins/not-a-plugin,themes/twentytwentyone
 
 [auto-approvals]
 commit-test-file-types-1=2d864e5dd9d89ea3362d965477432873bf970345

--- a/unittests.ini.dist
+++ b/unittests.ini.dist
@@ -65,6 +65,7 @@ wpscan-pr-1-plugin-name=Hello Dolly
 wpscan-pr-1-plugin-slug=hello-dolly
 wpscan-pr-1-plugin-name-api=hello/hello.php
 wpscan-pr-1-plugin-version=1.6
+wpscan-pr-1-plugin-path=plugins/hello/hello.php
 wpscan-pr-1-plugin2-dir=plugins/hello2
 wpscan-pr-1-plugin2-key=hello.php
 wpscan-pr-1-plugin2-name=Hello Dolly
@@ -76,12 +77,11 @@ wpscan-pr-1-theme-key=twentytwentyone
 wpscan-pr-1-theme-name=Twenty Twenty-One
 wpscan-pr-1-theme-slug=twentytwentyone
 wpscan-pr-1-theme-version=1.2
+wpscan-pr-1-theme-path=themes/twentytwentyone/style.css
 wpscan-pr-2-commit-id=5dd9e528b02c294683812f49c10ec97f6cbeb706
 wpscan-pr-2-dirs-scan=plugins,mu-plugins,themes
 wpscan-pr-3-commit-id=fa1546344701b53ef4cb81e3b77584e6c2b8bb5f
 wpscan-pr-3-dirs-scan=plugins,mu-plugins,themes
-wpscan-pr-4-commit-id=f2fc632ed26ff50aa671264d6dfae7a1e7f4deef
-wpscan-pr-4-dirs-altered=plugins/hello,plugins/not-a-plugin,themes/twentytwentyone
 
 [auto-approvals]
 commit-test-file-types-1=2d864e5dd9d89ea3362d965477432873bf970345

--- a/wpscan-scan.php
+++ b/wpscan-scan.php
@@ -281,7 +281,7 @@ function vipgoci_wpscan_scan_dirs_altered(
 			$addon_obsolete = version_compare(
 				$wpscan_results[ $addon_item_info['slug'] ]['latest_version'],
 				$addon_item_info['version_detected'],
-				'>='
+				'>'
 			);
 
 			$addon_security_vulnerabilities = ( ! empty(


### PR DESCRIPTION
This pull request fixes a bug whereby the latest plugin/theme will be reported as obsolete. 

In addition, this pull request adds tests to ensure plugins/themes with version numbers equal or higher to the latest are not reported as obsolete/vulnerable.

TODO:
- [x] Fix bug
- [x] Update test `tests/integration/WpscanScanDirsAlteredTest.php`
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #300 ]
