### PR TITLE
Changelog for version 1.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [1.3.8](https://github.com/Automattic/vip-go-ci/releases/tag/1.3.8) - 2023-09-25
 
 ### Updated
+- [#375](https://github.com/Automattic/vip-go-ci/pull/375): Upgrading PHPCS standards: WordPress-Coding-Standards, VIP-Coding-Standards, PHPCompatibility, PHPCSUtils and adding PHPCSExtra
 - [#371](https://github.com/Automattic/vip-go-ci/pull/371): tools-init.sh: Updating lock file mechanism to be safer
 - [#372](https://github.com/Automattic/vip-go-ci/pull/372): Add initial E2E test for latest-release.php
 - [#373](https://github.com/Automattic/vip-go-ci/pull/373): Use GitHub API version header in latest-release.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.8](https://github.com/Automattic/vip-go-ci/releases/tag/1.3.8) - 2023-09-25
+
+### Updated
+- [#371](https://github.com/Automattic/vip-go-ci/pull/371): tools-init.sh: Updating lock file mechanism to be safer
+- [#372](https://github.com/Automattic/vip-go-ci/pull/372): Add initial E2E test for latest-release.php
+- [#373](https://github.com/Automattic/vip-go-ci/pull/373): Use GitHub API version header in latest-release.php
+
 ## [1.3.7](https://github.com/Automattic/vip-go-ci/releases/tag/1.3.7) - 2023-09-11
 
 ### Updated

--- a/defines.php
+++ b/defines.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 /*
  * Version number and default name to use.
  */
-define( 'VIPGOCI_VERSION', '1.3.7' );
+define( 'VIPGOCI_VERSION', '1.3.8' );
 define( 'VIPGOCI_DEFAULT_NAME_TO_USE', 'vip-go-ci' );
 
 /*


### PR DESCRIPTION
Adding changelog for version 1.3.8.

TODO:
- [x] Define version number in CHANGELOG.md, add release date and update links
- [x] Add same version number in defines.php
- [x] Assign a milestone corresponding to the version number to this PR and PRs that will form the release
- [x] Assign label ([Changelog and version](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels))
- [x] Run unit-test suite
- [x] Run integration-test suite with secrets
- [x] E2E-test suite run successful
- [x] Manual testing
  - [x] Pull request with PHP linting issues
  - [x] Pull request with PHPCS issues
  - [x] Pull request without PHPCS issues, not auto-approved
  - [x] Pull request without PHPCS issues, is auto-approved
  - [x] Pull request with SVG issues
  - [x] Pull request with large file to be skipped
  - [x] Pull request with plugins and themes to be scanned via WPScan API
