### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.18.1
+        uses: shivammathur/setup-php@2.21.2
         with:
           coverage: none
           php-version: "${{ matrix.php }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,19 +56,19 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP 7.4
-        uses: shivammathur/setup-php@2.18.1
+        uses: shivammathur/setup-php@2.21.2
         with:
           coverage: none
           php-version: "7.4"
 
       - name: Set up PHP 8.0
-        uses: shivammathur/setup-php@2.18.1
+        uses: shivammathur/setup-php@2.21.2
         with:
           coverage: none
           php-version: "8.0"
 
       - name: Set up PHP 8.1
-        uses: shivammathur/setup-php@2.18.1
+        uses: shivammathur/setup-php@2.21.2
         with:
           coverage: none
           php-version: "8.1"
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.18.1
+        uses: shivammathur/setup-php@2.21.2
         with:
           coverage: none
           php-version: 8.1


### PR DESCRIPTION
This pull request will update GitHub Actions dependencies to the latest. This will resolve a few annotation warnings, see for example [here](https://github.com/Automattic/vip-go-ci/actions/runs/3322100556).

TODO:
- [x] Update `shivammathur/setup-php` to version `2.21.2`
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #312 ]
