### PR TITLE
Add changelog for version 1.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.10](https://github.com/Automattic/vip-go-ci/releases/tag/1.3.10) - 2023-11-02
+
+### Updated
+- [#380](https://github.com/Automattic/vip-go-ci/pull/380): Update --output functionality 
+- [#381](https://github.com/Automattic/vip-go-ci/pull/381): Update minimum requirements and TODO template
+
 ## [1.3.9](https://github.com/Automattic/vip-go-ci/releases/tag/1.3.9) - 2023-09-27
 
 ### Updated

--- a/defines.php
+++ b/defines.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 /*
  * Version number and default name to use.
  */
-define( 'VIPGOCI_VERSION', '1.3.9' );
+define( 'VIPGOCI_VERSION', '1.3.10' );
 define( 'VIPGOCI_DEFAULT_NAME_TO_USE', 'vip-go-ci' );
 
 /*


### PR DESCRIPTION
TODO:
- [x] Define version number in CHANGELOG.md, add release date and update links
- [x] Add same version number in defines.php
- [x] Assign a milestone corresponding to the version number to this PR and PRs that will form the release
- [x] Assign label ([Changelog and version](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels))
- [x] Unit-test suite run successful 
- [x] Integration-test suite successful (without secrets)
- [x] E2E-test suite run successful
- [x] Manual testing
  - [x] Pull request with PHP linting issues
  - [x] Pull request with plugins and themes to be scanned via WPScan API

Skipped as no relevant code was changed and other tests suffice:
- [ ] Manual testing
  - [ ] Pull request with PHPCS issues
  - [ ] Pull request without PHPCS issues, not auto-approved
  - [ ] Pull request without PHPCS issues, is auto-approved
  - [ ] Pull request with SVG issues
  - [ ] Pull request with large file to be skipped
- [ ] Run integration-test suite with secrets
