### PR TITLE
Version number sanitizing: Allow "-" in version numbers

### DIFF
--- a/output-security.php
+++ b/output-security.php
@@ -19,7 +19,7 @@ function vipgoci_output_sanitize_version_number(
 	string $version_number
 ) :string {
 	return preg_replace(
-		'/[^a-zA-Z0-9\.]/',
+		'/[^a-zA-Z0-9\.\-]/',
 		'',
 		$version_number
 	);

--- a/tests/unit/OutputSecuritySanitizeVersionNumberTest.php
+++ b/tests/unit/OutputSecuritySanitizeVersionNumberTest.php
@@ -33,11 +33,11 @@ final class OutputSecuritySanitizeVersionNumberTest extends TestCase {
 	 */
 	public function testSanitizeVersionNumber(): void {
 		$sanitized_number = vipgoci_output_sanitize_version_number(
-			PHP_EOL . ' 1.50.30.3b,    ' . "\t" . PHP_EOL
+			PHP_EOL . ' 1.50.30.3b,  - 5b  ' . "\t" . PHP_EOL
 		);
 
 		$this->assertSame(
-			'1.50.30.3b',
+			'1.50.30.3b-5b',
 			$sanitized_number
 		);
 	}


### PR DESCRIPTION
This pull request allows "-" in output when calling `vipgoci_output_sanitize_version_number()`.

TODO:
- [x] Allow "-" in output when sanitizing version numbers.
- [x] Update `tests/unit/OutputSecuritySanitizeVersionNumberTest.php`
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
  - [x] Run integration checks manually
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #333 ]