### PR TITLE
Use constants for content-type headers

### DIFF
--- a/defines.php
+++ b/defines.php
@@ -41,10 +41,11 @@ if ( ! defined( 'VIPGOCI_GITHUB_BASE_URL' ) ) {
 define( 'VIPGOCI_KB_IN_BYTES', 1024 );
 
 /*
- * Timeout constant for HTTP APIs.
+ * Constants for HTTP API functions.
  */
 define( 'VIPGOCI_HTTP_API_LONG_TIMEOUT', 20 );
 define( 'VIPGOCI_HTTP_API_SHORT_TIMEOUT', 5 );
+define( 'VIPGOCI_HTTP_API_CONTENT_TYPE_WWW_FORM_URLENCODED', 'application/x-www-form-urlencoded' );
 
 /*
  * Define exit-codes

--- a/defines.php
+++ b/defines.php
@@ -46,7 +46,7 @@ define( 'VIPGOCI_KB_IN_BYTES', 1024 );
 define( 'VIPGOCI_HTTP_API_LONG_TIMEOUT', 20 );
 define( 'VIPGOCI_HTTP_API_SHORT_TIMEOUT', 5 );
 define( 'VIPGOCI_HTTP_API_CONTENT_TYPE_APPLICATION_JSON', 'application/json' );
-define( 'VIPGOCI_HTTP_API_CONTENT_TYPE_WWW_FORM_URLENCODED', 'application/x-www-form-urlencoded' );
+define( 'VIPGOCI_HTTP_API_CONTENT_TYPE_X_WWW_FORM_URLENCODED', 'application/x-www-form-urlencoded' );
 
 /*
  * Define exit-codes

--- a/defines.php
+++ b/defines.php
@@ -45,6 +45,7 @@ define( 'VIPGOCI_KB_IN_BYTES', 1024 );
  */
 define( 'VIPGOCI_HTTP_API_LONG_TIMEOUT', 20 );
 define( 'VIPGOCI_HTTP_API_SHORT_TIMEOUT', 5 );
+define( 'VIPGOCI_HTTP_API_CONTENT_TYPE_APPLICATION_JSON', 'application/json' );
 define( 'VIPGOCI_HTTP_API_CONTENT_TYPE_WWW_FORM_URLENCODED', 'application/x-www-form-urlencoded' );
 
 /*

--- a/http-functions.php
+++ b/http-functions.php
@@ -590,7 +590,7 @@ function vipgoci_http_api_post_url(
 	bool $http_delete = false,
 	bool $json_encode = true,
 	int $http_version = CURL_HTTP_VERSION_NONE,
-	string $http_content_type = 'application/json'
+	string $http_content_type = VIPGOCI_HTTP_API_CONTENT_TYPE_APPLICATION_JSON
 ) :string|int {
 	/*
 	 * Actually send a request to HTTP API -- make sure

--- a/wp-core-misc.php
+++ b/wp-core-misc.php
@@ -512,7 +512,7 @@ function vipgoci_wpcore_api_determine_slug_and_other_for_addons(
 			false, // HTTP POST.
 			false, // Do not JSON encode.
 			CURL_HTTP_VERSION_1_1, // Use HTTP version 1.1 due to problems with HTTP 2.
-			VIPGOCI_HTTP_API_CONTENT_TYPE_WWW_FORM_URLENCODED // Use custom HTTP content-type header.
+			VIPGOCI_HTTP_API_CONTENT_TYPE_X_WWW_FORM_URLENCODED // Use custom HTTP content-type header.
 		);
 
 		if ( is_int( $api_data_raw ) ) {

--- a/wp-core-misc.php
+++ b/wp-core-misc.php
@@ -512,7 +512,7 @@ function vipgoci_wpcore_api_determine_slug_and_other_for_addons(
 			false, // HTTP POST.
 			false, // Do not JSON encode.
 			CURL_HTTP_VERSION_1_1, // Use HTTP version 1.1 due to problems with HTTP 2.
-			'application/x-www-form-urlencoded' // Custom HTTP Content-Type.
+			VIPGOCI_HTTP_API_CONTENT_TYPE_WWW_FORM_URLENCODED // Use custom HTTP content-type header.
 		);
 
 		if ( is_int( $api_data_raw ) ) {


### PR DESCRIPTION
Makes use of constants for content-type HTTP headers.

TODO:
- [x] Use constants for `application/json` and `application/x-www-form-urlencoded` HTTP header values.
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #312 ]
