### PR TITLE
Update tests/integration/WpscanScanSaveForSubmissionTest.php: Do not run tests when skip GitHub write is true

### DIFF
--- a/tests/integration/WpscanScanSaveForSubmissionTest.php
+++ b/tests/integration/WpscanScanSaveForSubmissionTest.php
@@ -298,6 +298,10 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 			return;
 		}
 
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
+			return;
+		}
+
 		vipgoci_unittests_output_suppress();
 
 		$this->options['local-git-repo'] =
@@ -381,6 +385,10 @@ final class WpscanScanSaveForSubmissionTest extends TestCase {
 		);
 
 		if ( -1 === $options_test ) {
+			return;
+		}
+
+		if ( vipgoci_unittests_skip_github_write_tests( $this ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Update `tests/integration/WpscanScanSaveForSubmissionTest.php` so that the tests do not run when skip GitHub write (`github-skip-write-tests`) in `tests/config-secrets.ini` is true .

TODO:
- [x] Update `tests/integration/WpscanScanSaveForSubmissionTest.php` to skip tests when GitHub write is true.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #333 ]
