### PR TITLE
Temporarily rollback git requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.11](https://github.com/Automattic/vip-go-ci/releases/tag/1.3.11) - 2023-11-02
+- [#383](https://github.com/Automattic/vip-go-ci/pull/383): Temporarily roll back git requirement
+
 ## [1.3.10](https://github.com/Automattic/vip-go-ci/releases/tag/1.3.10) - 2023-11-02
 
 ### Updated

--- a/defines.php
+++ b/defines.php
@@ -16,7 +16,7 @@ define( 'VIPGOCI_DEFAULT_NAME_TO_USE', 'vip-go-ci' );
 /*
  * Define minimum version requirements.
  */
-define( 'VIPGOCI_GIT_VERSION_MINIMUM', '2.30' );
+define( 'VIPGOCI_GIT_VERSION_MINIMUM', '2.10' );
 define( 'VIPGOCI_PHP_VERSION_MINIMUM', '8.0.0' );
 
 /*

--- a/defines.php
+++ b/defines.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 /*
  * Version number and default name to use.
  */
-define( 'VIPGOCI_VERSION', '1.3.10' );
+define( 'VIPGOCI_VERSION', '1.3.11' );
 define( 'VIPGOCI_DEFAULT_NAME_TO_USE', 'vip-go-ci' );
 
 /*


### PR DESCRIPTION
Temporarily rolls back git requirement.

TODO:
- [x] Added patch for git requirement
- [x] Check status of automated tests
- [x] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
