### PR TITLE
Update two constants related to HTTP API

### DIFF
--- a/defines.php
+++ b/defines.php
@@ -106,8 +106,13 @@ define( 'VIPGOCI_CACHE_CLEAR', '--VIPGOCI-CACHE-CLEAR-0x321--' );
 /*
  * Define for vipgoci_http_api_wait() function.
  */
-define( 'VIPGOCI_HTTP_API_WAIT_TIME_SECONDS', 2 );
-define( 'VIPGOCI_HTTP_API_WAIT_APIS_ARRAY', array( 'api.github.com' ) );
+
+// This can be overridden in programs using vip-go-ci as library.
+if ( ! defined( 'VIPGOCI_HTTP_API_WAIT_TIME_SECONDS' ) ) {
+	define( 'VIPGOCI_HTTP_API_WAIT_TIME_SECONDS', 3 );
+}
+
+define( 'VIPGOCI_HTTP_API_WAIT_APIS_ARRAY', array( VIPGOCI_GITHUB_BASE_URL ) );
 
 /*
  * Defines for files.


### PR DESCRIPTION
This pull request changes two constants related to HTTP API:

1. Make `VIPGOCI_HTTP_API_WAIT_TIME_SECONDS` conditional, so that programs using `vip-go-ci` as library can define their own value.
2. Define `VIPGOCI_HTTP_API_WAIT_APIS_ARRAY` so to use the `VIPGOCI_GITHUB_BASE_URL` constant.

- [x] Make `VIPGOCI_HTTP_API_WAIT_TIME_SECONDS` conditional
- [x] Use `VIPGOCI_GITHUB_BASE_URL` constant when defining `VIPGOCI_HTTP_API_WAIT_APIS_ARRAY`.
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #312 ]
