### PR TITLE
WPScan API: Update x-ratelimit-remaining header functionality

### DIFF
--- a/http-functions.php
+++ b/http-functions.php
@@ -253,7 +253,7 @@ function vipgoci_http_api_rate_limits_check(
 ) :void {
 	/*
 	 * Special case for WPScan API: Unlimited requests
-	 * are indicated with a negative number for 
+	 * are indicated with a negative number for
 	 * x-ratelimit-remaining header. Here we ignore
 	 * such headers for WPScan API responses.
 	 */

--- a/http-functions.php
+++ b/http-functions.php
@@ -251,8 +251,30 @@ function vipgoci_http_api_rate_limits_check(
 	string $http_api_url,
 	array $resp_headers
 ) :void {
+	/*
+	 * Special case for WPScan API: Unlimited requests
+	 * are indicated with a negative number for 
+	 * x-ratelimit-remaining header. Here we ignore
+	 * such headers for WPScan API responses.
+	 */
+	if (
+		( true === str_starts_with(
+			$http_api_url,
+			VIPGOCI_WPSCAN_API_BASE_URL,
+		) ) &&
+		( isset( $resp_headers['x-ratelimit-remaining'][0] ) ) &&
+		( is_numeric( $resp_headers['x-ratelimit-remaining'][0] ) ) &&
+		( $resp_headers['x-ratelimit-remaining'][0] < 0 )
+	) {
+		return;
+	}
+
+	/*
+	 * Look for ratelimit header.
+	 */
 	if (
 		( isset( $resp_headers['x-ratelimit-remaining'][0] ) ) &&
+		( is_numeric( $resp_headers['x-ratelimit-remaining'][0] ) ) &&
 		( $resp_headers['x-ratelimit-remaining'][0] <= 1 )
 	) {
 		vipgoci_sysexit(

--- a/http-functions.php
+++ b/http-functions.php
@@ -283,7 +283,8 @@ function vipgoci_http_api_rate_limits_check(
 			array(
 				'http_api_url'          => $http_api_url,
 				'x-ratelimit-remaining' => $resp_headers['x-ratelimit-remaining'][0],
-				'x-ratelimit-limit'     => $resp_headers['x-ratelimit-limit'][0],
+				'x-ratelimit-limit'     => isset( $resp_headers['x-ratelimit-limit'][0] )
+					?? $resp_headers['x-ratelimit-limit'][0],
 			),
 			VIPGOCI_EXIT_GITHUB_PROBLEM,
 			true // Log to IRC.

--- a/http-functions.php
+++ b/http-functions.php
@@ -244,8 +244,6 @@ function vipgoci_http_resp_sunset_header_check(
  * @param array  $resp_headers HTTP response headers.
  *
  * @return void
- *
- * @codeCoverageIgnore
  */
 function vipgoci_http_api_rate_limits_check(
 	string $http_api_url,

--- a/tests/unit/HttpFunctionsHttpApiRateLimitsCheckTest.php
+++ b/tests/unit/HttpFunctionsHttpApiRateLimitsCheckTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Test vipgoci_http_api_rate_limits_check() function.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class that implements the testing.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class HttpFunctionsHttpApiRateLimitsCheckTest extends TestCase {
+	/**
+	 * Data for the test.
+	 *
+	 * @var $TEST_DATA
+	 */
+	private const TEST_DATA = array(
+		array(
+			'url'     => 'https://127.0.0.1/api/v1',
+			'headers' => array(),
+			'output'  => '',
+		),
+		array(
+			'url'     => 'https://127.0.0.1/api/v1',
+			'headers' => array( 'x-ratelimit-remaining' => array( '100' ) ),
+			'output'  => '',
+		),
+		array(
+			'url'     => 'https://127.0.0.1/api/v1',
+			'headers' => array( 'x-ratelimit-remaining' => array( '0' ) ),
+			'output'  => '"Ran out of request limits for API, cannot continue without making further requests."' . PHP_EOL,
+		),
+		array(
+			'url'     => 'https://127.0.0.1/api/v1',
+			'headers' => array( 'x-ratelimit-remaining' => array( '-1' ) ),
+			'output'  => '"Ran out of request limits for API, cannot continue without making further requests."' . PHP_EOL,
+		),
+		array(
+			'url'     => 'https://wpscan.com/api/v3/plugins/test',
+			'headers' => array(),
+			'output'  => '',
+		),
+		array(
+			'url'     => 'https://wpscan.com/api/v3/plugins/test',
+			'headers' => array( 'x-ratelimit-remaining' => array( '100' ) ),
+			'output'  => '',
+		),
+		array(
+			'url'     => 'https://wpscan.com/api/v3/plugins/test',
+			'headers' => array( 'x-ratelimit-remaining' => array( '0' ) ),
+			'output'  => '"Ran out of request limits for API, cannot continue without making further requests."' . PHP_EOL,
+		),
+		array(
+			'url'     => 'https://wpscan.com/api/v3/plugins/test',
+			'headers' => array( 'x-ratelimit-remaining' => array( '-1' ) ),
+			'output'  => '',
+		),
+	);
+
+	/**
+	 * Setup function. Require files.
+	 *
+	 * @return void
+	 */
+	protected function setUp() :void {
+		require_once __DIR__ . '/../../defines.php';
+		require_once __DIR__ . '/../../http-functions.php';
+		require_once __DIR__ . '/helper/HttpFunctionsHttpApiRateLimitsCheck.php';
+	}
+
+	/**
+	 * Test different ratelimits headers when calling the function.
+	 *
+	 * @covers ::vipgoci_http_api_rate_limits_check
+	 *
+	 * @return void
+	 */
+	public function testRateLimits(): void {
+		foreach ( self::TEST_DATA as $test_item ) {
+			ob_start();
+
+			vipgoci_http_api_rate_limits_check(
+				$test_item['url'],
+				$test_item['headers']
+			);
+
+			$printed_data = ob_get_contents();
+			ob_end_clean();
+
+			$this->assertSame(
+				$test_item['output'],
+				$printed_data,
+				'Failed verifying with data: ' . json_encode( $test_item )
+			);
+		}
+	}
+}

--- a/tests/unit/HttpFunctionsHttpApiRateLimitsCheckTest.php
+++ b/tests/unit/HttpFunctionsHttpApiRateLimitsCheckTest.php
@@ -45,6 +45,11 @@ final class HttpFunctionsHttpApiRateLimitsCheckTest extends TestCase {
 			'output'  => '"Ran out of request limits for API, cannot continue without making further requests."' . PHP_EOL,
 		),
 		array(
+			'url'     => 'https://api.github.com/v1',
+			'headers' => array( 'x-ratelimit-remaining' => array( 'abc' ) ), // Invalid, not numeric.
+			'output'  => '',
+		),
+		array(
 			'url'     => 'https://wpscan.com/api/v3/plugins/test',
 			'headers' => array(),
 			'output'  => '',
@@ -62,6 +67,11 @@ final class HttpFunctionsHttpApiRateLimitsCheckTest extends TestCase {
 		array(
 			'url'     => 'https://wpscan.com/api/v3/plugins/test',
 			'headers' => array( 'x-ratelimit-remaining' => array( '-1' ) ),
+			'output'  => '',
+		),
+		array(
+			'url'     => 'https://wpscan.com/api/v3/plugins/test',
+			'headers' => array( 'x-ratelimit-remaining' => array( 'abc' ) ), // Invalid, not numeric.
 			'output'  => '',
 		),
 	);

--- a/tests/unit/HttpFunctionsHttpApiRateLimitsCheckTest.php
+++ b/tests/unit/HttpFunctionsHttpApiRateLimitsCheckTest.php
@@ -25,22 +25,22 @@ final class HttpFunctionsHttpApiRateLimitsCheckTest extends TestCase {
 	 */
 	private const TEST_DATA = array(
 		array(
-			'url'     => 'https://127.0.0.1/api/v1',
+			'url'     => 'https://api.github.com/v1',
 			'headers' => array(),
 			'output'  => '',
 		),
 		array(
-			'url'     => 'https://127.0.0.1/api/v1',
+			'url'     => 'https://api.github.com/v1',
 			'headers' => array( 'x-ratelimit-remaining' => array( '100' ) ),
 			'output'  => '',
 		),
 		array(
-			'url'     => 'https://127.0.0.1/api/v1',
+			'url'     => 'https://api.github.com/v1',
 			'headers' => array( 'x-ratelimit-remaining' => array( '0' ) ),
 			'output'  => '"Ran out of request limits for API, cannot continue without making further requests."' . PHP_EOL,
 		),
 		array(
-			'url'     => 'https://127.0.0.1/api/v1',
+			'url'     => 'https://api.github.com/v1',
 			'headers' => array( 'x-ratelimit-remaining' => array( '-1' ) ),
 			'output'  => '"Ran out of request limits for API, cannot continue without making further requests."' . PHP_EOL,
 		),

--- a/tests/unit/helper/HttpFunctionsHttpApiRateLimitsCheck.php
+++ b/tests/unit/helper/HttpFunctionsHttpApiRateLimitsCheck.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Helper function implementation for
+ * HttpFunctionsHttpApiRateLimitsCheckTest test.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+/**
+ * Print string $str when called.
+ *
+ * @param string $str         Message.
+ * @param array  $debug_data  Debug data (not used).
+ * @param int    $exit_status Exit status (not used).
+ * @param bool   $irc         (not used).
+ *
+ * @return void
+ */
+function vipgoci_sysexit(
+	string $str,
+	array $debug_data = array(),
+	int $exit_status = VIPGOCI_EXIT_USAGE_ERROR,
+	bool $irc = false
+) :void {
+	echo json_encode( $str ) . PHP_EOL;
+}
+
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+


### PR DESCRIPTION
This pull request will add a special case when parsing rate-limiting headers in case of WPScan API HTTP responses. Such responses made with a token key that provides unlimited HTTP API requests will result in a `x-ratelimit-remaining` header of negative value in responses from the API. Previously, that would result in an exit with error code, but this pull request adds an exception so that these are handled gracefully.

In addition, this pull request adds a sanity check to the header input, ensuring that the value is numeric.

TODO:
- [x] Update `vipgoci_http_api_rate_limits_check()` to support negative rate-limit header for WPScan API.
  - [x] Add sanity checking for input.
  - [x] Add test for function.
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #305 ]
