### PR TITLE
IRC API update: Replace cURL functionality with vipgoci_http_api_post_url()

### DIFF
--- a/other-web-services.php
+++ b/other-web-services.php
@@ -247,60 +247,6 @@ function vipgoci_irc_api_alerts_send(
 			'channel' => $channel,
 		);
 
-		$ch = curl_init();
-
-		curl_setopt(
-			$ch,
-			CURLOPT_URL,
-			$irc_api_url
-		);
-
-		curl_setopt(
-			$ch,
-			CURLOPT_RETURNTRANSFER,
-			1
-		);
-
-		curl_setopt(
-			$ch,
-			CURLOPT_CONNECTTIMEOUT,
-			VIPGOCI_HTTP_API_SHORT_TIMEOUT
-		);
-
-		curl_setopt(
-			$ch,
-			CURLOPT_USERAGENT,
-			VIPGOCI_CLIENT_ID
-		);
-
-		curl_setopt(
-			$ch,
-			CURLOPT_POST,
-			1
-		);
-
-		curl_setopt(
-			$ch,
-			CURLOPT_POSTFIELDS,
-			json_encode( $irc_api_postfields )
-		);
-
-		curl_setopt(
-			$ch,
-			CURLOPT_HEADERFUNCTION,
-			'vipgoci_curl_headers'
-		);
-
-		curl_setopt(
-			$ch,
-			CURLOPT_HTTPHEADER,
-			array( 'Authorization: Bearer ' . $irc_api_token )
-		);
-
-		vipgoci_curl_set_security_options(
-			$ch
-		);
-
 		/*
 		 * Execute query, keep record of how long time it
 		 * took, and keep count of how many requests we do.
@@ -314,21 +260,23 @@ function vipgoci_irc_api_alerts_send(
 			1
 		);
 
-		$resp_data = curl_exec( $ch );
-
-		vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'irc_api_post' );
-
-		$resp_headers = vipgoci_curl_headers(
-			null,
-			null
+		vipgoci_http_api_post_url(
+			$irc_api_url,
+			$irc_api_postfields,
+			array( 'bearer' => $irc_api_token ),
+			false,
+			true,
+			CURL_HTTP_VERSION_NONE,
+			VIPGOCI_HTTP_API_CONTENT_TYPE_APPLICATION_JSON,
+			0,
+			VIPGOCI_HTTP_API_SHORT_TIMEOUT
 		);
 
-		curl_close( $ch );
+		vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'irc_api_post' );
 
 		/*
 		 * Enforce a small wait between requests.
 		 */
-
 		time_nanosleep( 0, 500000000 );
 	}
 }


### PR DESCRIPTION
Modernizes the IRC API by using `vipgoci_http_api_post_url()` instead of calling the cURL functions directly.

#318 is a requirement.

TODO:
- [x] IRC API uses `vipgoci_http_api_post_url()` function.
- [x] Check status of automated tests
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #312 ]
