### PR TITLE
WPScan fixes: Ensure that WPScan type of items are not removed from results when filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here is an example of the scanning results provided by `vip-go-ci`:
 In addition to the above scanning, `vip-go-ci` can also automatically approve pull requests that fulfill a certain criteria:
 
 * Only non-functional changes are made in PHP code submitted (e.g., white-space changes only, comments added, etc).
-  * Plugins or themes that are vulnerable or are obsolete -- as determined by WPScan API -- are not auto-approved, even if the changes are non-functional.
+  * Plugins or themes that are vulnerable or are obsolete — as determined by WPScan API — are not auto-approved, even if the changes are non-functional.
 * With SVG scanning enabled, SVG files are approved if the scanner finds no issues in the scanned files.
 * Only CSS, images and other objects are altered and no PHP or JavaScript code. This is based on file-endings, and is configurable. For example, `.txt, .css, .gif, .jpg, .jpeg, .png`.
 * Any combination of the above that covers all the changes in the pull request submitted is automatically approved.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here is an example of the scanning results provided by `vip-go-ci`:
 In addition to the above scanning, `vip-go-ci` can also automatically approve pull requests that fulfill a certain criteria:
 
 * Only non-functional changes are made in PHP code submitted (e.g., white-space changes only, comments added, etc).
-* The submitted PHP or JavaScript code is registered in database of previously reviewed, safe code.
+  * Plugins or themes that are vulnerable or are obsolete -- as determined by WPScan API -- are not auto-approved, even if the changes are non-functional.
 * With SVG scanning enabled, SVG files are approved if the scanner finds no issues in the scanned files.
 * Only CSS, images and other objects are altered and no PHP or JavaScript code. This is based on file-endings, and is configurable. For example, `.txt, .css, .gif, .jpg, .jpeg, .png`.
 * Any combination of the above that covers all the changes in the pull request submitted is automatically approved.

--- a/results.php
+++ b/results.php
@@ -359,10 +359,20 @@ function vipgoci_results_approved_files_comments_remove(
 			 * Skip VIPGOCI_ISSUE_TYPE_INFO as that
 			 * does not report any errors.
 			 */
-
 			if ( strtolower(
 				$issue_item['issue']['level']
 			) === VIPGOCI_ISSUE_TYPE_INFO ) {
+				continue;
+			}
+
+			/*
+			 * Skip VIPGOCI_STATS_WPSCAN_API items as they
+			 * should always be displayed.
+			 */
+			if (
+				VIPGOCI_STATS_WPSCAN_API ===
+				$issue_item['type']
+			) {
 				continue;
 			}
 

--- a/tests/integration/ResultsApprovedFilesCommentsRemoveTest.php
+++ b/tests/integration/ResultsApprovedFilesCommentsRemoveTest.php
@@ -28,28 +28,143 @@ final class ResultsApprovedFilesCommentsRemoveTest extends TestCase {
 	}
 
 	/**
+	 * Results set for test.
+	 *
+	 * @var $results_arr
+	 */
+	private array $results_arr = array(
+		'issues' => array(
+			'32' => array(
+				array(
+					'type'      => 'phpcs',
+					'file_name' => 'php-file-1.php',
+					'file_line' => 7,
+					'issue'     => array(
+						'message'  => 'json_encode() is discouraged. Use wp_json_encode() instead.',
+						'source'   => 'WordPress.WP.AlternativeFunctions.json_encode_json_encode',
+						'severity' => 5,
+						'fixable'  => false,
+						'line'     => 7,
+						'column'   => 6,
+						'level'    => 'WARNING',
+					),
+				),
+				array(
+					'type'      => 'phpcs',
+					'file_name' => 'php-file-2.php',
+					'file_line' => 3,
+					'issue'     => array(
+						'message'  => 'All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'mysql_query\'.',
+						'source'   => 'WordPress.Security.EscapeOutput.OutputNotEscaped',
+						'severity' => 5,
+						'fixable'  => false,
+						'line'     => 3,
+						'column'   => 6,
+						'level'    => 'ERROR',
+					),
+				),
+				array(
+					'type'      => 'phpcs',
+					'file_name' => 'php-file-2.php',
+					'file_line' => 3,
+					'issue'     => array(
+						'message'  => 'Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead',
+						'source'   => 'PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved',
+						'severity' => 5,
+						'fixable'  => false,
+						'line'     => 3,
+						'column'   => 6,
+						'level'    => 'ERROR',
+					),
+				),
+				array(
+					'type'      => 'wpscan-api',
+					'file_name' => 'theme-1.css',
+					'file_line' => 3,
+					'issue'     => array(
+						'addon_type' => 'vipgoci-addon-theme',
+						'message'    => 'my-theme',
+						'level'      => 'ERROR',
+						'severity'   => 10,
+					),
+				),
+				array(
+					'type'      => 'wpscan-api',
+					'file_name' => 'plugin-1.php',
+					'file_line' => 3,
+					'issue'     => array(
+						'addon_type' => 'vipgoci-addon-plugin',
+						'message'    => 'my-plugin',
+						'level'      => 'ERROR',
+						'severity'   => 10,
+					),
+				),
+
+
+			),
+		),
+		'stats'  => array(
+			'phpcs'      => array(
+				'32' => array(
+					'error'   => 2,
+					'warning' => 1,
+					'info'    => 0,
+				),
+			),
+			'lint'       => array(
+				'32' => array(
+					'error'   => 0,
+					'warning' => 0,
+					'info'    => 0,
+				),
+			),
+			'wpscan-api' => array(
+				'32' => array(
+					'error'   => 2,
+					'warning' => 0,
+					'info'    => 0,
+				),
+			),
+		),
+	);
+
+	/**
 	 * Test function and compare result with expected results.
-	 * Expects results for one approved file to be removed.
 	 *
 	 * @return void
 	 *
 	 * @covers ::vipgoci_results_approved_files_comments_remove
 	 */
 	public function testRemoveCommentFromResults() :void {
-		$results_altered = json_decode(
-			'{"issues":{"32":[{"type":"phpcs","file_name":"bla-10.php","file_line":7,"issue":{"message":"json_encode() is discouraged. Use wp_json_encode() instead.","source":"WordPress.WP.AlternativeFunctions.json_encode_json_encode","severity":5,"fixable":false,"line":7,"column":6,"level":"WARNING"}},{"type":"phpcs","file_name":"bla-8.php","file_line":3,"issue":{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'mysql_query\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"line":3,"column":6,"level":"ERROR"}},{"type":"phpcs","file_name":"bla-8.php","file_line":3,"issue":{"message":"Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","source":"PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved","severity":5,"fixable":false,"line":3,"column":6,"level":"ERROR"}}]},"stats":{"phpcs":{"32":{"error":2,"warning":1,"info":0}},"lint":{"32":{"error":0,"warning":0,"info":0}}}}',
-			true
-		);
+		$results_altered = $this->results_arr;
 
