### PR TITLE
Update tests/integration/GitHubApiLabelsTest.php: Cast PR number to integer

### DIFF
--- a/tests/integration/GitHubApiLabelsTest.php
+++ b/tests/integration/GitHubApiLabelsTest.php
@@ -133,7 +133,7 @@ final class GitHubApiLabelsTest extends TestCase {
 			$this->options['repo-owner'],
 			$this->options['repo-name'],
 			$this->options['github-token'],
-			$this->options['labels-pr-to-modify'],
+			(int) $this->options['labels-pr-to-modify'],
 			$this::LABEL_NAME
 		);
 
@@ -182,7 +182,7 @@ final class GitHubApiLabelsTest extends TestCase {
 			$this->options['repo-owner'],
 			$this->options['repo-name'],
 			$this->options['github-token'],
-			$this->options['labels-pr-to-modify'],
+			(int) $this->options['labels-pr-to-modify'],
 			$this::LABEL_NAME
 		);
 


### PR DESCRIPTION
Update test `tests/integration/GitHubApiLabelsTest.php` so that pull request number is always an integer.

TODO:
- [x] Case pull request number to integer.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [ #333 ]
