### PR TITLE
tools-init.sh: Updating lock file mechanism to be safer

### DIFF
--- a/tools-init.sh
+++ b/tools-init.sh
@@ -134,7 +134,7 @@ function lock_remove() {
 			echo "$0: Removed lock"
 			rm -f "$TMP_LOCK_FILE"
 		else
-			echo "$0. Someone else got the lock file. Not removing lock file."
+			echo "$0: Someone else got the lock file. Not removing lock file."
 		fi
 	fi
 }

--- a/tools-init.sh
+++ b/tools-init.sh
@@ -104,6 +104,7 @@ function gh_fetch_and_verify() {
 	return 1 )
 }
 
+# Put lock file in place.
 function lock_place() {
 	# Get lock, if that fails, just exit
 	if [ -f "$TMP_LOCK_FILE" ] ; then
@@ -112,12 +113,34 @@ function lock_place() {
 	fi
 
 	# Acquire lock
-	touch "$TMP_LOCK_FILE"
+	echo "$$" > "$TMP_LOCK_FILE"
+
+	# Try to detect if two instances run at the same time
+	# on the same system. Should not happen often.
+	sleep 1
+
+	if [ "$$" == `cat "$TMP_LOCK_FILE"` ] ; then
+		echo "$0: Acquired lock ($TMP_LOCK_FILE)"
+	else
+		echo "$0: Someone else got the lock before us. Bailing out"
+		exit 1
+	fi
 }
 
+# Remove lock file, but only if we acquired it.
 function lock_remove() {
-	rm -f "$TMP_LOCK_FILE"
+	if [ -f "$TMP_LOCK_FILE" ] ; then
+		if [ "$$" == `cat "$TMP_LOCK_FILE"` ] ; then
+			echo "$0: Removed lock"
+			rm -f "$TMP_LOCK_FILE"
+		else
+			echo "$0. Someone else got the lock file. Not removing lock file."
+		fi
+	fi
 }
+
+# When exiting, ensure we remove lock file.
+trap lock_remove EXIT
 
 lock_place
 


### PR DESCRIPTION
This patch introduces two types of safeguards to the `tools-init.sh`script:
* Ensure lock file is not removed unless it is created by the currently running instance.
* When there is a fatal error of some kind, the usage of `trap`will ensure lock file is removed nevertheless (except for certain errors).

This should minimize any risk of leaving around lock files when there is a failure running the script. It is not perfect, but better than what we have now.

TODO:
- [x] tools-init.sh: Updating lock file mechanism to be safer
- [N/A] Add/update tests -- unit and/or integrated (if needed)
  - [N/A] Ensure only one function is tested per test file.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
- [x] Changelog entry (for VIP) [ #374 ]
