### PR TITLE
Update tools-init.sh: New version of VIP-Coding-Standards

### DIFF
--- a/tools-init.sh
+++ b/tools-init.sh
@@ -22,9 +22,9 @@ export WP_CODING_STANDARDS_SHA1SUM="c8161d77fcf63bdeaa3e8e6aa36bc1936b469070"
 
 # https://github.com/automattic/vip-coding-standards
 export VIP_CODING_STANDARDS_REPO="automattic/vip-coding-standards"
-export VIP_CODING_STANDARDS_VER="2.3.3"
+export VIP_CODING_STANDARDS_VER="2.3.4"
 export VIP_CODING_STANDARDS_VER_FILE="vip-coding-standards-$VIP_CODING_STANDARDS_VER.txt"
-export VIP_CODING_STANDARDS_SHA1SUM="44c6519c628d450be5330b2706ae9dbb09dbd6be"
+export VIP_CODING_STANDARDS_SHA1SUM="cdde10d915e1134a3f79965da84a05a621de1298"
 
 # https://github.com/sirbrillig/phpcs-variable-analysis
 export PHPCS_VARIABLE_ANALYSIS_REPO="sirbrillig/phpcs-variable-analysis"


### PR DESCRIPTION
Update `tools-init.sh`to get dependency updated.

TODO:
- [x] Update VIP-Coding-Standards to version `2.3.4`
- [N/A] Add/update tests -- unit and/or integrated (if needed)
  - [N/A] Ensure only one function is tested per test file.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
- [x] Changelog entry (for VIP) [#366]
