### PR TITLE
PHP 8.2 compatibility for tests/integration/GitHubPrGenericSupportCommentTest.php

### DIFF
--- a/tests/integration/GitHubPrGenericSupportCommentTest.php
+++ b/tests/integration/GitHubPrGenericSupportCommentTest.php
@@ -45,6 +45,13 @@ final class GitHubPrGenericSupportCommentTest extends TestCase {
 	private array $options = array();
 
 	/**
+	 * Variable for current user information.
+	 *
+	 * @var $current_user_info
+	 */
+	private mixed $current_user_info = null;
+
+	/**
 	 * Setup function. Require file, set up variables, etc.
 	 *
 	 * @return void


### PR DESCRIPTION
Fixes test `tests/integration/GitHubPrGenericSupportCommentTest.php`so to be compatible with PHP 8.2.

TODO:
- [x] Updated test `tests/integration/GitHubPrGenericSupportCommentTest.php` to be compatible with PHP 8.2.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [X] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
- [x] Changelog entry (for VIP) [ #368 ]
