### PR TITLE
Update WPScan generic comment messaging

### DIFF
--- a/defines.php
+++ b/defines.php
@@ -318,7 +318,7 @@ define( 'VIPGOCI_WPSCAN_UPDATEURI_WP_ORG_URLS', array( 'w.org', 'wordpress.org' 
 define( 'VIPGOCI_WPSCAN_VULNERABLE', 'vulnerable' );
 define( 'VIPGOCI_WPSCAN_OBSOLETE', 'obsolete' );
 
-define( 'VIPGOCI_WPSCAN_API_ERROR', 'Automated Addon Security Scanning' );
+define( 'VIPGOCI_WPSCAN_API_ERROR', 'Vulnerability and Update Scan' );
 
 define(
 	'VIPGOCI_WPSCAN_REPORT_START',


### PR DESCRIPTION
This pull request updates WPScan generic comment messaging indicating vulnerable/obsolete plugins/themes. Replaces `Automated Addon Security Scanning` with `Vulnerability and Update Scan`. 

TODO:
- [x] Update messaging, to `Vulnerability and Update Scan`.
- [x] Add/update tests -- unit and/or integrated (if needed)
  - [N/A] Ensure only one function is tested per test file.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #333 ]
