### PR TITLE
Set shivammathur/setup-php to fixed version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           coverage: none
           php-version: "${{ matrix.php }}"
-          tools: phpunit:9.5
+          tools: phpunit:9
         env:
           fail-fast: 'true'
 
@@ -80,7 +80,7 @@ jobs:
         with:
           coverage: none
           php-version: "8.2"
-          tools: phpunit:9.5
+          tools: phpunit:9
         env:
           fail-fast: 'true'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           coverage: none
           php-version: "${{ matrix.php }}"
-          tools: phpunit:9
+          tools: phpunit:10
         env:
           fail-fast: 'true'
 
@@ -80,7 +80,7 @@ jobs:
         with:
           coverage: none
           php-version: "8.2"
-          tools: phpunit:9
+          tools: phpunit:10
         env:
           fail-fast: 'true'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           coverage: none
           php-version: "${{ matrix.php }}"
-          tools: phpunit:10
+          tools: phpunit:9.5
         env:
           fail-fast: 'true'
 
@@ -80,7 +80,7 @@ jobs:
         with:
           coverage: none
           php-version: "8.2"
-          tools: phpunit:10
+          tools: phpunit:9.5
         env:
           fail-fast: 'true'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.25.2
         with:
           coverage: none
           php-version: "${{ matrix.php }}"
@@ -58,25 +58,25 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP 7.4
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.25.2
         with:
           coverage: none
           php-version: "7.4"
 
       - name: Set up PHP 8.0
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.25.2
         with:
           coverage: none
           php-version: "8.0"
 
       - name: Set up PHP 8.1
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.25.2
         with:
           coverage: none
           php-version: "8.1"
 
       - name: Set up PHP 8.2
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.25.2
         with:
           coverage: none
           php-version: "8.2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.25.2
         with:
           coverage: none
           php-version: 8.2


### PR DESCRIPTION
Latest version of shivammathur/setup-php has some problems with PHPUnit setup (404 errors). Switch to a fixed version and use 2.25.2.

TODO:
- [X] Switch to version 2.25.2 of shivammathur/setup-php
- [N/A] Add/update tests -- unit and/or integrated (if needed)
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
- [x] Changelog entry (for VIP) [ #359 ]
