### PR TITLE
Fix output suppression in tests

### DIFF
--- a/tests/integration/GitHubAuthenticatedUserGetTest.php
+++ b/tests/integration/GitHubAuthenticatedUserGetTest.php
@@ -41,9 +41,13 @@ final class GitHubAuthenticatedUserGetTest extends TestCase {
 			return;
 		}
 
+		vipgoci_unittests_output_suppress();
+
 		$gh_result = vipgoci_github_authenticated_user_get(
 			$this->options['github-token']
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertTrue(
 			isset(

--- a/tests/integration/GitHubPrGenericSupportCommentTest.php
+++ b/tests/integration/GitHubPrGenericSupportCommentTest.php
@@ -114,9 +114,13 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			( empty( $this->current_user_info ) ) &&
 			( ! empty( $this->options['github-token'] ) )
 		) {
+			vipgoci_unittests_output_suppress();
+
 			$this->current_user_info = vipgoci_github_authenticated_user_get(
 				$this->options['github-token']
 			);
+
+			vipgoci_unittests_output_unsuppress();
 		}
 
 		/*
@@ -361,11 +365,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			VIPGOCI_CACHE_CLEAR
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		// Check if commenting succeeded.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -423,11 +431,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			count( $prs_implicated ) > 0
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		// Check if commenting succeeded.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -468,11 +480,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			VIPGOCI_CACHE_CLEAR
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		// And make sure it did not succeed.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -538,11 +554,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			count( $prs_implicated ) > 0
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		// Check if commenting succeeded.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -583,11 +603,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			VIPGOCI_CACHE_CLEAR
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		// And make sure it did not succeed.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -652,12 +676,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		$this->assertTrue(
 			count( $prs_implicated ) > 0
 		);
+		vipgoci_unittests_output_suppress();
 
 		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		// Check if commenting succeeded -- should not have, as branch is invalid.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -681,11 +708,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			VIPGOCI_CACHE_CLEAR
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		// And make sure it did not succeed the second time.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -734,11 +765,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			count( $prs_implicated ) > 0
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		// Check if commenting succeeded.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -779,11 +814,15 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			VIPGOCI_CACHE_CLEAR
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		// And make sure it did not succeed.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -828,12 +867,14 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		$this->options['post-generic-pr-support-comments-on-drafts'] = array(
 			2 => true,
 		);
+		vipgoci_unittests_output_suppress();
 
 		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+		vipgoci_unittests_output_unsuppress();
 
 		// And make sure it did succeed.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -901,6 +942,7 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			$this->assertTrue(
 				count( $pr_comments ) === 0
 			);
+			vipgoci_unittests_output_suppress();
 
 			// Add label to make sure no comment is posted.
 			vipgoci_github_label_add_to_pr(
@@ -910,13 +952,18 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				$pr_item->number,
 				$test_label
 			);
+
+			vipgoci_unittests_output_unsuppress();
 		}
+
+		vipgoci_unittests_output_suppress();
 
 		// Try to submit support comment.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+		vipgoci_unittests_output_unsuppress();
 
 		// Make sure commenting did not succeed.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -943,12 +990,14 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		vipgoci_cache(
 			VIPGOCI_CACHE_CLEAR
 		);
+		vipgoci_unittests_output_suppress();
 
 		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+		vipgoci_unittests_output_unsuppress();
 
 		// And make sure it did not succeed.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -980,12 +1029,14 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		$this->options['post-generic-pr-support-comments-on-drafts'] = array(
 			2 => true,
 		);
+		vipgoci_unittests_output_suppress();
 
 		// Try re-posting.
 		vipgoci_report_submit_pr_generic_support_comment(
 			$this->options,
 			$prs_implicated
 		);
+		vipgoci_unittests_output_unsuppress();
 
 		// And make sure it did not succeed.
 		foreach ( $prs_implicated as $pr_item ) {
@@ -1004,6 +1055,8 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				)
 			);
 
+			vipgoci_unittests_output_suppress();
+
 			vipgoci_github_pr_label_remove(
 				$this->options['repo-owner'],
 				$this->options['repo-name'],
@@ -1011,6 +1064,8 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 				$pr_item->number,
 				$test_label
 			);
+
+			vipgoci_unittests_output_unsuppress();
 		}
 	}
 }

--- a/tests/integration/GitRepoGitVersionTest.php
+++ b/tests/integration/GitRepoGitVersionTest.php
@@ -12,7 +12,11 @@ final class GitRepoGitVersionTest extends TestCase {
 	 * @covers ::vipgoci_git_version
 	 */
 	public function testVersion1() {
+		vipgoci_unittests_output_suppress();
+
 		$git_version = vipgoci_git_version();
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			0,
@@ -22,8 +26,12 @@ final class GitRepoGitVersionTest extends TestCase {
 			)
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		// Verify second call returns same results (should be cached).
 		$git_version_2 = vipgoci_git_version();
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			$git_version,

--- a/tests/integration/GitRepoSubmoduleGetUrlTest.php
+++ b/tests/integration/GitRepoSubmoduleGetUrlTest.php
@@ -76,32 +76,40 @@ final class GitRepoSubmoduleGetUrlTest extends TestCase {
 			);
 		}
 
-		vipgoci_unittests_output_unsuppress();
-
 		$ret = vipgoci_gitrepo_submodule_get_url(
 			$this->options['local-git-repo'],
 			'folder1/vip-go-ci-repo'
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			'https://github.com/automattic/vip-go-ci',
 			$ret
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		$ret = vipgoci_gitrepo_submodule_get_url(
 			$this->options['local-git-repo'],
 			'folder1/vip-go-ci-INVALID'
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			null,
 			$ret
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		$ret = vipgoci_gitrepo_submodule_get_url(
 			$this->options['local-git-repo'],
 			'folder2/vip-go-ci-INVALID'
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			null,

--- a/tests/integration/MainRunInitOptionsRepoOptionsTest.php
+++ b/tests/integration/MainRunInitOptionsRepoOptionsTest.php
@@ -162,7 +162,11 @@ final class MainRunInitOptionsRepoOptionsTest extends TestCase {
 		$this->options['post-generic-pr-support-comments'] = false;
 		$this->options['skip-draft-prs']                   = false;
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_run_init_options_repo_options( $this->options );
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertTrue(
 			$this->options['post-generic-pr-support-comments'],
@@ -211,7 +215,11 @@ final class MainRunInitOptionsRepoOptionsTest extends TestCase {
 		$this->options['post-generic-pr-support-comments'] = false;
 		$this->options['skip-draft-prs']                   = true;
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_run_init_options_repo_options( $this->options );
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertFalse(
 			$this->options['post-generic-pr-support-comments'],

--- a/tests/integration/MainRunScanReviewsCommentsEnforceMaximumTest.php
+++ b/tests/integration/MainRunScanReviewsCommentsEnforceMaximumTest.php
@@ -144,10 +144,14 @@ final class MainRunScanReviewsCommentsEnforceMaximumTest extends TestCase {
 		 */
 		$this->options['review-comments-total-max'] = 0;
 
+		vipgoci_unittests_output_suppress();
+
 		$prs_comments_maxed = vipgoci_run_scan_reviews_comments_enforce_maximum(
 			$this->options,
 			$this->results
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(),
@@ -181,10 +185,14 @@ final class MainRunScanReviewsCommentsEnforceMaximumTest extends TestCase {
 		 */
 		$this->options['review-comments-total-max'] = 1;
 
+		vipgoci_unittests_output_suppress();
+
 		$prs_comments_maxed = vipgoci_run_scan_reviews_comments_enforce_maximum(
 			$this->options,
 			$this->results
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(

--- a/tests/integration/OptionsReadRepoSkipFilesTest.php
+++ b/tests/integration/OptionsReadRepoSkipFilesTest.php
@@ -113,9 +113,13 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 
 		$this->setUpLocalGitRepo();
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_options_read_repo_skip_files(
 			$this->options
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(
@@ -146,9 +150,13 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 
 		$this->setUpLocalGitRepo();
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_options_read_repo_skip_files(
 			$this->options
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(
@@ -179,9 +187,13 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 
 		$this->setUpLocalGitRepo();
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_options_read_repo_skip_files(
 			$this->options
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(
@@ -214,9 +226,13 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 
 		$this->setUpLocalGitRepo();
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_options_read_repo_skip_files(
 			$this->options
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(
@@ -247,9 +263,13 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 
 		$this->setUpLocalGitRepo();
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_options_read_repo_skip_files(
 			$this->options
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(
@@ -280,9 +300,13 @@ final class OptionsReadRepoSkipFilesTest extends TestCase {
 
 		$this->setUpLocalGitRepo();
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_options_read_repo_skip_files(
 			$this->options
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(

--- a/tests/integration/PhpcsScanDoScanTest.php
+++ b/tests/integration/PhpcsScanDoScanTest.php
@@ -158,15 +158,20 @@ final class PhpcsScanDoScanTest extends TestCase {
 		 * is not already part of the current
 		 * standard.
 		 */
+		vipgoci_unittests_output_suppress();
+
+		$phpcs_sniffs_for_standard = vipgoci_phpcs_get_sniffs_for_standard(
+			$this->options_phpcs['phpcs-path'],
+			$this->options_phpcs['phpcs-php-path'],
+			$this->options_phpcs['phpcs-standard']
+		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertFalse(
 			array_search(
 				$this->options_phpcs['phpcs-sniffs-include'],
-				vipgoci_phpcs_get_sniffs_for_standard(
-					$this->options_phpcs['phpcs-path'],
-					$this->options_phpcs['phpcs-php-path'],
-					$this->options_phpcs['phpcs-standard']
-				)
+				$phpcs_sniffs_for_standard
 			)
 		);
 

--- a/tests/integration/PhpcsScanGetAllStandardsTest.php
+++ b/tests/integration/PhpcsScanGetAllStandardsTest.php
@@ -26,10 +26,14 @@ final class PhpcsScanGetAllStandardsTest extends TestCase {
 	 * @covers ::vipgoci_phpcs_get_all_standards
 	 */
 	public function testGetAllStandardsTest1() {
+		vipgoci_unittests_output_suppress();
+
 		$all_standards = vipgoci_phpcs_get_all_standards(
 			$this->options_phpcs['phpcs-path'],
 			$this->options_phpcs['phpcs-php-path']
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertNotEmpty(
 			$all_standards

--- a/tests/integration/RepoMetaApiRepoMetaApiDataFetchTest.php
+++ b/tests/integration/RepoMetaApiRepoMetaApiDataFetchTest.php
@@ -88,6 +88,8 @@ final class RepoMetaApiRepoMetaApiDataFetchTest extends TestCase {
 			return;
 		}
 
+		vipgoci_unittests_output_suppress();
+
 		$repo_meta_data = vipgoci_repo_meta_api_data_fetch(
 			$this->options['repo-meta-api-base-url'],
 			$this->options['repo-meta-api-user-id'],
@@ -95,6 +97,8 @@ final class RepoMetaApiRepoMetaApiDataFetchTest extends TestCase {
 			$this->options['repo-owner'],
 			$this->options['repo-name']
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertTrue(
 			count(
@@ -114,6 +118,8 @@ final class RepoMetaApiRepoMetaApiDataFetchTest extends TestCase {
 		/*
 		 * Re-test due to caching.
 		 */
+		vipgoci_unittests_output_suppress();
+
 		$repo_meta_data_2 = vipgoci_repo_meta_api_data_fetch(
 			$this->options['repo-meta-api-base-url'],
 			$this->options['repo-meta-api-user-id'],
@@ -121,6 +127,8 @@ final class RepoMetaApiRepoMetaApiDataFetchTest extends TestCase {
 			$this->options['repo-owner'],
 			$this->options['repo-name']
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			$repo_meta_data,

--- a/tests/integration/RepoMetaApiRepoMetaApiDataMatchTest.php
+++ b/tests/integration/RepoMetaApiRepoMetaApiDataMatchTest.php
@@ -91,14 +91,19 @@ final class RepoMetaApiRepoMetaApiDataMatchTest extends TestCase {
 
 		$option_key_no = null;
 
+		vipgoci_unittests_output_suppress();
+
+		$repo_meta_api_data_match = vipgoci_repo_meta_api_data_match(
+			$this->options,
+			'',
+			$option_key_no
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
 		$this->assertSame(
 			false,
-
-			vipgoci_repo_meta_api_data_match(
-				$this->options,
-				'',
-				$option_key_no
-			)
+			$repo_meta_api_data_match
 		);
 
 		$this->assertSame(
@@ -123,14 +128,19 @@ final class RepoMetaApiRepoMetaApiDataMatchTest extends TestCase {
 
 		$option_key_no = null;
 
+		vipgoci_unittests_output_suppress();
+
+		$repo_meta_api_data_match = vipgoci_repo_meta_api_data_match(
+			$this->options,
+			'data_match0',
+			$option_key_no
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
 		$this->assertSame(
 			false,
-
-			vipgoci_repo_meta_api_data_match(
-				$this->options,
-				'data_match0',
-				$option_key_no
-			)
+			$repo_meta_api_data_match
 		);
 
 		$this->assertSame(
@@ -155,14 +165,19 @@ final class RepoMetaApiRepoMetaApiDataMatchTest extends TestCase {
 
 		$option_key_no = null;
 
+		vipgoci_unittests_output_suppress();
+
+		$repo_meta_api_data_match = vipgoci_repo_meta_api_data_match(
+			$this->options,
+			'data_match1',
+			$option_key_no
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
 		$this->assertSame(
 			false,
-
-			vipgoci_repo_meta_api_data_match(
-				$this->options,
-				'data_match1',
-				$option_key_no
-			)
+			$repo_meta_api_data_match
 		);
 	
 		$this->assertSame(
@@ -187,14 +202,19 @@ final class RepoMetaApiRepoMetaApiDataMatchTest extends TestCase {
 
 		$option_key_no = null;
 
+		vipgoci_unittests_output_suppress();
+
+		$repo_meta_api_data_match = vipgoci_repo_meta_api_data_match(
+			$this->options,
+			'data_match2',
+			$option_key_no
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
 		$this->assertSame(
 			true,
-
-			vipgoci_repo_meta_api_data_match(
-				$this->options,
-				'data_match2',
-				$option_key_no
-			)
+			$repo_meta_api_data_match
 		);
 
 		$this->assertSame(

--- a/tests/integration/ResultsFilterCommentsToMaxTest.php
+++ b/tests/integration/ResultsFilterCommentsToMaxTest.php
@@ -119,11 +119,15 @@ final class ResultsFilterCommentsToMaxTest extends TestCase {
 
 		$prs_comments_maxed = array();
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_results_filter_comments_to_max(
 			$this->options,
 			$this->results,
 			$prs_comments_maxed
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(
@@ -167,6 +171,8 @@ final class ResultsFilterCommentsToMaxTest extends TestCase {
 			return;
 		}
 
+		vipgoci_unittests_output_suppress();
+
 		/*
 		 * Exactly one more comment allowed.
 		 */
@@ -181,15 +187,21 @@ final class ResultsFilterCommentsToMaxTest extends TestCase {
 			)
 		);
 
+		vipgoci_unittests_output_unsuppress();
+
 		$this->options['review-comments-total-max'] = $comments_count + 1;
 
 		$prs_comments_maxed = array();
+
+		vipgoci_unittests_output_suppress();
 
 		vipgoci_results_filter_comments_to_max(
 			$this->options,
 			$this->results,
 			$prs_comments_maxed
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(
@@ -254,11 +266,15 @@ final class ResultsFilterCommentsToMaxTest extends TestCase {
 
 		$prs_comments_maxed = array();
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_results_filter_comments_to_max(
 			$this->options,
 			$this->results,
 			$prs_comments_maxed
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(

--- a/tests/integration/ResultsRemoveExistingGithubCommentsTest.php
+++ b/tests/integration/ResultsRemoveExistingGithubCommentsTest.php
@@ -191,6 +191,8 @@ final class ResultsRemoveExistingGithubCommentsTest extends TestCase {
 			'error' => 1,
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_results_remove_existing_github_comments(
 			$this->options,
 			$prs_implicated,
@@ -198,6 +200,8 @@ final class ResultsRemoveExistingGithubCommentsTest extends TestCase {
 			false,
 			array()
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			$results_expected,

--- a/tests/integration/SvgScanScanCommitTest.php
+++ b/tests/integration/SvgScanScanCommitTest.php
@@ -122,8 +122,11 @@ final class SvgScanScanCommitTest extends TestCase {
 		$issues_stats = array();
 		$issues_skipped = array();
 
+		vipgoci_unittests_output_suppress();
 
 		$prs_implicated = $this->getPRsImplicated();
+
+		vipgoci_unittests_output_unsuppress();
 
 		foreach( $prs_implicated as $pr_item ) {
 			$issues_stats[
@@ -213,6 +216,8 @@ final class SvgScanScanCommitTest extends TestCase {
 	 * @return array|bool|mixed|null
 	 */
 	public function getPRsImplicated() {
+		vipgoci_unittests_output_suppress();
+
 		$prs_implicated = vipgoci_github_prs_implicated(
 			$this->options['repo-owner'],
 			$this->options['repo-name'],
@@ -220,6 +225,8 @@ final class SvgScanScanCommitTest extends TestCase {
 			$this->options['github-token'],
 			$this->options['branches-ignore']
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		return $prs_implicated;
 	}

--- a/tests/integration/WpscanApiDoScanViaApiTest.php
+++ b/tests/integration/WpscanApiDoScanViaApiTest.php
@@ -79,11 +79,15 @@ final class WpscanApiDoScanViaApiTest extends TestCase {
 			return;
 		}
 
+		vipgoci_unittests_output_suppress();
+
 		$actual_results = vipgoci_wpscan_do_scan_via_api(
 			$this->options['plugin-slug'],
 			VIPGOCI_ADDON_PLUGIN,
 			$this->options['wpscan-api-token']
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertNotEmpty(
 			$actual_results
@@ -128,11 +132,15 @@ final class WpscanApiDoScanViaApiTest extends TestCase {
 			return;
 		}
 
+		vipgoci_unittests_output_suppress();
+
 		$actual_results = vipgoci_wpscan_do_scan_via_api(
 			$this->options['theme-slug'],
 			VIPGOCI_ADDON_THEME,
 			$this->options['wpscan-api-token']
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertNotEmpty(
 			$actual_results
@@ -177,11 +185,15 @@ final class WpscanApiDoScanViaApiTest extends TestCase {
 			return;
 		}
 
+		vipgoci_unittests_output_suppress();
+
 		$actual_results = vipgoci_wpscan_do_scan_via_api(
 			'my-invalid-theme',
 			VIPGOCI_ADDON_THEME,
 			'invalid-token'
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertNull(
 			$actual_results

--- a/tests/integration/WpscanScanCommitTest.php
+++ b/tests/integration/WpscanScanCommitTest.php
@@ -188,12 +188,16 @@ final class WpscanScanCommitTest extends TestCase {
 			'warning' => 0,
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_wpscan_scan_commit(
 			$this->options,
 			$commit_issues_submit,
 			$commit_issues_stats,
 			$commit_skipped_files
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(
@@ -246,9 +250,9 @@ final class WpscanScanCommitTest extends TestCase {
 			return;
 		}
 
-		$this->options['wpscan-api'] = true;
-
 		vipgoci_unittests_output_unsuppress();
+
+		$this->options['wpscan-api'] = true;
 
 		$commit_issues_submit = array();
 		$commit_issues_stats  = array();
@@ -259,12 +263,16 @@ final class WpscanScanCommitTest extends TestCase {
 			'warning' => 0,
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_wpscan_scan_commit(
 			$this->options,
 			$commit_issues_submit,
 			$commit_issues_stats,
 			$commit_skipped_files
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(

--- a/tests/integration/WpscanScanDirsAlteredTest.php
+++ b/tests/integration/WpscanScanDirsAlteredTest.php
@@ -195,6 +195,8 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 			),
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		$results_actual = vipgoci_wpscan_scan_dirs_altered(
 			$this->options,
 			explode(
@@ -203,6 +205,8 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 			),
 			$addon_data_and_slugs_for_addon_dirs
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$results_expected = array(
 			$this->options['wpscan-pr-1-plugin-dir'] => array(
@@ -366,6 +370,8 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 			),
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		$results_actual = vipgoci_wpscan_scan_dirs_altered(
 			$this->options,
 			explode(
@@ -374,6 +380,8 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 			),
 			$addon_data_and_slugs_for_addon_dirs
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(),
@@ -437,6 +445,8 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 			),
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		$results_actual = vipgoci_wpscan_scan_dirs_altered(
 			$this->options,
 			explode(
@@ -445,6 +455,8 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 			),
 			$addon_data_and_slugs_for_addon_dirs
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(),
@@ -464,11 +476,15 @@ final class WpscanScanDirsAlteredTest extends TestCase {
 		string $addon_slug,
 		string $addon_type
 	) :string {
+		vipgoci_unittests_output_suppress();
+
 		$wpscan_plugin_info = vipgoci_wpscan_do_scan_via_api(
 			$addon_slug,
 			$addon_type,
 			$this->options['wpscan-api-token']
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		return (string) $wpscan_plugin_info[ $addon_slug ]['latest_version'];
 	}

--- a/tests/integration/WpscanScanFindAddonDirsAlteredTest.php
+++ b/tests/integration/WpscanScanFindAddonDirsAlteredTest.php
@@ -174,13 +174,13 @@ final class WpscanScanFindAddonDirsAlteredTest extends TestCase {
 			return;
 		}
 
-		vipgoci_unittests_output_unsuppress();
-
 		$results_actual = vipgoci_wpscan_find_addon_dirs_altered(
 			$this->options,
 			$this->commit_skipped_files,
 			$this->getFilesAffectedByCommitByPR()
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$results_expected = array(
 			'plugins',
@@ -238,13 +238,13 @@ final class WpscanScanFindAddonDirsAlteredTest extends TestCase {
 			return;
 		}
 
-		vipgoci_unittests_output_unsuppress();
-
 		$results_actual = vipgoci_wpscan_find_addon_dirs_altered(
 			$this->options,
 			$this->commit_skipped_files,
 			$this->getFilesAffectedByCommitByPR()
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$results_expected = array(
 			'plugins/hello',
@@ -299,13 +299,13 @@ final class WpscanScanFindAddonDirsAlteredTest extends TestCase {
 			return;
 		}
 
-		vipgoci_unittests_output_unsuppress();
-
 		$results_actual = vipgoci_wpscan_find_addon_dirs_altered(
 			$this->options,
 			$this->commit_skipped_files,
 			$this->getFilesAffectedByCommitByPR()
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(

--- a/tests/integration/WpscanScanSaveForSubmissionTest.php
+++ b/tests/integration/WpscanScanSaveForSubmissionTest.php
@@ -316,6 +316,8 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 			'error'   => 0,
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		// Add label.
 		$this->prLabelAdd();
 
@@ -333,6 +335,8 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 
 		// Remove label.
 		$this->prLabelRemove();
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(
@@ -398,6 +402,8 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 			'error'   => 0,
 		);
 
+		vipgoci_unittests_output_suppress();
+
 		vipgoci_wpscan_scan_save_for_submission(
 			$this->options,
 			$commit_issues_submit,
@@ -406,6 +412,8 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 			$this->getFilesAffectedByCommitByPR(),
 			$this->problematic_addons_found
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertSame(
 			array(

--- a/tests/unit/WpscanReportCommentFormatResultTest.php
+++ b/tests/unit/WpscanReportCommentFormatResultTest.php
@@ -43,6 +43,8 @@ final class WpscanReportCommentFormatResultTest extends TestCase {
 	 * @return void
 	 */
 	public function testReportResultPlugin(): void {
+		vipgoci_unittests_output_suppress();
+
 		$report_str = vipgoci_wpscan_report_comment_format_result(
 			'repo_owner',
 			'repo_name',
@@ -74,6 +76,8 @@ final class WpscanReportCommentFormatResultTest extends TestCase {
 				20,
 			)
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertStringContainsString(
 			'Plugin with update available',
@@ -194,6 +198,8 @@ final class WpscanReportCommentFormatResultTest extends TestCase {
 	 * @return void
 	 */
 	public function testReportResultTheme(): void {
+		vipgoci_unittests_output_suppress();
+
 		$report_str = vipgoci_wpscan_report_comment_format_result(
 			'repo_owner',
 			'repo_name',
@@ -225,6 +231,8 @@ final class WpscanReportCommentFormatResultTest extends TestCase {
 				40,
 			)
 		);
+
+		vipgoci_unittests_output_unsuppress();
 
 		$this->assertStringContainsString(
 			'Theme with known vulnerability',


### PR DESCRIPTION
Some tests output log messages during testing, which they should not do. This patch resolves this issue.

TODO:
- [x] Suppress/unsuppress output during test runs for tests that are missing this.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
  - [x] Ran integration tests manually see [comment](https://github.com/Automattic/vip-go-ci/pull/340#issuecomment-1387390734).
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #333 ]
