### PR TITLE
Add PHP 8.2 to CI tests, rename one CI task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI 
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI 
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,8 @@ jobs:
 
       - name: Configure tools
         run: |
-          sed "s:/home/phpunit/:${HOME}/:; s:phpcs-php-path=/usr/bin/php:phpcs-php-path=/usr/bin/php7.4:g; s:svg-php-path=/usr/bin/php:svg-php-path=/usr/bin/php8.1:g; s:github-repo-url=.*:github-repo-url=${HOME}/vip-go-ci-tools/vip-go-ci-testing:g;" unittests.ini.dist > unittests.ini
+          sed "s:/home/phpunit/:${HOME}/:; s:phpcs-php-path=.*:phpcs-php-path=/usr/bin/php7.4:g; s:svg-php-path=.*:svg-php-path=/usr/bin/php8.1:g; s:github-repo-url=.*:github-repo-url=${HOME}/vip-go-ci-tools/vip-go-ci-testing:g;" unittests.ini.dist > unittests.ini
+          rm unittests.ini.dist
           touch unittests-secrets.ini
           sed "s:PROJECT_DIR:$(pwd):g" phpunit.xml.dist > phpunit.xml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         php:
           - '8.0'
           - '8.1'
+          - '8.2'
     steps:
       - name: Check out the source code
         uses: actions/checkout@v3
@@ -51,6 +52,7 @@ jobs:
         php:
           - '8.0'
           - '8.1'
+          - '8.2'
     steps:
       - name: Check out the source code
         uses: actions/checkout@v3
@@ -72,6 +74,12 @@ jobs:
         with:
           coverage: none
           php-version: "8.1"
+
+      - name: Set up PHP 8.2
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: none
+          php-version: "8.2"
           tools: phpunit:9
         env:
           fail-fast: 'true'
@@ -112,7 +120,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: none
-          php-version: 8.1
+          php-version: 8.2
 
       - name: Install tools
         run: |
@@ -121,4 +129,4 @@ jobs:
 
       - name: Run PHPCS
         run: |
-          ~/vip-go-ci-tools/phpcs/bin/phpcs --runtime-set 'testVersion' '8.1-'  --standard=PHPCompatibility,PHPCompatibilityParagonieRandomCompat,PHPCompatibilityParagonieSodiumCompat --ignore="vendor/*" .
+          ~/vip-go-ci-tools/phpcs/bin/phpcs --runtime-set 'testVersion' '8.2-'  --standard=PHPCompatibility,PHPCompatibilityParagonieRandomCompat,PHPCompatibilityParagonieSodiumCompat --ignore="vendor/*" .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,8 @@ jobs:
         env:
           VIPGOCI_TESTING_DEBUG_MODE: 'true'
 
-  phpcs-scan:
-    name: PHPCS scan
+  php-code-compatibility:
+    name: PHP code compatibility (8.2)
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code


### PR DESCRIPTION
Run test suites with PHP 8.2.

TODO:
- [x] Add testing with PHP 8.2
- [x] Rename `PHPCS scan` task to `PHP code compatibility (8.2)`
- [N/A] Add/update tests -- unit and/or integrated (if needed)
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #333 ]