-		$results_expected = json_decode(
-			'{"issues":{"32":[{"type":"phpcs","file_name":"bla-8.php","file_line":3,"issue":{"message":"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found \'mysql_query\'.","source":"WordPress.Security.EscapeOutput.OutputNotEscaped","severity":5,"fixable":false,"line":3,"column":6,"level":"ERROR"}},{"type":"phpcs","file_name":"bla-8.php","file_line":3,"issue":{"message":"Extension \'mysql_\' is deprecated since PHP 5.5 and removed since PHP 7.0; Use mysqli instead","source":"PHPCompatibility.Extensions.RemovedExtensions.mysql_DeprecatedRemoved","severity":5,"fixable":false,"line":3,"column":6,"level":"ERROR"}}]},"stats":{"phpcs":{"32":{"error":2,"warning":0,"info":0}},"lint":{"32":{"error":0,"warning":0,"info":0}}}}',
-			true
-		);
-
+		/*
+		 * Set auto-approved files array. Note that values
+		 * do not have any specific meaning.
+		 */
 		$auto_approved_files_arr = array(
-			'bla-10.php' => 'autoapprove-approved-php-file', // Not a value used generally, only for testing.
+			'php-file-1.php' => 'autoapprove-approved-php-file', // This file should be removed from results.
+			'theme-1.css'    => 'autoapprove-filetypes', // This one not.
+			'plugin-1.php'   => 'autoapprove-approved-php-file', // And not this one either.
 		);
 
+		/*
+		 * Prepare expected results based on original.
+		 * Manually remove the items applicable.
+		 */
+		$results_expected = $this->results_arr;
+
+		unset( $results_expected['issues']['32'][0] );
+
+		$results_expected['issues']['32'] = array_values(
+			$results_expected['issues']['32']
+		);
+
+		$results_expected['stats']['phpcs']['32']['warning'] = 0;
+
+		/*
+		 * Run function with provided data.
+		 */
 		vipgoci_unittests_output_suppress();
 
 		vipgoci_results_approved_files_comments_remove(
@@ -60,6 +175,9 @@ final class ResultsApprovedFilesCommentsRemoveTest extends TestCase {
 
 		vipgoci_unittests_output_unsuppress();
 
+		/*
+		 * Check if actual and expected results are the same.
+		 */
 		$this->assertSame(
 			$results_expected,
 			$results_altered


### PR DESCRIPTION
This pull request will ensure that WPScan type of items are not filtered from results due to the underlying files being auto-approved. 

The rationale is that WPScan type of items should always be reported; the fact that a add-on has a known issue or is obsolete will not be overridden by the file-ending or the fact that the changes were non-functional. 

TODO:
- [x] Added patch to ensure WPScan type of items are not filtered away.
- [x] Add test
  - [x] Verify that WPScan items are not filtered away.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
  - [x]  Run integration tests manually (see [comment](https://github.com/Automattic/vip-go-ci/pull/339/#issuecomment-1379053663)).
- [x] Update README
  - [x] The README file already mentions that a `pull request with obsolete or vulnerable plugin or theme is not auto-approved`.
  - [x] Remove reference to `database of previously reviewed, safe code`.
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #333 ]
