### PR TITLE
Fix WPScan issue: Invalid UpdateURI plugin/theme headers lead to error

### DIFF
--- a/tests/integration/WpCoreApiDetermineSlugAndOtherForAddonsTest.php
+++ b/tests/integration/WpCoreApiDetermineSlugAndOtherForAddonsTest.php
@@ -245,7 +245,6 @@ final class WpCoreApiDetermineSlugAndOtherForAddonsTest extends TestCase {
 		);
 	}
 
-
 	/**
 	 * Test invalid usage with plugin data.
 	 *
@@ -282,6 +281,46 @@ final class WpCoreApiDetermineSlugAndOtherForAddonsTest extends TestCase {
 			$actual_results,
 		);
 	}
+
+	/**
+	 * Test invalid usage with plugin data.
+	 *
+	 * @covers ::vipgoci_wpcore_api_determine_slug_and_other_for_addons
+	 *
+	 * @return void
+	 */
+	public function testInvalidPluginUsage3(): void {
+		vipgoci_unittests_output_suppress();
+
+		$actual_results = vipgoci_wpcore_api_determine_slug_and_other_for_addons(
+			array(
+				self::KEY_PLUGIN_PREFIX . '-hello/hello.php'  => array(
+					'type'          => 'vipgoci-addon-plugin',
+					'addon_headers' => array(
+						'Name'        => 'Hello Dolly',
+						'PluginURI'   => 'http://wordpress.org/plugins/hello-dolly/',
+						'Version'     => '1.6',
+						'Description' => 'This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly</cite> in the upper right of your admin screen on every page.',
+						'Author'      => 'Matt Mullenweg',
+						'Title'       => 'Hello Dolly',
+						'AuthorName'  => 'Matt Mullenweg',
+						'AuthorURI '  => 'http://ma.tt/',
+						'UpdateURI'   => 'wordpress/plugins/hello-dolly', // Invalid URL.
+					),
+				),
+			),
+		);
+
+		vipgoci_unittests_output_unsuppress();
+
+		$this->assertSame(
+			array(
+				self::KEY_PLUGIN_PREFIX . '-hello/hello.php' => null,
+			),
+			$actual_results,
+		);
+	}
+
 
 	/**
 	 * Test common usage of the function with themes.

--- a/wp-core-misc.php
+++ b/wp-core-misc.php
@@ -540,6 +540,8 @@ function vipgoci_wpcore_api_determine_slug_and_other_for_addons(
 				(
 					( null !== $update_uri_host ) &&
 					( false !== $update_uri_host ) &&
+					( is_string( $update_uri_host ) ) &&
+					( strlen( $update_uri_host ) > 0 ) &&
 					( true !== vipgoci_string_found_in_substrings_array(
 						VIPGOCI_WPSCAN_UPDATEURI_WP_ORG_URLS,
 						$update_uri_host,

--- a/wp-core-misc.php
+++ b/wp-core-misc.php
@@ -538,6 +538,7 @@ function vipgoci_wpcore_api_determine_slug_and_other_for_addons(
 			if (
 				( 'false' === $data_item['addon_headers']['UpdateURI'] ) ||
 				(
+					( null !== $update_uri_host ) &&
 					( false !== $update_uri_host ) &&
 					( true !== vipgoci_string_found_in_substrings_array(
 						VIPGOCI_WPSCAN_UPDATEURI_WP_ORG_URLS,


### PR DESCRIPTION
This pull request fixes a bug with invalid `UpdateURI` plugin/theme headers which lead to unexpected errors. 

TODO:
- [x] Added patch for invalid UpdateURI headers
- [x] Add/update tests -- unit and/or integrated (if needed)
  -  [x] Added test for invalid usage of UpdateURI headers
- [x] Check status of automated tests
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Changelog entry (for VIP) [#359]
