### PR TITLE
Adding user for CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,13 @@ jobs:
           git -C ~/vip-go-ci-tools/vip-go-ci-testing checkout master # Switch to default
 
       - name: Configure tools
+        env:
+          GH_TESTS_TOKEN: ${{ secrets.GH_TESTS_TOKEN }}
         run: |
           sed "s:/home/phpunit/:${HOME}/:; s:phpcs-php-path=.*:phpcs-php-path=/usr/bin/php7.4:g; s:svg-php-path=.*:svg-php-path=/usr/bin/php8.1:g; s:github-repo-url=.*:github-repo-url=${HOME}/vip-go-ci-tools/vip-go-ci-testing:g;" unittests.ini.dist > unittests.ini
           rm -f unittests.ini.dist
           echo '[git-secrets]' > unittests-secrets.ini
+          echo "github-token=$GH_TESTS_TOKEN" >> unittests-secrets.ini
           echo 'github-skip-write-tests=true' >> unittests-secrets.ini
           sed "s:PROJECT_DIR:$(pwd):g" phpunit.xml.dist > phpunit.xml
 
@@ -110,6 +113,10 @@ jobs:
         run: phpunit --testsuite=integration-tests
         env:
           VIPGOCI_TESTING_DEBUG_MODE: 'true'
+
+      - name: Clean up after integration tests
+        run: |
+          rm -f unittests-secrets.ini
 
   php-code-compatibility:
     name: PHP code compatibility (8.2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,9 @@ jobs:
       - name: Configure tools
         run: |
           sed "s:/home/phpunit/:${HOME}/:; s:phpcs-php-path=.*:phpcs-php-path=/usr/bin/php7.4:g; s:svg-php-path=.*:svg-php-path=/usr/bin/php8.1:g; s:github-repo-url=.*:github-repo-url=${HOME}/vip-go-ci-tools/vip-go-ci-testing:g;" unittests.ini.dist > unittests.ini
-          rm unittests.ini.dist
-          touch unittests-secrets.ini
+          rm -f unittests.ini.dist
+          echo '[git-secrets]' > unittests-secrets.ini
+          echo 'github-skip-write-tests=true' >> unittests-secrets.ini
           sed "s:PROJECT_DIR:$(pwd):g" phpunit.xml.dist > phpunit.xml
 
       - name: Set default PHP version

--- a/TESTING.md
+++ b/TESTING.md
@@ -42,10 +42,10 @@ To enable the testing of these, you need to set up a `unittests-secrets.ini` fil
 
 ```
 [git-secrets]
-github-token=            ; Personal access token from GitHub
+github-token=            ; Personal access token for GitHub API.
 github-skip-write-tests= ; Whether to skip tests that write data to GitHub (true or false).
-team-slug=               ; Team slug to test if present, is a string.
-org-name=                ; GitHub organisation name to use in testing
+team-slug=               ; Team slug to test if present, should be a string.
+org-name=                ; GitHub organisation name to use in testing.
 
 [repo-meta-api-secrets]
 repo-meta-api-base-url=         ; URL to base of meta API
@@ -90,7 +90,7 @@ When the integration test suite runs on GitHub Actions the suite is configured s
 
 The integration test suite is further more set up with a GitHub access token, guaranteeing enough rate limiting quota. The access token is stored in GitHub Actions secrets for the repository. More details are available in internal documentation.
 
-During testing, certain fields in the `unittests-secrets.ini` are not specified, which leads to certain tests to being skipped.
+During testing, certain fields in the `unittests-secrets.ini` file are not specified, which leads to certain tests to being skipped.
 
 ## Manual testing
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -88,7 +88,7 @@ Note that the test suite uses the `@runTestsInSeparateProcesses` and `@preserveG
 
 When the integration test suite runs on GitHub Actions the suite is configured specifically not to write any data to GitHub during testing. More specifically, the `github-skip-write-tests` key/value (see [above](#test-suite-secrets-file)) is set to `true` value in the `unittests-secrets.ini` file during execution of the tests (see [here](.github/workflows/ci.yml)), which leads to certain tests not being run.
 
-The integration test suite is further more set up with a GitHub access token, guaranteeing enough rate limiting quota. The access token is stored in GitHub Actions secrets for the repository. More details are available in internal documentation.
+The integration test suite is further more set up with a GitHub access token, guaranteeing enough rate limiting quota for the tests. The access token is stored in GitHub Actions secrets for the repository. More details are available in internal documentation.
 
 During testing, certain fields in the `unittests-secrets.ini` file are not specified, which leads to certain tests to being skipped.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -42,9 +42,10 @@ To enable the testing of these, you need to set up a `unittests-secrets.ini` fil
 
 ```
 [git-secrets]
-github-token= ; Personal access token from GitHub
-team-slug=    ; Team slug to test if present, is a string.
-org-name=     ; GitHub organisation name to use in testing
+github-token=            ; Personal access token from GitHub
+github-skip-write-tests= ; Whether to skip tests that write data to GitHub (true or false).
+team-slug=               ; Team slug to test if present, is a string.
+org-name=                ; GitHub organisation name to use in testing
 
 [repo-meta-api-secrets]
 repo-meta-api-base-url=         ; URL to base of meta API
@@ -79,9 +80,17 @@ Integration tests will execute the scanning utilities — PHPCS, SVG scanner and
 
 By using this command, you will run the tests of the test-suite which can be run (depending on tokens and other detail), and get feedback on any errors or warnings. Note that when run, requests will be made to the GitHub API using anonymous calls (unless configured to use an access-token as shown above). It can happen that the GitHub API returns with an error indicating that the maximum limit of API requests has been reached; the solution is to wait and re-run or switch to authenticted calls. 
 
-### Details on tests
+### Test isolation
 
 Note that the test suite uses the `@runTestsInSeparateProcesses` and `@preserveGlobalState` PHPUnit flags to avoid any influence of one test on another. Further, tests should include all required files in `setUp()` function to avoid the same function being defined multiple times across multiple tests during the same run. Combining the usage of `@runTestsInSeparateProcesses` and the inclusion of required files in `setUp()` means each test is independent of other tests, which enables functions to be defined for each test easily and avoids leakage between tests.
+
+### Integration tests and GitHub Actions
+
+When the integration test suite runs on GitHub Actions the suite is configured specifically not to write any data to GitHub during testing. More specifically, the `github-skip-write-tests` key/value (see [above](#test-suite-secrets-file)) is set to `true` value in the `unittests-secrets.ini` file during execution of the tests (see [here](.github/workflows/ci.yml)), which leads to certain tests not being run.
+
+The integration test suite is further more set up with a GitHub access token, guaranteeing enough rate limiting quota. The access token is stored in GitHub Actions secrets for the repository. More details are available in internal documentation.
+
+During testing, certain fields in the `unittests-secrets.ini` are not specified, which leads to certain tests to being skipped.
 
 ## Manual testing
 

--- a/http-functions.php
+++ b/http-functions.php
@@ -451,7 +451,6 @@ function vipgoci_http_api_fetch_url(
 	int $curl_retries_max = 4
 ) :string|null {
 	$curl_retries = 0;
-
 	/*
 	 * Attempt to send request -- retry if
 	 * it fails.
@@ -499,7 +498,6 @@ function vipgoci_http_api_fetch_url(
 			( strlen( $http_api_token ) > 0 )
 		) {
 			$tmp_http_headers_arr[] = 'Authorization: token ' . $http_api_token;
-
 		} elseif (
 			( is_array( $http_api_token ) ) &&
 			( isset( $http_api_token['wpscan_token'] ) )

--- a/tests/integration/AutoApprovalScanCommitTest.php
+++ b/tests/integration/AutoApprovalScanCommitTest.php
@@ -127,7 +127,10 @@ final class AutoApprovalScanCommitTest extends TestCase {
 		$this->options['pr-test-ap-auto-approval-1'] =
 			(int) $this->options['pr-test-ap-auto-approval-1'];
 
-		$this->cleanup_prs();
+		$tmp = null;
+		if ( ! vipgoci_unittests_skip_github_write_tests( $tmp ) ) {
+			$this->cleanup_prs();
+		}
 	}
 
 	/**
@@ -143,7 +146,10 @@ final class AutoApprovalScanCommitTest extends TestCase {
 			);
 		}
 
-		$this->cleanup_prs();
+		$tmp = null;
+		if ( ! vipgoci_unittests_skip_github_write_tests( $tmp ) ) {
+			$this->cleanup_prs();
+		}
 
 		unset( $this->options_git );
 		unset( $this->options_auto_approvals );
@@ -281,6 +287,10 @@ final class AutoApprovalScanCommitTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		if ( false === $this->safe_to_run ) {
 			$this->markTestSkipped(
 				'Test not safe to run due to earlier warnings'
@@ -404,6 +414,10 @@ final class AutoApprovalScanCommitTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		if ( false === $this->safe_to_run ) {
 			$this->markTestSkipped(
 				'Test not safe to run due to earlier warnings'
@@ -521,6 +535,9 @@ final class AutoApprovalScanCommitTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
 		if ( false === $this->safe_to_run ) {
 			$this->markTestSkipped(
 				'Test not safe to run due to earlier warnings'
@@ -640,6 +657,10 @@ final class AutoApprovalScanCommitTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		if ( false === $this->safe_to_run ) {
 			$this->markTestSkipped(
 				'Test not safe to run due to earlier warnings'
@@ -752,6 +773,9 @@ final class AutoApprovalScanCommitTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
 		if ( false === $this->safe_to_run ) {
 			$this->markTestSkipped(
 				'Test not safe to run due to earlier warnings'
@@ -880,6 +904,10 @@ final class AutoApprovalScanCommitTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 

--- a/tests/integration/AutoApprovalScanCommitTest.php
+++ b/tests/integration/AutoApprovalScanCommitTest.php
@@ -127,8 +127,7 @@ final class AutoApprovalScanCommitTest extends TestCase {
 		$this->options['pr-test-ap-auto-approval-1'] =
 			(int) $this->options['pr-test-ap-auto-approval-1'];
 
-		$tmp = null;
-		if ( ! vipgoci_unittests_skip_github_write_tests( $tmp ) ) {
+		if ( ! vipgoci_unittests_get_skip_github_write_tests() ) {
 			$this->cleanup_prs();
 		}
 	}
@@ -146,8 +145,7 @@ final class AutoApprovalScanCommitTest extends TestCase {
 			);
 		}
 
-		$tmp = null;
-		if ( ! vipgoci_unittests_skip_github_write_tests( $tmp ) ) {
+		if ( ! vipgoci_unittests_get_skip_github_write_tests() ) {
 			$this->cleanup_prs();
 		}
 

--- a/tests/integration/GitHubApiLabelsTest.php
+++ b/tests/integration/GitHubApiLabelsTest.php
@@ -97,10 +97,10 @@ final class GitHubApiLabelsTest extends TestCase {
 	 * @return void.
 	 */
 	protected function tearDown(): void {
-		$this->options_git     = null;
-		$this->options_secrets = null;
-		$this->options_labels  = null;
-		$this->options         = null;
+		unset( $this->options_git );
+		unset( $this->options_secrets );
+		unset( $this->options_labels );
+		unset( $this->options );
 	}
 
 	/**
@@ -118,6 +118,10 @@ final class GitHubApiLabelsTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 
@@ -163,6 +167,10 @@ final class GitHubApiLabelsTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 

--- a/tests/integration/GitHubAuthenticatedUserGetTest.php
+++ b/tests/integration/GitHubAuthenticatedUserGetTest.php
@@ -46,6 +46,10 @@ final class GitHubAuthenticatedUserGetTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		vipgoci_unittests_output_suppress();
 
 		$gh_result = vipgoci_github_authenticated_user_get(

--- a/tests/integration/GitHubPrGenericSupportCommentTest.php
+++ b/tests/integration/GitHubPrGenericSupportCommentTest.php
@@ -117,12 +117,10 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		 * but only if we have a token. This info will
 		 * be re-used.
 		 */
-		$tmp = null;
-
 		if (
 			( empty( $this->current_user_info ) ) &&
 			( ! empty( $this->options['github-token'] ) ) &&
-			( ! vipgoci_unittests_skip_github_write_tests( $tmp ) )
+			( ! vipgoci_unittests_get_skip_github_write_tests() )
 		) {
 			vipgoci_unittests_output_suppress();
 

--- a/tests/integration/GitHubPrGenericSupportCommentTest.php
+++ b/tests/integration/GitHubPrGenericSupportCommentTest.php
@@ -142,11 +142,9 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			$this
 		);
 
-		$tmp = null;
-
 		if (
 			( -1 !== $options_test ) &&
-			( ! vipgoci_unittests_skip_github_write_tests( $tmp ) )
+			( ! vipgoci_unittests_get_skip_github_write_tests() )
 		) {
 			$this->clearOldSupportComments();
 		}
@@ -164,11 +162,9 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			$this
 		);
 
-		$tmp = null;
-
 		if (
 			( -1 !== $options_test ) &&
-			( ! vipgoci_unittests_skip_github_write_tests( $tmp ) )
+			( ! vipgoci_unittests_get_skip_github_write_tests() )
 		) {
 			$this->clearOldSupportComments();
 		}

--- a/tests/integration/GitHubPrGenericSupportCommentTest.php
+++ b/tests/integration/GitHubPrGenericSupportCommentTest.php
@@ -117,9 +117,12 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		 * but only if we have a token. This info will
 		 * be re-used.
 		 */
+		$tmp = null;
+
 		if (
 			( empty( $this->current_user_info ) ) &&
-			( ! empty( $this->options['github-token'] ) )
+			( ! empty( $this->options['github-token'] ) ) &&
+			( ! vipgoci_unittests_skip_github_write_tests( $tmp ) )
 		) {
 			vipgoci_unittests_output_suppress();
 
@@ -133,14 +136,18 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		/*
 		 * Don't attempt cleanup if not configured.
 		 */
-
 		$options_test = vipgoci_unittests_options_test(
 			$this->options,
 			array(),
 			$this
 		);
 
-		if ( -1 !== $options_test ) {
+		$tmp = null;
+
+		if (
+			( -1 !== $options_test ) &&
+			( ! vipgoci_unittests_skip_github_write_tests( $tmp ) )
+		) {
 			$this->clearOldSupportComments();
 		}
 	}
@@ -157,7 +164,12 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			$this
 		);
 
-		if ( -1 !== $options_test ) {
+		$tmp = null;
+
+		if (
+			( -1 !== $options_test ) &&
+			( ! vipgoci_unittests_skip_github_write_tests( $tmp ) )
+		) {
 			$this->clearOldSupportComments();
 		}
 
@@ -343,6 +355,10 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		// Configure branches we can post against.
 		$this->options['post-generic-pr-support-comments-branches'] =
 			array(
@@ -421,6 +437,10 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 
@@ -547,6 +567,10 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		// Configure branches we allow posting against.
 		$this->options['post-generic-pr-support-comments-branches'] =
 			array(
@@ -670,6 +694,10 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		// Configure branches to post against.
 		$this->options['post-generic-pr-support-comments-branches'] =
 			array(
@@ -755,6 +783,10 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 
@@ -919,6 +951,10 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 

--- a/tests/integration/GitHubRepoCollaboratorsTest.php
+++ b/tests/integration/GitHubRepoCollaboratorsTest.php
@@ -52,6 +52,10 @@ final class GitHubRepoCollaboratorsTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		vipgoci_unittests_output_suppress();
 
 		$repo_collaborators_all = vipgoci_github_repo_collaborators_get(
@@ -94,6 +98,10 @@ final class GitHubRepoCollaboratorsTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 

--- a/tests/integration/GitHubStatusCreateTest.php
+++ b/tests/integration/GitHubStatusCreateTest.php
@@ -186,6 +186,10 @@ final class GitHubStatusCreateTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		/*
 		 * Set build status and
 		 * then verify that it is failed.

--- a/tests/integration/IncludesForTestsConfig.php
+++ b/tests/integration/IncludesForTestsConfig.php
@@ -141,7 +141,7 @@ function vipgoci_unittests_options_test(
  * Returns true if to skip tests that write data via GitHub API,
  * otherwise false.
  *
- * @return bool True when to skip tests that write data.
+ * @return bool True when to skip tests that write data, otherwise false.
  */
 function vipgoci_unittests_get_skip_github_write_tests() :bool {
 	$config_arr = array(
@@ -169,7 +169,7 @@ function vipgoci_unittests_get_skip_github_write_tests() :bool {
  *
  * @param object|null $test_instance Instance of test class.
  *
- * @return bool True when to skip tests that write data.
+ * @return bool True when to skip tests that write data, otherwise false.
  */
 function vipgoci_unittests_skip_github_write_tests(
 	object|null &$test_instance

--- a/tests/integration/IncludesForTestsConfig.php
+++ b/tests/integration/IncludesForTestsConfig.php
@@ -138,15 +138,12 @@ function vipgoci_unittests_options_test(
 }
 
 /**
- * Returns true if to skip tests that write data via GitHub API.
+ * Returns true if to skip tests that write data via GitHub API,
+ * otherwise false.
  *
- * @param object|null $test_instance Instance of test class.
- *
- * @return bool
+ * @return bool True when to skip tests that write data.
  */
-function vipgoci_unittests_skip_github_write_tests(
-	object|null &$test_instance
-) :bool {
+function vipgoci_unittests_get_skip_github_write_tests() :bool {
 	$config_arr = array(
 		'github-skip-write-tests' => null,
 	);
@@ -161,6 +158,23 @@ function vipgoci_unittests_skip_github_write_tests(
 		( isset( $config_arr['github-skip-write-tests'] ) ) &&
 		( '1' === $config_arr['github-skip-write-tests'] )
 	) {
+		return true;
+	}
+
+	return false;
+}
+/**
+ * Returns true if to skip tests that write data via GitHub API
+ * and will mark test as skipped as well. Otherwise returns false.
+ *
+ * @param object|null $test_instance Instance of test class.
+ *
+ * @return bool True when to skip tests that write data.
+ */
+function vipgoci_unittests_skip_github_write_tests(
+	object|null &$test_instance
+) :bool {
+	if ( true === vipgoci_unittests_get_skip_github_write_tests() ) {
 		if ( null !== $test_instance ) {
 			$test_instance->markTestSkipped(
 				'Skipping test, should not be run as configured to skip tests that write data via GitHub API and this test does so'

--- a/tests/integration/IncludesForTestsConfig.php
+++ b/tests/integration/IncludesForTestsConfig.php
@@ -137,3 +137,38 @@ function vipgoci_unittests_options_test(
 	return 0;
 }
 
+/**
+ * Returns true if to skip tests that write data via GitHub API.
+ *
+ * @param object $test_instance Instance of test class.
+ *
+ * @return bool
+ */
+function vipgoci_unittests_skip_github_write_tests(
+	&$test_instance
+) :bool {
+	$config_arr = array(
+		'github-skip-write-tests' => null,
+	);
+
+	vipgoci_unittests_get_config_values(
+		'git-secrets',
+		$config_arr,
+		true
+	);
+
+	if (
+		( isset( $config_arr['github-skip-write-tests'] ) ) &&
+		( '1' === $config_arr['github-skip-write-tests'] )
+	) {
+		if ( null !== $test_instance ) {
+			$test_instance->markTestSkipped(
+				'Skipping test, should not be run as configured to skip tests that write data via GitHub API and this test does'
+			);
+		}
+
+		return true;
+	}
+
+	return false;
+}

--- a/tests/integration/IncludesForTestsConfig.php
+++ b/tests/integration/IncludesForTestsConfig.php
@@ -163,7 +163,7 @@ function vipgoci_unittests_skip_github_write_tests(
 	) {
 		if ( null !== $test_instance ) {
 			$test_instance->markTestSkipped(
-				'Skipping test, should not be run as configured to skip tests that write data via GitHub API and this test does'
+				'Skipping test, should not be run as configured to skip tests that write data via GitHub API and this test does so'
 			);
 		}
 

--- a/tests/integration/IncludesForTestsConfig.php
+++ b/tests/integration/IncludesForTestsConfig.php
@@ -140,12 +140,12 @@ function vipgoci_unittests_options_test(
 /**
  * Returns true if to skip tests that write data via GitHub API.
  *
- * @param object $test_instance Instance of test class.
+ * @param object|null $test_instance Instance of test class.
  *
  * @return bool
  */
 function vipgoci_unittests_skip_github_write_tests(
-	&$test_instance
+	object|null &$test_instance
 ) :bool {
 	$config_arr = array(
 		'github-skip-write-tests' => null,

--- a/tests/integration/MainRunScanReviewsCommentsEnforceMaximumTest.php
+++ b/tests/integration/MainRunScanReviewsCommentsEnforceMaximumTest.php
@@ -160,6 +160,10 @@ final class MainRunScanReviewsCommentsEnforceMaximumTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		/*
 		 * Test with no maximum comments allowed.
 		 */
@@ -198,6 +202,10 @@ final class MainRunScanReviewsCommentsEnforceMaximumTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 

--- a/tests/integration/MainRunScanTotalCommentsMaxWarningPostTest.php
+++ b/tests/integration/MainRunScanTotalCommentsMaxWarningPostTest.php
@@ -48,6 +48,13 @@ final class MainRunScanTotalCommentsMaxWarningPostTest extends TestCase {
 	private array $options = array();
 
 	/**
+	 * Variable for information about owner of access token.
+	 *
+	 * @var $current_user_info
+	 */
+	private mixed $current_user_info = null;
+
+	/**
 	 * Set up all variables, etc.
 	 *
 	 * @return void

--- a/tests/integration/MainRunScanTotalCommentsMaxWarningPostTest.php
+++ b/tests/integration/MainRunScanTotalCommentsMaxWarningPostTest.php
@@ -212,6 +212,10 @@ final class MainRunScanTotalCommentsMaxWarningPostTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		$this->options['review-comments-total-max'] = 100;
 
 		$prs_comments_maxed = array(
@@ -270,6 +274,10 @@ final class MainRunScanTotalCommentsMaxWarningPostTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 

--- a/tests/integration/PhpcsScanValidateSniffsInOptionAndReportTest.php
+++ b/tests/integration/PhpcsScanValidateSniffsInOptionAndReportTest.php
@@ -180,6 +180,10 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		$this->options['commit'] =
 			$this->options['phpcs-validate-sniffs-and-report-include-commit'];
 
@@ -368,6 +372,10 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		$this->options['commit'] =
 			$this->options['phpcs-validate-sniffs-and-report-include-commit'];
 
@@ -507,6 +515,10 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 
@@ -695,6 +707,10 @@ final class PhpcsScanValidateSniffsInOptionAndReportTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This pull request updates code and other files needed so that a GH user will work with the CI tests, unit and integration.

TODO:
- [x] Update tests that "write" data to GitHub and disable if configured in that way.
  - [x] Update configuration so that these tests are disabled for the integration tests run via GitHub Actions.
- [x] Document new configuration options and usage on GitHub Actions.
- [x] Document GH user.
- [x] Add/update tests -- unit and/or integrated (if needed)
  - [N/A] Ensure only one function is tested per test file.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #333 ]
