### PR TITLE
Add GitHub API version HTTP header

### DIFF
--- a/defines.php
+++ b/defines.php
@@ -26,7 +26,7 @@ define( 'VIPGOCI_CLIENT_ID', 'automattic-vip-go-ci' );
 
 
 /*
- * Base URLs for GitHub
+ * GitHub defines.
  */
 define( 'VIPGOCI_GITHUB_WEB_BASE_URL', 'https://github.com' );
 
@@ -34,6 +34,8 @@ define( 'VIPGOCI_GITHUB_WEB_BASE_URL', 'https://github.com' );
 if ( ! defined( 'VIPGOCI_GITHUB_BASE_URL' ) ) {
 	define( 'VIPGOCI_GITHUB_BASE_URL', 'https://api.github.com' );
 }
+
+define( 'VIPGOCI_GITHUB_API_VERSION', '2022-11-28' );
 
 /*
  * Defines for various sizes, such as KB.

--- a/github-api.php
+++ b/github-api.php
@@ -10,6 +10,11 @@ declare(strict_types=1);
 /**
  * Add GitHub API version header to provided
  * array if URL is GitHub.
+ *
+ * @param string $http_api_url     Request URL to consider.
+ * @param array  $http_headers_arr HTTP headers array.
+ *
+ * @return void
  */
 function vipgoci_github_api_version_header_maybe_add(
 	string $http_api_url,

--- a/github-api.php
+++ b/github-api.php
@@ -8,6 +8,22 @@
 declare(strict_types=1);
 
 /**
+ * Add GitHub API version header to provided
+ * array if URL is GitHub.
+ */
+function vipgoci_github_api_version_header_maybe_add(
+	string $http_api_url,
+	array &$http_headers_arr
+) {
+	if ( true === str_starts_with(
+		$http_api_url,
+		VIPGOCI_GITHUB_BASE_URL
+	) ) {
+		$http_headers_arr[] = 'X-GitHub-Api-Version: ' . VIPGOCI_GITHUB_API_VERSION;
+	}
+}
+
+/**
  * Fetch diffs between two commits from GitHub API,
  * cache results.
  *

--- a/http-functions.php
+++ b/http-functions.php
@@ -489,26 +489,36 @@ function vipgoci_http_api_fetch_url(
 			'vipgoci_curl_headers'
 		);
 
+		/*
+		 * Set HTTP headers.
+		 */
+		$tmp_http_headers_arr = array();
+
 		if (
 			( is_string( $http_api_token ) ) &&
 			( strlen( $http_api_token ) > 0 )
 		) {
+			$tmp_http_headers_arr[] = 'Authorization: token ' . $http_api_token;
+
+		} elseif (
+			( is_array( $http_api_token ) ) &&
+			( isset( $http_api_token['wpscan_token'] ) )
+		) {
+			$tmp_http_headers_arr[] = 'Authorization: Token token=' .
+				$http_api_token['wpscan_token'];
+		}
+
+		vipgoci_github_api_version_header_maybe_add(
+			$http_api_url,
+			$tmp_http_headers_arr
+		);
+
+		if ( ! empty( $tmp_http_headers_arr ) ) {
 			curl_setopt(
 				$ch,
 				CURLOPT_HTTPHEADER,
-				array( 'Authorization: token ' . $http_api_token )
+				$tmp_http_headers_arr
 			);
-		} elseif ( is_array( $http_api_token ) ) {
-			if ( isset( $http_api_token['wpscan_token'] ) ) {
-				curl_setopt(
-					$ch,
-					CURLOPT_HTTPHEADER,
-					array(
-						'Authorization: Token token=' .
-							$http_api_token['wpscan_token'],
-					)
-				);
-			}
 		}
 
 		vipgoci_curl_set_security_options(
@@ -769,7 +779,9 @@ function vipgoci_http_api_post_url(
 			'vipgoci_curl_headers'
 		);
 
-		// Construct HTTP headers to send with the request.
+		/*
+		 * Set HTTP headers.
+		 */
 		$tmp_http_headers_arr = array();
 
 		if (
@@ -787,6 +799,11 @@ function vipgoci_http_api_post_url(
 		if ( strlen( $http_content_type ) > 0 ) {
 			$tmp_http_headers_arr[] = 'Content-Type: ' . $http_content_type;
 		}
+
+		vipgoci_github_api_version_header_maybe_add(
+			$http_api_url,
+			$tmp_http_headers_arr
+		);
 
 		if ( ! empty( $tmp_http_headers_arr ) ) {
 			curl_setopt(
@@ -1072,11 +1089,30 @@ function vipgoci_http_api_put_url(
 			'vipgoci_curl_headers'
 		);
 
-		curl_setopt(
-			$ch,
-			CURLOPT_HTTPHEADER,
-			array( 'Authorization: token ' . $http_api_token )
+		/*
+		 * Set HTTP headers.
+		 */
+		$tmp_http_headers_arr = array();
+
+		if (
+			( is_string( $http_api_token ) ) &&
+			( strlen( $http_api_token ) > 0 )
+		) {
+			$tmp_http_headers_arr[] = 'Authorization: token ' . $http_api_token;
+		}
+
+		vipgoci_github_api_version_header_maybe_add(
+			$http_api_url,
+			$tmp_http_headers_arr
 		);
+
+		if ( ! empty( $tmp_http_headers_arr ) ) {
+			curl_setopt(
+				$ch,
+				CURLOPT_HTTPHEADER,
+				$tmp_http_headers_arr
+			);
+		}
 
 		vipgoci_curl_set_security_options(
 			$ch

--- a/tests/unit/GitHubVersionHeaderMaybeAddTest.php
+++ b/tests/unit/GitHubVersionHeaderMaybeAddTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Test vipgoci_github_api_version_header_maybe_add() function.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class that implements the testing.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class GitHubVersionHeaderMaybeAddTest extends TestCase {
+	/**
+	 * Setup function. Require file.
+	 *
+	 * @return void
+	 */
+	protected function setUp() :void {
+		require_once __DIR__ . '/../../defines.php';
+		require_once __DIR__ . '/../../github-api.php';
+	}
+
+	/**
+	 * Test condition when header should not be added to array.
+	 *
+	 * @covers ::vipgoci_github_api_version_header_maybe_add
+	 *
+	 * @return void
+	 */
+	public function testVersionHeaderNoneAdded(): void {
+		$http_headers_arr = array();
+
+		vipgoci_github_api_version_header_maybe_add(
+			'http://127.0.0.1/user',
+			$http_headers_arr
+		);
+
+		$this->assertSame(
+			array(),
+			$http_headers_arr
+		);
+	}
+
+	/**
+	 * Test condition when header should be added to array.
+	 *
+	 * @covers ::vipgoci_github_api_version_header_maybe_add
+	 *
+	 * @return void
+	 */
+	public function testVersionHeaderAdded(): void {
+		$http_headers_arr = array();
+
+		vipgoci_github_api_version_header_maybe_add(
+			VIPGOCI_GITHUB_BASE_URL . '/user',
+			$http_headers_arr
+		);
+
+		$this->assertSame(
+			array(
+				'X-GitHub-Api-Version: ' . VIPGOCI_GITHUB_API_VERSION,
+			),
+			$http_headers_arr
+		);
+	}
+}


### PR DESCRIPTION
This pull request implements the new [GitHub API version header](https://github.blog/2022-11-28-to-infinity-and-beyond-enabling-the-future-of-githubs-rest-api-with-api-versioning/) so requests to the GitHub API from `vip-go-ci` will include the HTTP header when this patch is merged. The header value is set to `2022-11-28`.


TODO:
- [x] Add GitHub API version HTTP header
- [x] Add test for `vipgoci_github_api_version_header_maybe_add()`
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
  - [x] Run integration checks manually
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #333 ]
