### PR TITLE
Collection of hacks for PHP 8 batch compatibility scanning

### DIFF
--- a/defines.php
+++ b/defines.php
@@ -187,7 +187,7 @@ define( 'VIPGOCI_CACHE_CLEAR', '--VIPGOCI-CACHE-CLEAR-0x321--' );
 /*
  * Define for vipgoci_http_api_wait() function.
  */
-define( 'VIPGOCI_HTTP_API_WAIT_TIME_SECONDS', 2 );
+define( 'VIPGOCI_HTTP_API_WAIT_TIME_SECONDS', 5 );
 
 /*
  * Defines for files.

--- a/git-repo.php
+++ b/git-repo.php
@@ -1858,4 +1858,3 @@ function vipgoci_git_diffs_fetch(
 
 	return $results;
 }
-

--- a/http-functions.php
+++ b/http-functions.php
@@ -667,7 +667,7 @@ function vipgoci_http_api_fetch_url(
 					'http_response_headers' => $resp_headers,
 					'http_response_body'    => $resp_data,
 				),
-				0,
+				-2,
 				true // Log to IRC.
 			);
 
@@ -870,7 +870,7 @@ function vipgoci_http_api_post_url(
 			$ret_val = -1;
 
 			// Set wait period between requests. May be altered.
-			$retry_sleep = 10;
+			$retry_sleep = 15;
 
 			/*
 			 * Figure out if to retry.
@@ -950,7 +950,7 @@ function vipgoci_http_api_post_url(
 					'http_response_headers' => $resp_headers,
 					'http_response_body'    => $resp_data,
 				),
-				0,
+				-2,
 				true // Log to IRC.
 			);
 
@@ -1177,7 +1177,7 @@ function vipgoci_http_api_put_url(
 					'http_response_headers' => $resp_headers,
 					'http_reponse_body'     => $resp_data,
 				),
-				0,
+				-2,
 				true // Log to IRC.
 			);
 
@@ -1203,4 +1203,3 @@ function vipgoci_http_api_put_url(
 
 	return $ret_val;
 }
-

--- a/log.php
+++ b/log.php
@@ -37,6 +37,9 @@ function vipgoci_log(
 	 * otherwise, do print it,
 	 */
 
+	// HACK
+	$vipgoci_debug_level = -1;
+
 	if ( $debug_level > $vipgoci_debug_level ) {
 		return;
 	}
@@ -125,4 +128,3 @@ function vipgoci_sysexit(
 
 	exit( $exit_status );
 }
-

--- a/main.php
+++ b/main.php
@@ -2656,7 +2656,7 @@ function vipgoci_run_scan(
 			'repo-owner' => $options['repo-owner'],
 			'repo-name'  => $options['repo-name'],
 		),
-		0,
+		-2,
 		true // Log to IRC.
 	);
 
@@ -3228,4 +3228,3 @@ function vipgoci_shutdown_function(
 		);
 	}
 }
-

--- a/misc.php
+++ b/misc.php
@@ -427,8 +427,9 @@ function vipgoci_filter_file_path(
 			 */
 			if (
 				( false !== $file_folders_match ) &&
-				( is_numeric( $file_folders_match ) ) &&
-				( 0 === $file_folders_match )
+				( is_numeric( $file_folders_match ) ) // &&
+				// HACK
+				// ( 0 === $file_folders_match )
 			) {
 				$file_folders_match = true;
 				break;

--- a/misc.php
+++ b/misc.php
@@ -493,7 +493,7 @@ function vipgoci_filter_file_path(
 					'file_folders_match' => $file_folders_match,
 				),
 			),
-			2
+			0
 		);
 
 		return false;
@@ -528,7 +528,7 @@ function vipgoci_scandir_git_repo(
 			'filter'    => $filter,
 			'base_path' => $base_path,
 		),
