### PR TITLE
Apply constant for WordPress.org API

### DIFF
--- a/defines.php
+++ b/defines.php
@@ -274,6 +274,11 @@ define( 'VIPGOCI_ADDON_PLUGIN', 'vipgoci-addon-plugin' );
 define( 'VIPGOCI_ADDON_THEME', 'vipgoci-addon-theme' );
 
 /*
+ * WordPress.org defines.
+ */
+define( 'VIPGOCI_WORDPRESS_ORG_API_BASE_URL', 'https://api.wordpress.org' );
+
+/*
  * Defines for WPScan API support.
  */
 define( 'VIPGOCI_WPSCAN_BASE_URL', 'https://wpscan.com' );

--- a/wp-core-misc.php
+++ b/wp-core-misc.php
@@ -487,7 +487,9 @@ function vipgoci_wpcore_api_determine_slug_and_other_for_addons(
 		$addon_query_type_short = VIPGOCI_ADDON_PLUGIN === $addon_query_type ?
 			'plugins' : 'themes';
 
-		$api_url = 'https://api.wordpress.org/' . rawurlencode( $addon_query_type_short ) . '/update-check/1.1/';
+		$api_url = VIPGOCI_WORDPRESS_ORG_API_BASE_URL . '/' .
+			rawurlencode( $addon_query_type_short ) . '/' .
+			'update-check/1.1/';
 
 		$api_query_data = array(
 			$addon_query_type_short => json_encode(


### PR DESCRIPTION
Add and 

TODO:
- [x] Added patch to add and use constant for WordPress.org API.
- [x] Check status of automated tests
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #312 ]

