### PR TITLE
Use GitHub API version header in latest-release.php

### DIFF
--- a/defines.php
+++ b/defines.php
@@ -35,6 +35,7 @@ if ( ! defined( 'VIPGOCI_GITHUB_BASE_URL' ) ) {
 	define( 'VIPGOCI_GITHUB_BASE_URL', 'https://api.github.com' );
 }
 
+// GitHub API version header. If updated, update latest-release.php too.
 define( 'VIPGOCI_GITHUB_API_VERSION', '2022-11-28' );
 
 /*

--- a/latest-release.php
+++ b/latest-release.php
@@ -10,8 +10,9 @@
 
 declare(strict_types=1);
 
-$github_url = 'https://api.github.com/repos/automattic/vip-go-ci/releases';
-$client_id  = 'automattic-vip-go-ci-release-checker';
+$github_url         = 'https://api.github.com/repos/automattic/vip-go-ci/releases';
+$client_id          = 'automattic-vip-go-ci-release-checker';
+$github_api_version = 'X-GitHub-Api-Version: 2022-11-28'; // If updated, update defines.php too.
 
 $ch = curl_init();
 
@@ -21,7 +22,7 @@ curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT, 20 );
 curl_setopt( $ch, CURLOPT_USERAGENT, $client_id );
 curl_setopt( $ch, CURLOPT_MAXREDIRS, 0 );
 curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, false );
-
+curl_setopt( $ch, CURLOPT_HTTPHEADER, array( $github_api_version ) );
 
 $resp_data_raw = curl_exec( $ch );
 


### PR DESCRIPTION
Use GitHub API version header in `latest-release.php`. Adds comments to remind that version number in `defines.php`needs to be updated when updated in `latest-release.php`.

TODO:
- [x] Use GitHub API version header in `latest-release.php`
- [x] Add comments to remind that version number in `defines.php`needs to be updated when updated in `latest-release.php`.
- [/NA] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
- [x] Changelog entry (for VIP) [ #374 ]
