### PR TITLE
Change capitalization in WPScan results

### DIFF
--- a/tests/unit/WpscanReportCommentFormatResultTest.php
+++ b/tests/unit/WpscanReportCommentFormatResultTest.php
@@ -90,12 +90,12 @@ final class WpscanReportCommentFormatResultTest extends TestCase {
 		);
 
 		$this->assertStringNotContainsString(
-			'Theme',
+			'theme',
 			$report_str
 		);
 
 		$this->assertStringContainsString(
-			'Plugin Name',
+			'Plugin name',
 			$report_str
 		);
 
@@ -250,7 +250,7 @@ final class WpscanReportCommentFormatResultTest extends TestCase {
 		);
 
 		$this->assertStringContainsString(
-			'Theme Name',
+			'Theme name',
 			$report_str
 		);
 

--- a/wpscan-reports.php
+++ b/wpscan-reports.php
@@ -203,10 +203,10 @@ function vipgoci_wpscan_report_comment_format_result(
 
 	// Type of addon.
 	if ( VIPGOCI_ADDON_PLUGIN === $issue_type ) {
-		$res .= '**Plugin Name**: ' . vipgoci_output_markdown_escape( $issue['message'] ) . "\n" .
+		$res .= '**Plugin name**: ' . vipgoci_output_markdown_escape( $issue['message'] ) . "\n" .
 			'**Plugin URI**: ' . $addon_url_escaped . "\n";
 	} elseif ( VIPGOCI_ADDON_THEME === $issue_type ) {
-		$res .= '**Theme Name**: ' . vipgoci_output_markdown_escape( $issue['message'] ) . "\n" .
+		$res .= '**Theme name**: ' . vipgoci_output_markdown_escape( $issue['message'] ) . "\n" .
 			'**Theme URI**: ' . $addon_url_escaped . "\n";
 	}
 


### PR DESCRIPTION
Change capitalization for WPScan results, from `Plugin Name` to `Plugin name`, similar for themes.

TODO:
- [x] Update capitalization.
- [x] Update tests 
  - [x] Ensure only one function is tested per test file.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [NA] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #333 ]
