### PR TITLE
Rename test class, update function name in comments

### DIFF
--- a/tests/unit/HttpApiRateLimitUsageTest.php
+++ b/tests/unit/HttpApiRateLimitUsageTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-final class GitHubRateLimitUsageTest extends TestCase {
+final class HttpApiRateLimitUsageTest extends TestCase {
 	/**
 	 * Setup function. Require files, etc.
 	 *

--- a/tests/unit/MiscDirectoryPathMakeRelativeToBaseTest.php
+++ b/tests/unit/MiscDirectoryPathMakeRelativeToBaseTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test vipgoci_directory_path_make_relative_to_base() function.
+ * Test vipgoci_directory_path_get_dir_and_include_base() function.
  *
  * @package Automattic/vip-go-ci
  */
@@ -30,7 +30,7 @@ final class MiscDirectoryPathMakeRelativeToBaseTest extends TestCase {
 	/**
 	 * Test various usage cases of the function.
 	 *
-	 * @covers ::vipgoci_directory_path_make_relative_to_base
+	 * @covers ::vipgoci_directory_path_get_dir_and_include_base
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
This pull request brings in two updates for consistency:
* Rename test class for test `tests/unit/HttpApiRateLimitUsageTest` to match file-name.
* Update function name in comments in test `tests/unit/MiscDirectoryPathMakeRelativeToBaseTest.php`

TODO:
- [x] Rename test class for test `tests/unit/HttpApiRateLimitUsageTest` 
- [x] Update function name in comments in test `tests/unit/MiscDirectoryPathMakeRelativeToBaseTest.php`
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #312 ]
 
