### PR TITLE
Document type-of-change label usage and add to pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -17,6 +17,7 @@ TODO:
 - [ ] Add to, or update, `Scan run detail` report as applicable
 - [ ] Check status of automated tests
 - [ ] Ensure `PHPDoc` comments are up to date for functions added or altered
+- [ ] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
 - [ ] Changelog entry (for VIP)
 
 ***

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -33,6 +33,7 @@ TODO:
   - [ ] Ensure only one function is tested per test file.
 - [ ] Ensure `PHPDoc` comments are up to date for functions added or altered
 - [ ] Update repository documentation (README.md, RELEASING.md, TESTING.md, TOOLS-UPDATE.md)
+- [ ] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
 - [ ] Changelog entry (for VIP)
 - [ ] Public documentation changes
 - [ ] Check status of automated tests
@@ -45,7 +46,7 @@ TODO:
 - [ ] Define version number in CHANGELOG.md, add release date and update links
 - [ ] Add same version number in defines.php
 - [ ] Assign a milestone corresponding to the version number to this PR and PRs that will form the release
-- [ ] Assign label (changelog)
+- [ ] Assign label ([Changelog and version](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels))
 - [ ] Run unit-test suite
 - [ ] Run integration-test suite with secrets
 - [ ] Manual testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Each GitHub issue and pull request relating to this repository should have a pri
 Each GitHub issue and pull-request should have a type of change label associated with it. The definition of these are as follows:
 
 * [Bug](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Bug): Code change to fix a bug, or a bug report.
-* [Changelog and version](https://github.com/Automattic/vip-go-ci/labels/%5B%20Type%20%5D%20Changelog%20%26%20version): Pull request for updates to `CHANGELOG.md`.
+* [Changelog & version](https://github.com/Automattic/vip-go-ci/labels/%5B%20Type%20%5D%20Changelog%20%26%20version): Pull request for updates to `CHANGELOG.md`.
 * [Clean up](https://github.com/Automattic/vip-go-ci/labels/%5B%20Type%20%5D%20Clean%20up): Pull request for general code clean ups.
 * [Documentation](https://github.com/Automattic/vip-go-ci/labels/%5B%20Type%20%5D%20Documentation): Pull request to update documentation.
 * [Enhancement](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Enhancement): A general enhancement – new feature, better implementation, new tests and so forth.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,21 @@ Please note that some time may pass until we respond to your request, and this m
 
 ### Priorities
 
-Each GitHub issue relating to this repository should have a priority label to make prioritizing easier. The definition of each priority is as follows:
+Each GitHub issue and pull request relating to this repository should have a priority label to make prioritizing easier. The definition of each priority is as follows:
 
 * [Critical](https://github.com/Automattic/vip-go-ci/labels/%5BPri%5D%20Critical): A bug currently affecting normal operation or a security problem that needs to be addressed urgently.
 * [High](https://github.com/Automattic/vip-go-ci/labels/%5BPri%5D%20High): An issue that is: a) relevant to current goals of the project, b) a bug that needs to addressed soon to maintain stability, or c) a feature often requested. 
 * [Normal](https://github.com/Automattic/vip-go-ci/labels/%5BPri%5D%20Normal): Most issues belong here. These will include features less often requested, new lower priority features, documentation updates, etc.
 * [Low](https://github.com/Automattic/vip-go-ci/labels/%5BPri%5D%20Low): Features that are good to have belong here.
 
+### Type of change labels
+
+Each GitHub issue and pull-request should have a type of change label associated with it. The definition of these are as follows:
+
+* [Bug](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20DBug): Code change to fix a bug, or a bug report.
+* [Changelog and version](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20DChangelog%20and%20version): Pull request for updates to `CHANGELOG.md`.
+* [Clean up](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Clean%20up): Pull request for general code clean ups.
+* [Documentation](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Documentation): Pull request to update documentation.
+* [Enhancement](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Enhancement): A general enhancement – new feature, better implementation, new tests and so forth.
+* [Remove feature](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20DRemove%20feature): Pull request to remove feature code.
+* [Update dependency](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20DUpdate%20Dependency): Pull request to update one or more dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,5 +26,5 @@ Each GitHub issue and pull-request should have a type of change label associated
 * [Clean up](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Clean%20up): Pull request for general code clean ups.
 * [Documentation](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Documentation): Pull request to update documentation.
 * [Enhancement](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Enhancement): A general enhancement – new feature, better implementation, new tests and so forth.
-* [Remove feature](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20DRemove%20feature): Pull request to remove feature code.
-* [Update dependency](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20DUpdate%20Dependency): Pull request to update one or more dependencies.
+* [Remove feature](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Remove%20feature): Pull request to remove feature code.
+* [Update dependency](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Update%20dependency): Pull request to update one or more dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,10 @@ Each GitHub issue and pull request relating to this repository should have a pri
 
 Each GitHub issue and pull-request should have a type of change label associated with it. The definition of these are as follows:
 
-* [Bug](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20DBug): Code change to fix a bug, or a bug report.
-* [Changelog and version](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20DChangelog%20and%20version): Pull request for updates to `CHANGELOG.md`.
-* [Clean up](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Clean%20up): Pull request for general code clean ups.
-* [Documentation](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Documentation): Pull request to update documentation.
+* [Bug](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Bug): Code change to fix a bug, or a bug report.
+* [Changelog and version](https://github.com/Automattic/vip-go-ci/labels/%5B%20Type%20%5D%20Changelog%20%26%20version): Pull request for updates to `CHANGELOG.md`.
+* [Clean up](https://github.com/Automattic/vip-go-ci/labels/%5B%20Type%20%5D%20Clean%20up): Pull request for general code clean ups.
+* [Documentation](https://github.com/Automattic/vip-go-ci/labels/%5B%20Type%20%5D%20Documentation): Pull request to update documentation.
 * [Enhancement](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Enhancement): A general enhancement – new feature, better implementation, new tests and so forth.
-* [Remove feature](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Remove%20feature): Pull request to remove feature code.
-* [Update dependency](https://github.com/Automattic/vip-go-ci/labels/%5BType%5D%20Update%20dependency): Pull request to update one or more dependencies.
+* [Remove feature](https://github.com/Automattic/vip-go-ci/labels/%5B%20Type%20%5D%20Remove%20feature): Pull request to remove feature code.
+* [Update dependency](https://github.com/Automattic/vip-go-ci/labels/%5B%20Type%20%5D%20Update%20dependency): Pull request to update one or more dependencies.


### PR DESCRIPTION
This pull request documents the usage of labels in the `CONTRIBUTING.md` file and adds checkboxes for labelling in pull request templates (`.github/PULL_REQUEST_TEMPLATE`).

TODO:
- [x] Add labels to CONTRIBUTING.md.
- [x] Link to labels from TODO lists in pull request template.
- [x] Check status of automated tests
- [x] Changelog entry (for VIP) [ #359 ]
