### PR TITLE
Update repo links for manual testing steps

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -106,7 +106,7 @@ Manual testing is still required to ensure the final behavior of `vip-go-ci` is 
 
 ### Setting up
 
-Begin by forking [this repository](https://github.com/gudmdharalds-a8c/vip-go-ci-manual-testing). Use the forked repository to run the manual tests.
+Begin by forking [this repository](https://github.com/Automattic/vip-go-ci-manual-testing). Use the forked repository to run the manual tests.
 
 Navigate into the [tests/manual](tests/manual) directory on the command line. Then follow these steps:
 

--- a/tests/manual/vipgoci-run.sh.dist
+++ b/tests/manual/vipgoci-run.sh.dist
@@ -187,7 +187,7 @@ if [ ! -d "$GIT_REPO_PATH" ] ; then
 	git -C "$GIT_REPO_BASE_PATH" clone "https://github.com/$REPO_ORG/$REPO_NAME.git"
 
 	# Fetch external branch from another repository
-	git -C "$GIT_REPO_PATH" fetch "https://github.com/gudmdharalds/vip-go-ci-manual-testing.git" ext-branch-with-phpcs-issues-original:ext-branch-with-phpcs-issues
+	git -C "$GIT_REPO_PATH" fetch "https://github.com/Automattic/vip-go-ci-manual-testing.git" ext-branch-with-phpcs-issues-original:ext-branch-with-phpcs-issues
 else
 	git -C "$GIT_REPO_PATH" pull
 fi


### PR DESCRIPTION
Update repo links for manual testing steps to point to `Automattic` copy