### PR TITLE
Increment counter when request limit is reached

### DIFF
--- a/http-functions.php
+++ b/http-functions.php
@@ -275,6 +275,12 @@ function vipgoci_http_api_rate_limit_check(
 		( is_numeric( $resp_headers['x-ratelimit-remaining'][0] ) ) &&
 		( $resp_headers['x-ratelimit-remaining'][0] <= 1 )
 	) {
+		vipgoci_counter_report(
+			VIPGOCI_COUNTERS_DO,
+			'http_api_request_limit_reached',
+			1
+		);
+
 		vipgoci_sysexit(
 			'Exceeded rate limit for HTTP API, unable to ' .
 				'continue without making further requests.',

--- a/main.php
+++ b/main.php
@@ -1894,6 +1894,7 @@ function vipgoci_run_cleanup_send_pixel_api(
 				$options['pixel-api-groupprefix'] .
 					'-actions' =>
 				array(
+					'http_api_request_limit_reached',
 					'github_pr_approval',
 					'github_pr_non_approval',
 					'http_api_request_get',
@@ -1912,6 +1913,7 @@ function vipgoci_run_cleanup_send_pixel_api(
 					$options['repo-owner'] . '-' .
 					$options['repo-name']
 				=> array(
+					'http_api_request_limit_reached',
 					'github_pr_approval',
 					'github_pr_non_approval',
 					'github_pr_files_linted',

--- a/main.php
+++ b/main.php
@@ -1899,7 +1899,7 @@ function vipgoci_run_cleanup_send_pixel_api(
 					'http_api_request_put',
 					'http_api_request_delete',
 					'http_api_request_failure',
-          'http_api_request_limit_reached',
+					'http_api_request_limit_reached',
 					'github_pr_approval',
 					'github_pr_non_approval',
 					'github_pr_lint_issues',
@@ -1914,8 +1914,8 @@ function vipgoci_run_cleanup_send_pixel_api(
 					$options['repo-owner'] . '-' .
 					$options['repo-name']
 				=> array(
-          'http_api_request_failure',
-          'http_api_request_limit_reached',
+					'http_api_request_failure',
+					'http_api_request_limit_reached',
 					'github_pr_approval',
 					'github_pr_non_approval',
 					'github_pr_files_linted',

--- a/tests/unit/HttpFunctionsHttpApiRateLimitsCheckTest.php
+++ b/tests/unit/HttpFunctionsHttpApiRateLimitsCheckTest.php
@@ -39,64 +39,64 @@ final class HttpFunctionsHttpApiRateLimitsCheckTest extends TestCase {
 	public function dataRateLimits() :array {
 		return array(
 			array(
-				'https://api.github.com/v1',
-				array(),
-				'',
-				null,
+				'https://api.github.com/v1', // Request URL (input).
+				array(), // HTTP response header (input).
+				'', // Expected log message outputted.
+				array(), // Expected counters result array.
 			),
 			array(
 				'https://api.github.com/v1',
 				array( 'x-ratelimit-remaining' => array( '100' ) ),
 				'',
-				null,
+				array(),
 			),
 			array(
 				'https://api.github.com/v1',
 				array( 'x-ratelimit-remaining' => array( '0' ) ),
 				'"Exceeded rate limit for HTTP API, unable to continue without making further requests."' . PHP_EOL,
-				1,
+				array( 'http_api_request_limit_reached' => 1 ),
 			),
 			array(
 				'https://api.github.com/v1',
 				array( 'x-ratelimit-remaining' => array( '-1' ) ),
 				'"Exceeded rate limit for HTTP API, unable to continue without making further requests."' . PHP_EOL,
-				1,
+				array( 'http_api_request_limit_reached' => 1 ),
 			),
 			array(
 				'https://api.github.com/v1',
 				array( 'x-ratelimit-remaining' => array( 'abc' ) ), // Invalid, not numeric.
 				'',
-				null,
+				array(),
 			),
 			array(
 				'https://wpscan.com/api/v3/plugins/test',
 				array(),
 				'',
-				null,
+				array(),
 			),
 			array(
 				'https://wpscan.com/api/v3/plugins/test',
 				array( 'x-ratelimit-remaining' => array( '100' ) ),
 				'',
-				null,
+				array(),
 			),
 			array(
 				'https://wpscan.com/api/v3/plugins/test',
 				array( 'x-ratelimit-remaining' => array( '0' ) ),
 				'"Exceeded rate limit for HTTP API, unable to continue without making further requests."' . PHP_EOL,
-				1,
+				array( 'http_api_request_limit_reached' => 1 ),
 			),
 			array(
 				'https://wpscan.com/api/v3/plugins/test',
 				array( 'x-ratelimit-remaining' => array( '-1' ) ),
 				'',
-				null,
+				array(),
 			),
 			array(
 				'https://wpscan.com/api/v3/plugins/test',
 				array( 'x-ratelimit-remaining' => array( 'abc' ) ), // Invalid, not numeric.
 				'',
-				null,
+				array(),
 			),
 		);
 	}
@@ -111,51 +111,44 @@ final class HttpFunctionsHttpApiRateLimitsCheckTest extends TestCase {
 	 * @return void
 	 */
 	public function testRateLimits(
-		string $url,
-		array $headers,
-		string $output,
-		null|int $counter_status
+		string $url_input,
+		array $headers_input,
+		string $output_expected,
+		array $counters_expected
 	): void {
 		ob_start();
 
 		vipgoci_http_api_rate_limit_check(
-			$url,
-			$headers
+			$url_input,
+			$headers_input
 		);
 
-		$printed_data = ob_get_contents();
+		$output_actual = ob_get_contents();
 		ob_end_clean();
 
-		$counters_report = vipgoci_counter_report(
+		$counters_actual = vipgoci_counter_report(
 			VIPGOCI_COUNTERS_DUMP,
 			null,
 			null
 		);
 
 		$log_detail = array(
-			'url'            => $url,
-			'headers'        => $headers,
-			'output'         => $output,
-			'counter_status' => $counter_status,
+			'url_input'         => $url_input,
+			'headers_input'     => $headers_input,
+			'output_expected'   => $output_expected,
+			'counters_expected' => $counters_expected,
 		); 
 
 		$this->assertSame(
-			$output,
-			$printed_data,
+			$output_expected,
+			$output_actual,
 			'Verification failed using data: ' . json_encode( $log_detail )
 		);
 
-		if ( null !== $counter_status ) {
-			$this->assertSame(
-				array( 'http_api_request_limit_reached' => $counter_status ),
-				$counters_report,
-				'Failed verifying with data: ' . json_encode( $log_detail )
-			);
-		} else {
-			$this->assertSame(
-				array(),
-				$counters_report
-			);
-		}
+		$this->assertSame(
+			$counters_expected,
+			$counters_actual,
+			'Failed verifying with data: ' . json_encode( $log_detail )
+		);
 	}
 }


### PR DESCRIPTION
Increment `http_api_request_limit_reached` counter when request limit is reached and send to statistics API.

TODO:
- [x] Increment `http_api_request_limit_reached` counter when request limit is reached.
- [x] Send `http_api_request_limit_reached` to statistics service.
- [x] Update test for `vipgoci_http_api_rate_limit_check()` function.
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #312 ]
