### PR TITLE
Do not display "No issues were found...." when maximum number of comments is reached 

### DIFF
--- a/main.php
+++ b/main.php
@@ -2689,6 +2689,14 @@ function vipgoci_run_scan_total_comments_max_warning_post(
 				VIPGOCI_REVIEW_COMMENTS_TOTAL_MAX,
 				$options['commit']
 			);
+
+			// Record that we submitted feedback to GitHub.
+			vipgoci_report_feedback_to_github_was_submitted(
+				$options['repo-owner'],
+				$options['repo-name'],
+				$pr_number,
+				true
+			);
 		}
 	}
 }

--- a/main.php
+++ b/main.php
@@ -2667,6 +2667,8 @@ function vipgoci_run_scan_reviews_comments_enforce_maximum(
  * If we reached maximum number of
  * comments earlier, put a message out
  * so people actually know about it.
+ * Record as well that feedback has
+ * been submitted.
  *
  * @param array $options            Array of options.
  * @param array $prs_comments_maxed Array of PRs with maximum number of


### PR DESCRIPTION

This pull request ensures that `No issues were found to report when scanning latest commit` is not published when maximum number of active comments is reached for a scanned pull request.

TODO:
- [x] Record we submitted feedback to GitHub when maximum number of active comments is reached
- [x] Update test `tests/integration/MainRunScanTotalCommentsMaxWarningPostTest.php`
- [x] Check status of automated tests
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #312 ]