-		2
+		-2
 	);
 
 	/*

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -337,16 +337,19 @@ function vipgoci_phpcs_scan_single_file(
 		$file_extension = null;
 	}
 
-	$temp_file_name = vipgoci_save_temp_file(
-		'vipgoci-phpcs-scan-',
-		$file_extension,
-		$file_contents
-	);
+	// Hack - we don't need to copy over the file, we can just pass the contents
+	// $temp_file_name = vipgoci_save_temp_file(
+	// 	'vipgoci-phpcs-scan-',
+	// 	$file_extension,
+	// 	$file_contents
+	// );
+	
+	$temp_file_name = $options['local-git-repo'] . '/' . $file_name;
 
 	/*
 	 * Skips the phpcs scan when the validation contains any issue
 	 */
-	if ( true === $options['skip-large-files'] ) {
+	if ( $options['skip-large-files'] ?? false ) {
 		$validation = vipgoci_validate(
 			$temp_file_name,
 			$file_name,
@@ -361,8 +364,8 @@ function vipgoci_phpcs_scan_single_file(
 				'temp_file_name'         => $temp_file_name,
 				'validation'             => $validation,
 			);
-
-			unlink( $temp_file_name );
+			// HACK
+			// unlink( $temp_file_name );
 
 			return $skipped;
 		}
@@ -413,20 +416,25 @@ function vipgoci_phpcs_scan_single_file(
 	/*
 	 * Log results.
 	 */
-	vipgoci_log(
-		( null !== $file_issues_arr_master ) ?
-			'PHPCS returned results' :
-			'Error when running PHPCS',
-		array(
-			'filename'        => $file_name,
-			'file_issues_str' => $file_issues_str,
-			'issues_stats'    => isset( $file_issues_arr_master['totals'] ) ?
-				$file_issues_arr_master['totals'] : null,
-		)
-	);
+	// HACK
+	if ( $file_issues_arr_master && ( $file_issues_arr_master['totals']['errors'] || $file_issues_arr_master['totals']['warnings'] ) ) {
+		vipgoci_log(
+			( null !== $file_issues_arr_master ) ?
+				'PHPCS returned results' :
+				'Error when running PHPCS',
+			array(
+				'filename'        => $file_name,
+				'file_issues_str' => $file_issues_str,
+				'issues_stats'    => isset( $file_issues_arr_master['totals'] ) ?
+					$file_issues_arr_master['totals'] : null,
+			),
+			-2
+		);
+	}
 
+	// HACK
 	/* Get rid of temporary file */
-	unlink( $temp_file_name );
+	// unlink( $temp_file_name );
 
 	return array(
 		'file_issues_arr_master' => $file_issues_arr_master,
@@ -1656,4 +1664,3 @@ function vipgoci_phpcs_possibly_use_new_standard_file(
 		);
 	}
 }
-

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -125,7 +125,7 @@ function vipgoci_phpcs_do_scan(
 	 * Feed PHPCS the temporary file specified by our caller.
 	 */
 	$cmd = sprintf(
-		'%s -d memory_limit=500M -d max_execution_time=300 %s --severity=%s --report=%s',
+		'%s -d memory_limit=500M -d max_execution_time=300 %s --error-severity=%s --warning-severity=8 --report=%s',
 		escapeshellcmd( $phpcs_php_path ),
 		escapeshellcmd( $phpcs_path ),
 		escapeshellarg( (string) $phpcs_severity ),


### PR DESCRIPTION
I don't expect this ever to get merged, but maybe some of the things done can be worked in the codebase properly.

When running the scans, we have had to deal with a few issues:

#### To achieve better concurrency we had to reduce the number of IO operations.
I spotted that vip-go-ci copies over the file to a temporary file and then scans that - I'm not sure of the reason, but I don't think it's relevant when running locally. So I just circumvented the part.

#### Log verbosity

Had to tweak log levels to reduce the amount of information, so that only the errors are printed.
For example, the entry is not printed when the scan result is empty.

#### Increase intervals

GH Issues API is throttling aggressively with "secondary rate-limits". To account for that, the `VIPGOCI_HTTP_API_WAIT_TIME_SECONDS` was bumped to 5.

#### --error-severity vs --warning-severity

The production version uses `--severity=5` which means `--error-severity=5 --warning-severity=5`. However, I discovered that having `--severity=5` trumps both specific arguments.
