### PR TITLE
fix: phpcs error parse issue by running phpcs in quiet mode

### DIFF
--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -125,7 +125,7 @@ function vipgoci_phpcs_do_scan(
 	 * Feed PHPCS the temporary file specified by our caller.
 	 */
 	$cmd = sprintf(
-		'%s -d memory_limit=500M -d max_execution_time=300 %s --severity=%s --report=%s',
+		'%s -d memory_limit=500M -d max_execution_time=300 %s --severity=%s --report=%s -q',
 		escapeshellcmd( $phpcs_php_path ),
 		escapeshellcmd( $phpcs_path ),
 		escapeshellarg( (string) $phpcs_severity ),
@@ -1576,4 +1576,3 @@ function vipgoci_phpcs_possibly_use_new_standard_file(
 		);
 	}
 }
-


### PR DESCRIPTION
<!-- ATTENTION: :wave: Just a quick reminder that this is a PUBLIC repository. Please do not include any internal links or sensitive data (like PII, private code, client names, site URLs, etc. If you're not sure if something is safe to share, please just ask! -->

<!-- Please have a look at the document on contributing before submitting a pull request: https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md -->

This PR fixes when the `phpcs` reports the errors but fails to parse the generated JSON errors, by adding `-q` argument to the `phpcs` command.

## Details
Currently, `vip-go-ci` is being used in the project's workflow. The workflow was succeeding even though `phpcs` was reporting errors and the workflow was also failing to add PR comments as well.

## Log
```log
[ 2024-02-20T17:59:30+00:00 GMT -- 0 ]  "Running PHPCS now"; {
    "cmd": "php -d memory_limit=500M -d max_execution_time=300 \/home\/samplebot\/vip-go-ci-tools\/phpcs\/bin\/phpcs --severity='1' --report='json' --standard='\/home\/samplebot\/workspace\/phpcs.xml' --exclude='WordPress.Files.FileName' '\/tmp\/vipgoci-phpcs-scan-aaqkfY.php'"
}
[ 2024-02-20T17:59:31+00:00 GMT -- 0 ]  "Error when running PHPCS"; {
    "filename": "plugins\/sample-plugin\/inc\/classes\/class-plugin.php",
    "file_issues_str": "\u001b[31mE\u001b[0m 1 \/ 1 (100%)\n\n\n{\"totals\":{\"errors\":1,\"warnings\":0,\"fixable\":0},\"files\":{\"\\\/tmp\\\/vipgoci-phpcs-scan-aaqkfY.php\":{\"errors\":1,\"warnings\":0,\"messages\":[{\"message\":\"Mismatched text domain. Expected 'example' or 'example-plugin' but got 'johndoe'.\",\"source\":\"WordPress.WP.I18n.TextDomainMismatch\",\"severity\":5,\"fixable\":false,\"type\":\"ERROR\",\"line\":45,\"column\":26}]}}}",
    "issues_stats": null
}
[ 2024-02-20T17:59:31+00:00 GMT -- 0 ]  "Fetching file-contents from local Git repository"; {
    "repo_owner": "janedoe",
    "repo_name": "example",
    "commit_id": "<commit-id-1>",
    "filename": "plugins\/sample-plugin\/inc\/classes\/class-plugin.php",
    "local_git_repo": "\/home\/samplebot\/workspace"
}
[ 2024-02-20T17:59:31+00:00 GMT -- 0 ]  "Failed parsing output from PHPCS"; {
    "repo_owner": "janedoe",
    "repo_name": "example",
    "commit_id": "<commit-id-2>",
    "file_name": "plugins\/sample-plugin\/inc\/classes\/class-plugin.php",
    "file_issues_arr_master": null,
    "file_issues_str": "\u001b[31mE\u001b[0m 1 \/ 1 (100%)\n\n\n{\"totals\":{\"errors\":1,\"warnings\":0,\"fixable\":0},\"files\":{\"\\\/tmp\\\/vipgoci-phpcs-scan-aaqkfY.php\":{\"errors\":1,\"warnings\":0,\"messages\":[{\"message\":\"Mismatched text domain. Expected 'example' or 'example-plugin' but got 'johndoe'.\",\"source\":\"WordPress.WP.I18n.TextDomainMismatch\",\"severity\":5,\"fixable\":false,\"type\":\"ERROR\",\"line\":45,\"column\":26}]}}}"
}
```

As you can see, the `phpcs` is reporting errors but the errors parsing is failing, which resulted in no errors being reported.

### Cause
The `phpcs.xml` configuration file has a configuration which show the progress of the `phpcs` scan.

```
<arg value="sp"/>
```

## Solution
By adding `-q` to the `phpcs` command, we can override the behaviors and suppress the progress report, and fix the error parsing issue.

TODO:
- [x] Added patch for [describe issue]
- [ ] Add/update tests -- unit/integrated/E2E (if needed)
  - [ ] Ensure only one function/functionality is tested per test file.
- [ ] New/updated software requirements? 
  - [ ] Update README.md
  - [ ] Update defines.php
- [ ] Add to, or update, `Scan run detail` report as applicable
- [ ] Check status of automated tests
- [x] Ensure `PHPDoc` comments are up to date for functions added or altered
- [x] Assign appropriate [priority](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#priorities) and [type of change labels](https://github.com/Automattic/vip-go-ci/blob/trunk/CONTRIBUTING.md#type-of-change-labels).
- [ ] Changelog entry (for VIP)


Closes: #384 
