### PR TITLE
Update --output functionality

### DIFF
--- a/main.php
+++ b/main.php
@@ -123,7 +123,6 @@ function vipgoci_help_print() :void {
 		"\t" . '                                                 to be PHPCS scanned to be specified in file in root' . PHP_EOL .
 		"\t" . '                                                 of repository (.vipgoci_phpcs_skip_folders).' . PHP_EOL .
 		"\t" . '                                                 Folders should be separated by newlines.' . PHP_EOL .
-		"\t" . '--output=FILE                  Where to save PHPCS output.' . PHP_EOL .
 		PHP_EOL .
 		'SVG scanning configuration:' . PHP_EOL .
 		"\t" . '--svg-checks=BOOL              Enable or disable SVG checks, both auto-approval of SVG' . PHP_EOL .
@@ -214,6 +213,8 @@ function vipgoci_help_print() :void {
 		"\t" . '                               explain what the bot does. Can contain HTML or Markdown.' . PHP_EOL .
 		"\t" . '--scan-details-msg-include=BOOL If to include additional detail about the scan, versions of' . PHP_EOL .
 		"\t" . '                                software used, options altered and so forth. Enabled by default.' . PHP_EOL .
+		PHP_EOL .
+		"\t" . '--output=FILE                  Where to save results output.' . PHP_EOL .
 		PHP_EOL .
 		'Generic support comments configuration:' . PHP_EOL .
 		"\t" . '--post-generic-pr-support-comments=BOOL            Whether to post generic comment to pull requests' . PHP_EOL .

--- a/main.php
+++ b/main.php
@@ -3080,7 +3080,7 @@ function vipgoci_run_scan(
 				'repo-owner'     => $options['repo-owner'],
 				'repo-name'      => $options['repo-name'],
 				'commit'         => $options['commit'],
-				'prs_implicated' => array_keys( $prs_implicated ),
+				'prs_implicated' => $prs_implicated,
 			)
 		);
 	}

--- a/tests/integration/ResultsOutputDumpTest.php
+++ b/tests/integration/ResultsOutputDumpTest.php
@@ -30,7 +30,7 @@ final class ResultsOutputDumpTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	protected function setUp() :void {
+	protected function setUp(): void {
 		require_once __DIR__ . '/../../results.php';
 		require_once __DIR__ . '/../../log.php';
 
@@ -65,26 +65,26 @@ final class ResultsOutputDumpTest extends TestCase {
 			'commit'         => 'abc123',
 			'prs_implicated' => array(
 				1 => (object) array(
-					'title'       => 'testing #1',
-					'base' => (object) array(
+					'title' => 'testing #1',
+					'base'  => (object) array(
 						'ref' => 'main',
 					),
-					'head' => (object) array(
+					'head'  => (object) array(
 						'ref' => 'add/testing1',
 					),
-					'user' => (object) array(
+					'user'  => (object) array(
 						'login' => 'user1',
 					),
 				),
 				2 => (object) array(
-					'title'       => 'testing #2',
-					'base' => (object) array(
+					'title' => 'testing #2',
+					'base'  => (object) array(
 						'ref' => 'main',
 					),
-					'head' => (object) array(
+					'head'  => (object) array(
 						'ref' => 'add/testing2',
 					),
-					'user' => (object) array(
+					'user'  => (object) array(
 						'login' => 'user2',
 					),
 				),

--- a/tests/integration/ResultsOutputDumpTest.php
+++ b/tests/integration/ResultsOutputDumpTest.php
@@ -32,6 +32,7 @@ final class ResultsOutputDumpTest extends TestCase {
 	 */
 	protected function setUp() :void {
 		require_once __DIR__ . '/../../results.php';
+		require_once __DIR__ . '/../../log.php';
 
 		$this->temp_dump_file = tempnam(
 			sys_get_temp_dir(),
@@ -63,11 +64,32 @@ final class ResultsOutputDumpTest extends TestCase {
 			'repo-name'      => 'test-repo',
 			'commit'         => 'abc123',
 			'prs_implicated' => array(
-				1 => array(
-					'test1',
+				1 => (object) array(
+					'title'       => 'testing #1',
+					'base' => (object) array(
+						'ref' => 'main',
+					),
+					'head' => (object) array(
+						'ref' => 'add/testing1',
+					),
+					'user' => (object) array(
+						'login' => 'user1',
+					),
 				),
-				2 => array(
-					'test2',
+				2 => (object) array(
+					'title'       => 'testing #2',
+					'base' => (object) array(
+						'ref' => 'main',
+					),
+					'head' => (object) array(
+						'ref' => 'add/testing2',
+					),
+					'user' => (object) array(
+						'login' => 'user2',
+					),
+				),
+				3 => (object) array(
+					'invalid' => false,
 				),
 			),
 		);
@@ -87,7 +109,26 @@ final class ResultsOutputDumpTest extends TestCase {
 		);
 
 		$this->assertSame(
-			$data,
+			array(
+				'results'        => array( 1, 2, 3, 4 ),
+				'repo-owner'     => 'test-owner',
+				'repo-name'      => 'test-repo',
+				'commit'         => 'abc123',
+				'prs_implicated' => array(
+					1 => array(
+						'title'       => 'testing #1',
+						'base_branch' => 'main',
+						'head_branch' => 'add/testing1',
+						'creator'     => 'user1',
+					),
+					2 => array(
+						'title'       => 'testing #2',
+						'base_branch' => 'main',
+						'head_branch' => 'add/testing2',
+						'creator'     => 'user2',
+					),
+				),
+			),
 			$dumped_contents
 		);
 	}


### PR DESCRIPTION
Brings in updates to `--output` functionality to make it more useful.

TODO:
- [x] `--output` will now output more data on PRs.
- [x] Update `--help` message so that `--output` is grouped with results.
- [x] Add/update tests -- unit/integrated/E2E (if needed)
  - [x] Ensure only one function/functionality is tested per test file.
- [N/A] Add to, or update, `Scan run detail` report as applicable
- [x] Check status of automated tests
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
- [x] Changelog entry (for VIP) [ #382 ]
