### PR TITLE
Attempt to fix a problem with E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
     steps:
       - name: Check out the source code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
         
       - name: Ask git to fetch latest branch and other branches
         run: git fetch origin latest && git pull


### PR DESCRIPTION
This pull request attempts to resolve a problem sometimes encountered when running E2E tests (probably when not on a pull request branch, see [example](https://github.com/Automattic/vip-go-ci/actions/runs/6314241075/job/17144700490)). With the added reference, there should hopefully always be a branch available when checking out.

TODO:
- [x] Added patch for E2E test checkout
- [N/A] Add/update tests -- unit/integrated/E2E (if needed)
  - [N/A] Ensure only one function/functionality is tested per test file.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
- [x] Changelog entry (for VIP) [ #377 ]
