### PR TITLE
Add checks to WPScan API reporting logic, ensure CVSS outputted includes precision

### DIFF
--- a/tests/unit/WpscanReportCommentFormatResultTest.php
+++ b/tests/unit/WpscanReportCommentFormatResultTest.php
@@ -60,6 +60,9 @@ final class WpscanReportCommentFormatResultTest extends TestCase {
 						array(
 							'id'    => '0100100 ;',
 							'title' => 'Security problem in My Plugin < 1.9.0',
+							'cvss'  => array(
+								'score' => '7.3',
+							),
 						),
 					),
 				),
@@ -171,6 +174,16 @@ final class WpscanReportCommentFormatResultTest extends TestCase {
 			VIPGOCI_WPSCAN_BASE_URL . '/vulnerability/0100100%20%3B',
 			$report_str
 		);
+
+		$this->assertStringContainsString(
+			'Severity',
+			$report_str
+		);
+
+		$this->assertStringContainsString(
+			'7.3/10 (HIGH)',
+			$report_str
+		);
 	}
 
 	/**
@@ -198,6 +211,9 @@ final class WpscanReportCommentFormatResultTest extends TestCase {
 						array(
 							'id'    => '0100100',
 							'title' => 'Security problem in My Theme',
+							'cvss'  => array(
+								'score' => '5.0',
+							),
 						),
 					),
 				),
@@ -307,6 +323,16 @@ final class WpscanReportCommentFormatResultTest extends TestCase {
 
 		$this->assertStringContainsString(
 			VIPGOCI_WPSCAN_BASE_URL . '/vulnerability/0100100',
+			$report_str
+		);
+
+		$this->assertStringContainsString(
+			'Severity',
+			$report_str
+		);
+
+		$this->assertStringContainsString(
+			'5.0/10 (MEDIUM)',
 			$report_str
 		);
 	}

--- a/wpscan-reports.php
+++ b/wpscan-reports.php
@@ -238,7 +238,7 @@ function vipgoci_wpscan_report_comment_format_result(
 
 		foreach ( $issue['details']['vulnerabilities'] as $vuln_item ) {
 			if (
-				( ! isset( $vuln_item['id'] ) ) || 
+				( ! isset( $vuln_item['id'] ) ) ||
 				( ! isset( $vuln_item['title'] ) )
 			) {
 				vipgoci_log(

--- a/wpscan-reports.php
+++ b/wpscan-reports.php
@@ -237,6 +237,20 @@ function vipgoci_wpscan_report_comment_format_result(
 		$res .= "\n\r";
 
 		foreach ( $issue['details']['vulnerabilities'] as $vuln_item ) {
+			if (
+				( ! isset( $vuln_item['id'] ) ) || 
+				( ! isset( $vuln_item['title'] ) )
+			) {
+				vipgoci_log(
+					'Vulnerability detail item from WPScan API is invalid, missing fields',
+					array(
+						'vuln_item' => $vuln_item,
+					)
+				);
+
+				continue;
+			}
+
 			$res .= '### &#x1f512; Security information' . "\n"; // Header markup and lock sign.
 
 			/*
@@ -257,13 +271,20 @@ function vipgoci_wpscan_report_comment_format_result(
 			) . "\n";
 
 			// May not be included, enterprise only feature.
-			if ( isset( $vuln_item['cvss']['score'] ) ) {
-				// Escape severity as float.
-				$res .= '**Severity**: ' . ( (float) $vuln_item['cvss']['score'] ) . '/10 (';
+			if (
+				( isset( $vuln_item['cvss']['score'] ) ) &&
+				( is_numeric( $vuln_item['cvss']['score'] ) )
+			) {
+				// Output severity as float.
+				$res .= '**Severity**: ';
+				$res .= sprintf( '%.1f', (float) $vuln_item['cvss']['score'] );
+				$res .= '/10 (';
 
 				// Escape output string.
 				$res .= vipgoci_output_markdown_escape(
-					vipgoci_wpscan_report_format_cvss_score( $vuln_item['cvss']['score'] )
+					vipgoci_wpscan_report_format_cvss_score(
+						(float) $vuln_item['cvss']['score']
+					)
 				);
 
 				$res .= ')' . "\n";


### PR DESCRIPTION
This pull request will add a few checks before printing WPScan API results. It will furthermore ensure CVSS score is cast to float and printed so that it will include a precision point. Also, it adds more testing logic to the relevant unit tests.

TODO:
- [x] Added few checks to WPScan API result printing
- [x] Ensure CVSS score includes precision point
- [x] Update unit test for functions altered
- [x] Check status of automated tests
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #305 ]
