### PR TITLE
tools-init.sh: Only update in 5% of cases and a small fix

### DIFF
--- a/tools-init.sh
+++ b/tools-init.sh
@@ -136,7 +136,7 @@ function lock_place() {
 # Remove lock file, but only if we acquired it.
 function lock_remove() {
 	if [ -f "$TMP_LOCK_FILE" ] ; then
-		if [ "$$" == `cat "$TMP_LOCK_FILE"` ] ; then
+		if [ "$$" == "`cat \"$TMP_LOCK_FILE\"`" ] ; then
 			echo "$0: Removed lock"
 			rm -f "$TMP_LOCK_FILE"
 		else

--- a/tools-init.sh
+++ b/tools-init.sh
@@ -164,10 +164,10 @@ fi
 if [ -d ~/vip-go-ci-tools ] ; then
 	#
 	# We have got the tools installed already,
-	# only check in 10% of cases if we should
+	# only check in 5% of cases if we should
 	# upgrade.
 	#
-	export TMP_RAND=`seq 1 10 | sort -R | head -n 1`
+	export TMP_RAND=`seq 1 20 | sort -R | head -n 1`
 
 	if [ "$TMP_RAND" -ne "1" ] ; then
 		echo "$0: Will not check for updates at this time, exiting"

--- a/tools-init.sh
+++ b/tools-init.sh
@@ -164,10 +164,10 @@ fi
 if [ -d ~/vip-go-ci-tools ] ; then
 	#
 	# We have got the tools installed already,
-	# only check in 33% of cases if we should
+	# only check in 10% of cases if we should
 	# upgrade.
 	#
-	export TMP_RAND=`seq 1 3 | sort -R | head -n 1`
+	export TMP_RAND=`seq 1 10 | sort -R | head -n 1`
 
 	if [ "$TMP_RAND" -ne "1" ] ; then
 		echo "$0: Will not check for updates at this time, exiting"

--- a/tools-init.sh
+++ b/tools-init.sh
@@ -125,7 +125,7 @@ function lock_place() {
 	# on the same system. Should not happen often.
 	sleep 1
 
-	if [ "$$" == `cat "$TMP_LOCK_FILE"` ] ; then
+	if [ "$$" == "`cat \"$TMP_LOCK_FILE\"`" ] ; then
 		echo "$0: Acquired lock ($TMP_LOCK_FILE)"
 	else
 		echo "$0: Someone else got the lock before us. Bailing out"


### PR DESCRIPTION
Changes `tools-init.sh`so to update only in 10% of cases. Also fixes a small issue with one if the ìf`statements.


TODO:
- [x] Added patch tools-init.sh
- [x] Fix `if`statement
- [N/A] Add/update tests -- unit/integrated/E2E (if needed)
  - [N/A] Ensure only one function/functionality is tested per test file.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [x] Test, test, test
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
- [x] Changelog entry (for VIP) [ #377 ]
