### PR TITLE
WPScan fixes: Changes to file path and addon location, update tests

### DIFF
--- a/results.php
+++ b/results.php
@@ -367,6 +367,18 @@ function vipgoci_results_approved_files_comments_remove(
 			}
 
 			/*
+			 * Skip VIPGOCI_STATS_WPSCAN_API items as they
+			 * should always be displayed.
+			 */
+
+			if (
+				VIPGOCI_STATS_WPSCAN_API ===
+				$issue_item['type']
+			) {
+				continue;
+			}
+
+			/*
 			 * We have found an item that is approved,
 			 * and has non-info issues -- remove it
 			 * from the array of submittable issues.

--- a/results.php
+++ b/results.php
@@ -359,7 +359,6 @@ function vipgoci_results_approved_files_comments_remove(
 			 * Skip VIPGOCI_ISSUE_TYPE_INFO as that
 			 * does not report any errors.
 			 */
-
 			if ( strtolower(
 				$issue_item['issue']['level']
 			) === VIPGOCI_ISSUE_TYPE_INFO ) {
@@ -370,7 +369,6 @@ function vipgoci_results_approved_files_comments_remove(
 			 * Skip VIPGOCI_STATS_WPSCAN_API items as they
 			 * should always be displayed.
 			 */
-
 			if (
 				VIPGOCI_STATS_WPSCAN_API ===
 				$issue_item['type']

--- a/results.php
+++ b/results.php
@@ -359,20 +359,10 @@ function vipgoci_results_approved_files_comments_remove(
 			 * Skip VIPGOCI_ISSUE_TYPE_INFO as that
 			 * does not report any errors.
 			 */
+
 			if ( strtolower(
 				$issue_item['issue']['level']
 			) === VIPGOCI_ISSUE_TYPE_INFO ) {
-				continue;
-			}
-
-			/*
-			 * Skip VIPGOCI_STATS_WPSCAN_API items as they
-			 * should always be displayed.
-			 */
-			if (
-				VIPGOCI_STATS_WPSCAN_API ===
-				$issue_item['type']
-			) {
 				continue;
 			}
 

--- a/tests/integration/WpscanScanCommitTest.php
+++ b/tests/integration/WpscanScanCommitTest.php
@@ -30,14 +30,17 @@ final class WpscanScanCommitTest extends TestCase {
 		'wpscan-pr-1-plugin-dir'      => null,
 		'wpscan-pr-1-plugin-key'      => null,
 		'wpscan-pr-1-plugin-name'     => null,
+		'wpscan-pr-1-plugin-slug'     => null,
 		'wpscan-pr-1-plugin-version'  => null,
 		'wpscan-pr-1-plugin2-dir'     => null,
 		'wpscan-pr-1-plugin2-key'     => null,
 		'wpscan-pr-1-plugin2-name'    => null,
+		'wpscan-pr-1-plugin2-slug'    => null,
 		'wpscan-pr-1-plugin2-version' => null,
 		'wpscan-pr-1-theme-dir'       => null,
-		'wpscan-pr-1-theme-key'       => null,
 		'wpscan-pr-1-theme-name'      => null,
+		'wpscan-pr-1-theme-path'      => null,
+		'wpscan-pr-1-theme-slug'      => null,
 		'wpscan-pr-1-theme-version'   => null,
 	);
 
@@ -330,6 +333,7 @@ final class WpscanScanCommitTest extends TestCase {
 							'level'      => 'warning',
 							'severity'   => 7,
 							'details'    => array(
+								'slug'               => $this->options['wpscan-pr-1-plugin-slug'],
 								'installed_location' => $this->options['wpscan-pr-1-plugin-dir'],
 								'version_detected'   => $this->options['wpscan-pr-1-plugin-version'],
 								'vulnerabilities'    => array(),
@@ -346,6 +350,7 @@ final class WpscanScanCommitTest extends TestCase {
 							'level'      => 'warning',
 							'severity'   => 7,
 							'details'    => array(
+								'slug'               => $this->options['wpscan-pr-1-plugin2-slug'],
 								'installed_location' => $this->options['wpscan-pr-1-plugin2-dir'],
 								'version_detected'   => $this->options['wpscan-pr-1-plugin2-version'],
 								'vulnerabilities'    => array(),
@@ -354,7 +359,7 @@ final class WpscanScanCommitTest extends TestCase {
 					),
 					array(
 						'type'      => 'wpscan-api',
-						'file_name' => $this->options['wpscan-pr-1-theme-dir'] . '/' . $this->options['wpscan-pr-1-theme-key'],
+						'file_name' => $this->options['wpscan-pr-1-theme-path'],
 						'file_line' => 1,
 						'issue'     => array(
 							'addon_type' => 'vipgoci-addon-theme',
@@ -362,6 +367,7 @@ final class WpscanScanCommitTest extends TestCase {
 							'level'      => 'warning',
 							'severity'   => 7,
 							'details'    => array(
+								'slug'               => $this->options['wpscan-pr-1-theme-slug'],
 								'installed_location' => $this->options['wpscan-pr-1-theme-dir'],
 								'version_detected'   => $this->options['wpscan-pr-1-theme-version'],
 								'vulnerabilities'    => array(),

--- a/tests/integration/WpscanScanDirsAlteredTest.php
+++ b/tests/integration/WpscanScanDirsAlteredTest.php
@@ -207,6 +207,7 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 		$results_expected = array(
 			$this->options['wpscan-pr-1-plugin-dir'] => array(
 				$this->options['wpscan-pr-1-plugin-dir'] => array(
+					'slug'               => $this->options['wpscan-pr-1-plugin-slug'],
 					'wpscan_results'     => array(
 						'friendly_name'  => $this->options['wpscan-pr-1-plugin-name'],
 						'latest_version' => $this->getAddonVersionNumber(
@@ -224,6 +225,7 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 			),
 			$this->options['wpscan-pr-1-theme-dir']  => array(
 				$this->options['wpscan-pr-1-theme-slug'] => array(
+					'slug'               => $this->options['wpscan-pr-1-theme-slug'],
 					'wpscan_results'     => array(
 						'friendly_name'  => $this->options['wpscan-pr-1-theme-name'],
 						'latest_version' => $this->getAddonVersionNumber(

--- a/tests/integration/WpscanScanSaveForSubmissionTest.php
+++ b/tests/integration/WpscanScanSaveForSubmissionTest.php
@@ -64,6 +64,7 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 					'popular'         => true,
 					'vulnerabilities' => array(),
 				),
+				'slug'               => 'hello-dolly',
 				'addon_data_for_dir' => array(
 					'type'             => 'vipgoci-addon-plugin',
 					'addon_headers'    => array(
@@ -84,7 +85,7 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 					),
 					'name'             => 'Hello Dolly',
 					'version_detected' => '1.6',
-					'file_name'        => '/tmp/plugins/hello/hello.php',
+					'file_name'        => '%local-git-repo%plugins/hello/hello.php',
 					'id'               => 'w.org/plugins/hello-dolly',
 					'slug'             => 'hello-dolly',
 					'new_version'      => '1.7.2',
@@ -104,6 +105,7 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 					'popular'         => true,
 					'vulnerabilities' => array(),
 				),
+				'slug'               => 'twentytwentyone',
 				'addon_data_for_dir' => array(
 					'type'             => 'vipgoci-addon-theme',
 					'addon_headers'    => array(
@@ -124,7 +126,7 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 					),
 					'name'             => 'Twenty Twenty-One',
 					'version_detected' => '1.0',
-					'file_name'        => '/tmp/themes/twentytwentyone/style.css',
+					'file_name'        => '%local-git-repo%themes/twentytwentyone/style.css',
 					'id'               => 'w.org/themes/twentytwentyone',
 					'slug'             => 'twentytwentyone',
 					'new_version'      => '1.6',
@@ -398,6 +400,20 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 			'error'   => 0,
 		);
 
+		$this->problematic_addons_found['plugins/hello']['hello.php']['addon_data_for_dir']['file_name'] =
+			str_replace(
+				'%local-git-repo%',
+				$this->options['local-git-repo'] . DIRECTORY_SEPARATOR,
+				$this->problematic_addons_found['plugins/hello']['hello.php']['addon_data_for_dir']['file_name']
+			);
+
+		$this->problematic_addons_found['themes/twentytwentyone']['style.css']['addon_data_for_dir']['file_name'] =
+			str_replace(
+				'%local-git-repo%',
+				$this->options['local-git-repo'] . DIRECTORY_SEPARATOR,
+				$this->problematic_addons_found['themes/twentytwentyone']['style.css']['addon_data_for_dir']['file_name']
+			);
+
 		vipgoci_wpscan_scan_save_for_submission(
 			$this->options,
 			$commit_issues_submit,
@@ -431,6 +447,7 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 							'security'   => 'obsolete',
 							'severity'   => 7,
 							'details'    => array(
+								'slug'                => 'hello-dolly',
 								'url'                 => 'https://wordpress.org/plugins/hello-dolly/',
 								'installed_location'  => 'plugins/hello',
 								'version_detected'    => '1.6',
@@ -451,6 +468,7 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 							'security'   => 'vulnerable',
 							'severity'   => 10,
 							'details'    => array(
+								'slug'                => 'twentytwentyone',
 								'url'                 => 'https://wordpress.org/themes/twentytwentyone/',
 								'installed_location'  => 'themes/twentytwentyone',
 								'version_detected'    => '1.0',

--- a/unittests.ini.dist
+++ b/unittests.ini.dist
@@ -71,7 +71,6 @@ wpscan-pr-1-plugin2-dir=plugins/hello2
 wpscan-pr-1-plugin2-key=hello.php
 wpscan-pr-1-plugin2-name=Hello Dolly
 wpscan-pr-1-plugin2-slug=hello-dolly
-wpscan-pr-1-plugin2-name-api=hello/hello.php
 wpscan-pr-1-plugin2-version=1.6
 wpscan-pr-1-theme-dir=themes/twentytwentyone
 wpscan-pr-1-theme-key=twentytwentyone

--- a/wpscan-scan.php
+++ b/wpscan-scan.php
@@ -511,12 +511,19 @@ function vipgoci_wpscan_scan_save_for_submission(
 					$issue_severity = VIPGOCI_WPSCAN_VULNERABLE === $problem_addon_files[ $problem_addon_file_name ]['security_type'] ?
 						10 : 7;
 
+					// Calculate relative file path.
+					$file_name = str_replace(
+						$options['local-git-repo'] . DIRECTORY_SEPARATOR,
+						'',
+						$issue_details['addon_data_for_dir']['file_name']
+					);
+
 					// Determine installed location.
-					$addon_installed_location = $dir_with_problem_addons;
+					$addon_installed_location = dirname( $file_name );
 
 					$commit_issues_submit[ $pr_number ][] = array(
 						'type'      => VIPGOCI_STATS_WPSCAN_API,
-						'file_name' => $dir_with_problem_addons . DIRECTORY_SEPARATOR . $problem_addon_file_name, // Required field.
+						'file_name' => $file_name, // Required field.
 						'file_line' => 1, // Required field, even if not used.
 						'issue'     => array(
 							'addon_type' => $issue_details['addon_data_for_dir']['type'],


### PR DESCRIPTION
This pull request brings in a few fixes for the WPScan API integration.

TODO:
- [x] Fixes:
  - [x] File path and addon location are calculated directly from repository data.
- [x] Add/update tests -- unit and/or integrated (if needed)
  - [x] Update tests in relation to path and add-on location changes.
  - [x] Add slugs to tests.
- [x] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
  - [x] Run integration tests manually (see [comment](https://github.com/Automattic/vip-go-ci/pull/338#issuecomment-1379140452)).
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #333 ]
