### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.25.2
+        uses: shivammathur/setup-php@c5fc0d8281aba02c7fda07d3a70cc5371548067d # 2.25.2
         with:
           coverage: none
           php-version: "${{ matrix.php }}"
@@ -58,25 +58,25 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP 7.4
-        uses: shivammathur/setup-php@2.25.2
+        uses: shivammathur/setup-php@c5fc0d8281aba02c7fda07d3a70cc5371548067d # 2.25.2
         with:
           coverage: none
           php-version: "7.4"
 
       - name: Set up PHP 8.0
-        uses: shivammathur/setup-php@2.25.2
+        uses: shivammathur/setup-php@c5fc0d8281aba02c7fda07d3a70cc5371548067d # 2.25.2
         with:
           coverage: none
           php-version: "8.0"
 
       - name: Set up PHP 8.1
-        uses: shivammathur/setup-php@2.25.2
+        uses: shivammathur/setup-php@c5fc0d8281aba02c7fda07d3a70cc5371548067d # 2.25.2
         with:
           coverage: none
           php-version: "8.1"
 
       - name: Set up PHP 8.2
-        uses: shivammathur/setup-php@2.25.2
+        uses: shivammathur/setup-php@c5fc0d8281aba02c7fda07d3a70cc5371548067d # 2.25.2
         with:
           coverage: none
           php-version: "8.2"
@@ -138,7 +138,7 @@ jobs:
         run: git fetch origin latest && git pull
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.25.2
+        uses: shivammathur/setup-php@c5fc0d8281aba02c7fda07d3a70cc5371548067d # 2.25.2
         with:
           coverage: none
           php-version: "${{ matrix.php }}"
@@ -163,7 +163,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.25.2
+        uses: shivammathur/setup-php@c5fc0d8281aba02c7fda07d3a70cc5371548067d # 2.25.2
         with:
           coverage: none
           php-version: 8.2


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 1
- Repo-level unpinned usage count from the trunk recheck: 7
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Verification commands:

```bash
# shivammathur/setup-php # 2.25.2 -> c5fc0d8281aba02c7fda07d3a70cc5371548067d
gh api repos/shivammathur/setup-php/commits/2.25.2 --jq '.sha'
# expected: c5fc0d8281aba02c7fda07d3a70cc5371548067d
```
