### PR TITLE
Offically support PHP 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you have a feature request, please read the [file on contributing](CONTRIBUTI
 
 ### System requirements
 
-* `vip-go-ci` requires PHP 8.0 or PHP 8.1. PHP 8.1 is recommended. PHP 8.2 is not yet supported.
+* `vip-go-ci` requires PHP 8.0, PHP 8.1 or PHP 8.2. PHP 8.2 is recommended.
   * Required PHP add-ons include: `curl` and `xml`. Also, PCNTL should be enabled.
   * The PHP-based utlities — PHPCS, SVG scanner and PHP Lint — can be run using different PHP versions than `vip-go-ci` itself. See individual sections below on this. 
     * These utilities have their own requirements.


### PR DESCRIPTION
All fixes for PHP 8.2 are now complete. Make PHP 8.2 officially supported.

TODO:
- [x] Update README.md to reflect support.
- [N/A] Add/update tests -- unit/integrated/E2E (if needed)
  - [N/A] Ensure only one function/functionality is tested per test file.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [N/A] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
- [x] Changelog entry (for VIP) [ #377 ]
