### PR TITLE
Update shivammathur/setup-php dependency to use @v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.21.2
+        uses: shivammathur/setup-php@2.22.0
         with:
           coverage: none
           php-version: "${{ matrix.php }}"
@@ -56,19 +56,19 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP 7.4
-        uses: shivammathur/setup-php@2.21.2
+        uses: shivammathur/setup-php@2.22.0
         with:
           coverage: none
           php-version: "7.4"
 
       - name: Set up PHP 8.0
-        uses: shivammathur/setup-php@2.21.2
+        uses: shivammathur/setup-php@2.22.0
         with:
           coverage: none
           php-version: "8.0"
 
       - name: Set up PHP 8.1
-        uses: shivammathur/setup-php@2.21.2
+        uses: shivammathur/setup-php@2.22.0
         with:
           coverage: none
           php-version: "8.1"
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.21.2
+        uses: shivammathur/setup-php@2.22.0
         with:
           coverage: none
           php-version: 8.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.22.0
+        uses: shivammathur/setup-php@v2
         with:
           coverage: none
           php-version: "${{ matrix.php }}"
@@ -56,19 +56,19 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP 7.4
-        uses: shivammathur/setup-php@2.22.0
+        uses: shivammathur/setup-php@v2
         with:
           coverage: none
           php-version: "7.4"
 
       - name: Set up PHP 8.0
-        uses: shivammathur/setup-php@2.22.0
+        uses: shivammathur/setup-php@v2
         with:
           coverage: none
           php-version: "8.0"
 
       - name: Set up PHP 8.1
-        uses: shivammathur/setup-php@2.22.0
+        uses: shivammathur/setup-php@v2
         with:
           coverage: none
           php-version: "8.1"
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.22.0
+        uses: shivammathur/setup-php@v2
         with:
           coverage: none
           php-version: 8.1


### PR DESCRIPTION
Update dependency `shivammathur/setup-php` to use tag `@v2`; this eliminates manually updating the workflow to use the latest version number available. 

This also resolves a few run-time warnings, see for example [here](https://github.com/Automattic/vip-go-ci/actions/runs/3430508549).

TODO:
- [x] Update `shivammathur/setup-php` to use version `@v2`.
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #312 ]
