### PR TITLE
Rename class "ResultsOutputDump" in test to match file name

### DIFF
--- a/tests/integration/ResultsOutputDumpTest.php
+++ b/tests/integration/ResultsOutputDumpTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-final class ResultsOutputDump extends TestCase {
+final class ResultsOutputDumpTest extends TestCase {
 	/**
 	 * Temporary file to dump results to.
 	 *


### PR DESCRIPTION
Rename class `ResultsOutputDump` to `ResultsOutputDumpTest` in [test](https://github.com/Automattic/vip-go-ci/blob/0b02054574f4f3802d72af0e1982ffe270a5fcc1/tests/integration/ResultsOutputDumpTest.php#L20) to match file name.

TODO:
- [x] Rename class `ResultsOutputDump` to `ResultsOutputDumpTest` to match file name
- [N/A] Add/update tests -- unit and/or integrated (if needed)
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [ ] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
- [x] Changelog entry (for VIP) [ #359 ]
