### PR TITLE
Avoid GitHub lookups when there is no work to process

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -1191,6 +1191,11 @@ function vipgoci_github_pr_reviews_dismiss_with_non_active_comments(
 		)
 	);
 
+	// Comments cannot lead to a dismissal when there are no eligible reviews.
+	if ( empty( $pr_reviews ) ) {
+		return;
+	}
+
 	/*
 	 * Get all comments to the current pull request.
 	 *

--- a/reports.php
+++ b/reports.php
@@ -1137,35 +1137,37 @@ function vipgoci_report_submit_pr_review_from_results(
 			}
 		}
 
-		/*
-		 * Check if there are any previous comments about skipped files.
-		 */
-		$pr_reviews_commented = vipgoci_github_pr_reviews_get(
-			$repo_owner,
-			$repo_name,
-			$pr_number,
-			$github_token,
-			array(
-				'login' => 'myself',
-				'state' => array( 'COMMENTED', 'CHANGES_REQUESTED' ),
-			)
-		);
-
-		$pr_reviews_commented = array_column(
-			$pr_reviews_commented,
-			'body'
-		);
-
 		$validation_message = vipgoci_skip_file_get_validation_message_prefix(
 			VIPGOCI_VALIDATION_MAXIMUM_LINES,
 			$skip_large_files_limit
 		);
 
-		$results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ] = vipgoci_skip_file_check_previous_pr_comments(
-			$results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ],
-			$pr_reviews_commented,
-			$validation_message
-		);
+		/*
+		 * Fetch previous reviews only when there are skipped files to compare.
+		 */
+		if ( 0 < $results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ]['total'] ) {
+			$pr_reviews_commented = vipgoci_github_pr_reviews_get(
+				$repo_owner,
+				$repo_name,
+				$pr_number,
+				$github_token,
+				array(
+					'login' => 'myself',
+					'state' => array( 'COMMENTED', 'CHANGES_REQUESTED' ),
+				)
+			);
+
+			$pr_reviews_commented = array_column(
+				$pr_reviews_commented,
+				'body'
+			);
+
+			$results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ] = vipgoci_skip_file_check_previous_pr_comments(
+				$results[ VIPGOCI_SKIPPED_FILES ][ $pr_number ],
+				$pr_reviews_commented,
+				$validation_message
+			);
+		}
 
 		/*
 		 * If there are no issues to report to GitHub,

--- a/results.php
+++ b/results.php
@@ -52,6 +52,11 @@ function vipgoci_results_remove_existing_github_comments(
 			$comments_removed[ $pr_item->number ] = array();
 		}
 
+		// Without new issues, there are no comments to deduplicate.
+		if ( empty( $results['issues'][ $pr_item->number ] ) ) {
+			continue;
+		}
+
 		/*
 		 * Get all commits related to the current
 		 * pull request.
@@ -463,6 +468,11 @@ function vipgoci_results_filter_comments_to_max(
 		$results['issues'] as
 			$pr_number => $pr_issues_comments
 	) {
+		// Existing comments cannot affect the limit when nothing will be added.
+		if ( empty( $pr_issues_comments ) ) {
+			continue;
+		}
+
 		/*
 		 * Take into account previously submitted comments
 		 * by us for the current pull request.

--- a/tests/unit/GitHubRequestGuardsTest.php
+++ b/tests/unit/GitHubRequestGuardsTest.php
@@ -166,6 +166,66 @@ final class GitHubRequestGuardsTest extends TestCase {
 	}
 
 	/**
+	 * Pagination must select distinct fixtures and cache the combined result.
+	 *
+	 * @return void
+	 */
+	public function testPaginatedCommitsUseQuerySpecificFixtures(): void {
+		$first_page = array();
+		for ( $i = 1; $i <= 100; $i++ ) {
+			$first_page[] = array( 'sha' => 'commit-' . $i );
+		}
+
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/commits?page=1&per_page=100'] = $first_page;
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/commits?page=2&per_page=100'] = array( array( 'sha' => 'last-commit' ) );
+
+		$commits = vipgoci_github_prs_commits_list( 'owner', 'repo', 42, 'test-token' );
+
+		$this->assertCount( 101, $commits );
+		$this->assertSame( 'commit-1', $commits[0] );
+		$this->assertSame( 'commit-100', $commits[99] );
+		$this->assertSame( 'last-commit', $commits[100] );
+		$this->assertSame( $commits, vipgoci_github_prs_commits_list( 'owner', 'repo', 42, 'test-token' ) );
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/commits', 'GET /repos/owner/repo/pulls/42/commits' ) );
+		$this->assertSame(
+			array(
+				'https://api.github.com/repos/owner/repo/pulls/42/commits?page=1&per_page=100',
+				'https://api.github.com/repos/owner/repo/pulls/42/commits?page=2&per_page=100',
+			),
+			array_column( $GLOBALS['vipgoci_test_http_requests'], 'url' )
+		);
+	}
+
+	/**
+	 * An explicit transport failure must override a successful path-only fixture.
+	 *
+	 * @return void
+	 */
+	public function testQuerySpecificGetFailureOverridesFallbackFixture(): void {
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/commits?page=2&per_page=100'] = null;
+
+		$response = vipgoci_http_api_fetch_url(
+			'https://api.github.com/repos/owner/repo/pulls/42/commits?page=2&per_page=100',
+			'test-token',
+			false
+		);
+
+		$this->assertNull( $response );
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/commits' ) );
+	}
+
+	/**
+	 * The real deletion call must preserve its HTTP DELETE flag at the boundary.
+	 *
+	 * @return void
+	 */
+	public function testCommentDeletionUsesDeleteMethod(): void {
+		vipgoci_github_pr_reviews_comments_delete( $this->options, '10' );
+
+		$this->assertRequests( array( 'DELETE /repos/owner/repo/pulls/comments/10' ) );
+	}
+
+	/**
 	 * Empty PRs must not fetch history even when dismissed comments can be reposted.
 	 *
 	 * @return void
@@ -441,6 +501,31 @@ final class GitHubRequestGuardsTest extends TestCase {
 		$this->assertSame(
 			':no_entry_sign: **Error**: Escape output (*WordPress.Security.EscapeOutput.OutputNotEscaped*).',
 			$body['comments'][0]['body']
+		);
+	}
+
+	/**
+	 * The production failure branch must receive an integer, not JSON text "-1".
+	 *
+	 * @return void
+	 */
+	public function testFailedReviewSubmissionReportsFailure(): void {
+		$results                                = $this->emptyResults();
+		$results['issues'][42]                  = array( $this->issue() );
+		$results['stats']['phpcs'][42]['error'] = 1;
+		$GLOBALS['vipgoci_test_http_responses']['POST /repos/owner/repo/pulls/42/reviews'] = -1;
+
+		$this->submitReport( $results );
+
+		$this->assertRequests(
+			array(
+				'POST /repos/owner/repo/pulls/42/reviews',
+				'POST /repos/owner/repo/issues/42/comments',
+			)
+		);
+		$this->assertStringContainsString(
+			'commit-ID: abc',
+			$GLOBALS['vipgoci_test_http_requests'][1]['body']['body']
 		);
 	}
 

--- a/tests/unit/GitHubRequestGuardsTest.php
+++ b/tests/unit/GitHubRequestGuardsTest.php
@@ -1,0 +1,513 @@
+<?php
+/**
+ * Verify empty-work guards and preserve useful GitHub processing.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercise real result processing, API filtering and caching with fake HTTP.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
+#[CoversFunction( 'vipgoci_results_remove_existing_github_comments' )]
+#[CoversFunction( 'vipgoci_results_filter_comments_to_max' )]
+#[CoversFunction( 'vipgoci_github_pr_reviews_dismiss_with_non_active_comments' )]
+#[CoversFunction( 'vipgoci_report_submit_pr_review_from_results' )]
+final class GitHubRequestGuardsTest extends TestCase {
+	/**
+	 * Options for the fixture repository.
+	 *
+	 * @var array
+	 */
+	private array $options = array(
+		'repo-owner'                                  => 'owner',
+		'repo-name'                                   => 'repo',
+		'token'                                       => 'test-token',
+		'review-comments-total-max'                   => 1,
+		'dismissed-reviews-exclude-reviews-from-team' => array(),
+	);
+
+	/**
+	 * Load production functions and isolate their HTTP boundary.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		require_once __DIR__ . '/../../defines.php';
+		require_once __DIR__ . '/../../cache.php';
+		require_once __DIR__ . '/../../github-api.php';
+		require_once __DIR__ . '/../../github-misc.php';
+		require_once __DIR__ . '/../../results.php';
+		require_once __DIR__ . '/../../reports.php';
+		require_once __DIR__ . '/../../skip-file.php';
+		require_once __DIR__ . '/../../output-security.php';
+		require_once __DIR__ . '/../../other-web-services.php';
+		require_once __DIR__ . '/../../log.php';
+		require_once __DIR__ . '/helper/GitHubRequestGuards.php';
+
+		$GLOBALS['vipgoci_debug_level']         = -1;
+		$GLOBALS['vipgoci_test_http_requests']  = array();
+		$GLOBALS['vipgoci_test_http_responses'] = array(
+			'GET /repos/owner/repo/pulls/42/commits' => array( array( 'sha' => 'abc' ) ),
+		);
+
+		vipgoci_cache( VIPGOCI_CACHE_CLEAR );
+		vipgoci_cache(
+			array( 'vipgoci_github_authenticated_user_get', 'test-token' ),
+			(object) array( 'login' => 'bot' )
+		);
+	}
+
+	/**
+	 * Return initialized, empty scan results for a pull request.
+	 *
+	 * @return array Results fixture.
+	 */
+	private function emptyResults(): array {
+		return array(
+			'issues'        => array( 42 => array() ),
+			'stats'         => array(
+				'phpcs' => array(
+					42 => array(
+						'error'   => 0,
+						'warning' => 0,
+						'info'    => 0,
+					),
+				),
+			),
+			'skipped-files' => array(
+				42 => array(
+					'issues' => array(),
+					'total'  => 0,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Return one issue with a known matching comment.
+	 *
+	 * @return array Issue fixture.
+	 */
+	private function issue(): array {
+		return array(
+			'type'      => 'phpcs',
+			'file_name' => 'test.php',
+			'file_line' => 3,
+			'issue'     => array(
+				'message'  => 'Escape output.',
+				'source'   => 'WordPress.Security.EscapeOutput.OutputNotEscaped',
+				'level'    => 'ERROR',
+				'severity' => 5,
+			),
+		);
+	}
+
+	/**
+	 * Return a review fixture, defaulting to our changes-requested review.
+	 *
+	 * @param string $state Review state.
+	 * @param string $login Review author.
+	 * @param string $body  Review body.
+	 *
+	 * @return array Review fixture.
+	 */
+	private function review( string $state = 'CHANGES_REQUESTED', string $login = 'bot', string $body = '' ): array {
+		return array(
+			'id'    => 7,
+			'state' => $state,
+			'user'  => array( 'login' => $login ),
+			'body'  => $body,
+		);
+	}
+
+	/**
+	 * Return an inline comment fixture.
+	 *
+	 * @param int|null $position Active diff position, or null for an obsolete comment.
+	 *
+	 * @return array Comment fixture.
+	 */
+	private function comment( ?int $position = 3 ): array {
+		return array(
+			'id'                     => 10,
+			'pull_request_review_id' => 7,
+			'pull_request_url'       => 'https://api.github.com/repos/owner/repo/pulls/42',
+			'original_commit_id'     => 'abc',
+			'commit_id'              => 'abc',
+			'path'                   => 'test.php',
+			'position'               => $position,
+			'body'                   => 'Escape output.',
+			'user'                   => array( 'login' => 'bot' ),
+			'created_at'             => '2026-01-02T00:00:00Z',
+			'updated_at'             => '2026-01-02T00:00:00Z',
+		);
+	}
+
+	/**
+	 * Assert the complete sequence of external requests.
+	 *
+	 * @param array $expected Expected methods and paths.
+	 *
+	 * @return void
+	 */
+	private function assertRequests( array $expected ): void {
+		$this->assertSame( $expected, array_column( $GLOBALS['vipgoci_test_http_requests'], 'request' ) );
+	}
+
+	/**
+	 * Empty PRs must not fetch history even when dismissed comments can be reposted.
+	 *
+	 * @return void
+	 */
+	public function testEmptyDeduplicationMakesNoRequests(): void {
+		$results  = $this->emptyResults();
+		$expected = $results;
+
+		vipgoci_results_remove_existing_github_comments(
+			$this->options,
+			array(
+				(object) array(
+					'number'     => 42,
+					'created_at' => '2026-01-01T00:00:00Z',
+				),
+			),
+			$results,
+			true
+		);
+
+		$this->assertSame( $expected, $results );
+		$this->assertRequests( array() );
+	}
+
+	/**
+	 * An empty PR must not prevent deduplication for another PR.
+	 *
+	 * @return void
+	 */
+	public function testDeduplicationStillRemovesExistingIssuesInMixedRun(): void {
+		$results                                = $this->emptyResults();
+		$results['issues'][41]                  = array();
+		$results['issues'][42]                  = array( $this->issue() );
+		$results['stats']['phpcs'][42]['error'] = 1;
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/comments'] = array( $this->comment() );
+
+		vipgoci_results_remove_existing_github_comments(
+			$this->options,
+			array(
+				(object) array(
+					'number'     => 41,
+					'created_at' => '2025-01-01T00:00:00Z',
+				),
+				(object) array(
+					'number'     => 42,
+					'created_at' => '2026-01-01T00:00:00Z',
+				),
+			),
+			$results
+		);
+
+		$this->assertSame(
+			array(
+				42 => array(),
+				41 => array(),
+			),
+			$results['issues']
+		);
+		$this->assertSame( 0, $results['stats']['phpcs'][42]['error'] );
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/commits', 'GET /repos/owner/repo/pulls/comments' ) );
+	}
+
+	/**
+	 * Without new comments, the cap cannot remove or warn about anything.
+	 *
+	 * @return void
+	 */
+	public function testEmptyCommentLimitMakesNoRequests(): void {
+		$results  = $this->emptyResults();
+		$expected = $results;
+		$maxed    = array();
+
+		vipgoci_results_filter_comments_to_max( $this->options, $results, $maxed );
+
+		$this->assertSame( $expected, $results );
+		$this->assertSame( array(), $maxed );
+		$this->assertRequests( array() );
+	}
+
+	/**
+	 * Nonempty results must still honor the dismissed-review repost setting.
+	 *
+	 * @return void
+	 */
+	public function testDismissedReviewCommentsCanStillBeReposted(): void {
+		$results                                = $this->emptyResults();
+		$results['issues'][42]                  = array( $this->issue() );
+		$results['stats']['phpcs'][42]['error'] = 1;
+		$expected                               = $results;
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/comments']   = array( $this->comment() );
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/reviews'] = array( $this->review( 'DISMISSED' ) );
+
+		vipgoci_results_remove_existing_github_comments(
+			$this->options,
+			array(
+				(object) array(
+					'number'     => 42,
+					'created_at' => '2026-01-01T00:00:00Z',
+				),
+			),
+			$results,
+			true
+		);
+
+		$this->assertSame( $expected, $results );
+		$this->assertRequests(
+			array(
+				'GET /repos/owner/repo/pulls/42/commits',
+				'GET /repos/owner/repo/pulls/comments',
+				'GET /repos/owner/repo/pulls/42/reviews',
+			)
+		);
+	}
+
+	/**
+	 * Existing active comments must still count toward the cap.
+	 *
+	 * @return void
+	 */
+	public function testCommentLimitStillRemovesExcessIssuesInMixedRun(): void {
+		$results                                = $this->emptyResults();
+		$results['issues']                      = array(
+			41 => array(),
+			42 => array( $this->issue() ),
+		);
+		$results['stats']['phpcs'][42]['error'] = 1;
+		$maxed                                  = array();
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/comments'] = array( $this->comment() );
+
+		vipgoci_results_filter_comments_to_max( $this->options, $results, $maxed );
+
+		$this->assertSame(
+			array(
+				41 => array(),
+				42 => array(),
+			),
+			$results['issues']
+		);
+		$this->assertSame( 0, $results['stats']['phpcs'][42]['error'] );
+		$this->assertSame( array( 42 => true ), $maxed );
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/comments' ) );
+	}
+
+	/**
+	 * Reviews in other states or by other people do not need dismissal comments.
+	 *
+	 * @return void
+	 */
+	public function testNoEligibleReviewsSkipsCommentFetch(): void {
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/reviews'] = array(
+			$this->review( 'APPROVED' ),
+			$this->review( 'CHANGES_REQUESTED', 'someone-else' ),
+		);
+
+		vipgoci_github_pr_reviews_dismiss_with_non_active_comments( $this->options, 42 );
+
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/reviews' ) );
+	}
+
+	/**
+	 * A PR with no reviews has no comments relevant to dismissal.
+	 *
+	 * @return void
+	 */
+	public function testNoReviewsSkipsCommentFetch(): void {
+		vipgoci_github_pr_reviews_dismiss_with_non_active_comments( $this->options, 42 );
+
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/reviews' ) );
+	}
+
+	/**
+	 * An empty comment response must never cause an eligible review to be dismissed.
+	 *
+	 * @return void
+	 */
+	public function testNoCommentsDoesNotDismissEligibleReview(): void {
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/reviews'] = array( $this->review() );
+
+		vipgoci_github_pr_reviews_dismiss_with_non_active_comments( $this->options, 42 );
+
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/reviews', 'GET /repos/owner/repo/pulls/42/comments' ) );
+	}
+
+	/**
+	 * Eligible reviews still require a fresh comment snapshot before dismissal.
+	 *
+	 * @return void
+	 */
+	public function testEligibleReviewRefreshesCommentsAndDismissesObsoleteReview(): void {
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/reviews']  = array( $this->review() );
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/comments'] = array( $this->comment() );
+		vipgoci_github_pr_reviews_comments_get_by_pr( $this->options, 42, array( 'login' => 'myself' ) );
+		$GLOBALS['vipgoci_test_http_requests'] = array();
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/comments'] = array( $this->comment( null ) );
+
+		vipgoci_github_pr_reviews_dismiss_with_non_active_comments( $this->options, 42 );
+
+		$this->assertRequests(
+			array(
+				'GET /repos/owner/repo/pulls/42/reviews',
+				'GET /repos/owner/repo/pulls/42/comments',
+				'PUT /repos/owner/repo/pulls/42/reviews/7/dismissals',
+			)
+		);
+	}
+
+	/**
+	 * Active inline comments must keep a blocking review in place.
+	 *
+	 * @return void
+	 */
+	public function testActiveCommentPreventsDismissal(): void {
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/reviews']  = array( $this->review() );
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/comments'] = array( $this->comment( null ), $this->comment() );
+
+		vipgoci_github_pr_reviews_dismiss_with_non_active_comments( $this->options, 42 );
+
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/reviews', 'GET /repos/owner/repo/pulls/42/comments' ) );
+	}
+
+	/**
+	 * Submit fixture results through the production report builder.
+	 *
+	 * @param array $results Scan results.
+	 *
+	 * @return void
+	 */
+	private function submitReport( array $results ): void {
+		vipgoci_report_submit_pr_review_from_results(
+			'owner',
+			'repo',
+			'test-token',
+			'abc',
+			$results,
+			'',
+			'',
+			20,
+			false,
+			1000,
+			'Test bot'
+		);
+	}
+
+	/**
+	 * A clean scan has no skipped-file history to compare.
+	 *
+	 * @return void
+	 */
+	public function testCleanReportMakesNoRequests(): void {
+		$this->submitReport( $this->emptyResults() );
+		$this->assertRequests( array() );
+	}
+
+	/**
+	 * Reporting real issues does not require skipped-file history either.
+	 *
+	 * @return void
+	 */
+	public function testIssuesWithoutSkippedFilesStillSubmitReviewWithoutHistoryFetch(): void {
+		$results                                = $this->emptyResults();
+		$results['issues'][42]                  = array( $this->issue() );
+		$results['stats']['phpcs'][42]['error'] = 1;
+
+		$this->submitReport( $results );
+
+		$this->assertRequests( array( 'POST /repos/owner/repo/pulls/42/reviews' ) );
+		$body = $GLOBALS['vipgoci_test_http_requests'][0]['body'];
+		$this->assertSame( 'REQUEST_CHANGES', $body['event'] );
+		$this->assertSame( 'abc', $body['commit_id'] );
+		$this->assertCount( 1, $body['comments'] );
+		$this->assertSame( 'test.php', $body['comments'][0]['path'] );
+		$this->assertSame( 3, $body['comments'][0]['position'] );
+		$this->assertSame(
+			':no_entry_sign: **Error**: Escape output (*WordPress.Security.EscapeOutput.OutputNotEscaped*).',
+			$body['comments'][0]['body']
+		);
+	}
+
+	/**
+	 * A first review fetch after reporting must not dismiss the new active review.
+	 *
+	 * @return void
+	 */
+	public function testNewlySubmittedActiveReviewIsNotDismissed(): void {
+		$results                                = $this->emptyResults();
+		$results['issues'][42]                  = array( $this->issue() );
+		$results['stats']['phpcs'][42]['error'] = 1;
+
+		$this->submitReport( $results );
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/reviews']  = array( $this->review() );
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/comments'] = array( $this->comment() );
+
+		vipgoci_github_pr_reviews_dismiss_with_non_active_comments( $this->options, 42 );
+
+		$this->assertRequests(
+			array(
+				'POST /repos/owner/repo/pulls/42/reviews',
+				'GET /repos/owner/repo/pulls/42/reviews',
+				'GET /repos/owner/repo/pulls/42/comments',
+			)
+		);
+	}
+
+	/**
+	 * Skipped files must still be compared with prior reports to avoid duplicates.
+	 *
+	 * @return void
+	 */
+	public function testPreviouslyReportedSkippedFileIsNotReposted(): void {
+		$results                      = $this->emptyResults();
+		$results['skipped-files'][42] = array(
+			'issues' => array( 'max-lines' => array( 'large.php' ) ),
+			'total'  => 1,
+		);
+		$body                         = '**skipped-files**' . PHP_EOL . PHP_EOL .
+			'Maximum number of lines exceeded (1000):' . PHP_EOL .
+			' - large.php' . PHP_EOL . PHP_EOL .
+			'Note that the above file(s) were not analyzed due to their length.';
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/reviews'] = array( $this->review( 'COMMENTED', 'bot', $body ) );
+
+		$this->submitReport( $results );
+
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/reviews' ) );
+	}
+
+	/**
+	 * Newly skipped files must still generate a review without code issues.
+	 *
+	 * @return void
+	 */
+	public function testNewSkippedFileIsStillReported(): void {
+		$results                      = $this->emptyResults();
+		$results['skipped-files'][42] = array(
+			'issues' => array( 'max-lines' => array( 'large.php' ) ),
+			'total'  => 1,
+		);
+
+		$this->submitReport( $results );
+
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/reviews', 'POST /repos/owner/repo/pulls/42/reviews' ) );
+		$body = $GLOBALS['vipgoci_test_http_requests'][1]['body'];
+		$this->assertSame( 'COMMENT', $body['event'] );
+		$this->assertStringContainsString( 'large.php', $body['body'] );
+	}
+}

--- a/tests/unit/helper/GitHubRequestGuards.php
+++ b/tests/unit/helper/GitHubRequestGuards.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * HTTP boundary doubles for GitHubRequestGuardsTest.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter
+
+/**
+ * Record a request and return the configured response without using the network.
+ *
+ * @param string $method HTTP method.
+ * @param string $url    Request URL.
+ * @param array  $body   Request body.
+ *
+ * @return string JSON response.
+ */
+function vipgoci_unittests_github_request( string $method, string $url, array $body = array() ): string {
+	global $vipgoci_test_http_requests, $vipgoci_test_http_responses;
+
+	$request = $method . ' ' . parse_url( $url, PHP_URL_PATH );
+
+	$vipgoci_test_http_requests[] = array(
+		'request' => $request,
+		'body'    => $body,
+	);
+
+	return json_encode( $vipgoci_test_http_responses[ $request ] ?? array() );
+}
+
+/**
+ * Replace the external GET transport, keeping API parsing and caching real.
+ *
+ * @param string            $http_api_url           Request URL.
+ * @param null|string|array $http_api_token         Token, unused.
+ * @param bool              $fatal_error_on_failure Failure policy, unused.
+ * @param int               $curl_retries_max       Retry limit, unused.
+ *
+ * @return string JSON response.
+ */
+function vipgoci_http_api_fetch_url(
+	string $http_api_url,
+	null|string|array $http_api_token,
+	bool $fatal_error_on_failure = true,
+	int $curl_retries_max = 4
+): string {
+	return vipgoci_unittests_github_request( 'GET', $http_api_url );
+}
+
+/**
+ * Record review submissions without posting to GitHub.
+ *
+ * @param string            $http_api_url        Request URL.
+ * @param array             $http_api_postfields Request body.
+ * @param null|string|array $http_api_token      Token, unused.
+ *
+ * @return string JSON response.
+ */
+function vipgoci_http_api_post_url(
+	string $http_api_url,
+	array $http_api_postfields,
+	null|string|array $http_api_token
+): string {
+	return vipgoci_unittests_github_request( 'POST', $http_api_url, $http_api_postfields );
+}
+
+/**
+ * Record dismissals without changing GitHub reviews.
+ *
+ * @param string $http_api_url        Request URL.
+ * @param array  $http_api_postfields Request body.
+ * @param string $http_api_token      Token, unused.
+ * @param int    $retry_max           Retry limit, unused.
+ *
+ * @return int Success status.
+ */
+function vipgoci_http_api_put_url(
+	string $http_api_url,
+	array $http_api_postfields,
+	string $http_api_token,
+	int $retry_max = 4
+): int {
+	vipgoci_unittests_github_request( 'PUT', $http_api_url, $http_api_postfields );
+	return 0;
+}
+
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+// phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter

--- a/tests/unit/helper/GitHubRequestGuards.php
+++ b/tests/unit/helper/GitHubRequestGuards.php
@@ -12,24 +12,36 @@ declare(strict_types=1);
 
 /**
  * Record a request and return the configured response without using the network.
+ * Prefer method + path + query fixtures, falling back to method + path fixtures.
+ * Encode successful responses as JSON; preserve null and -1 failure sentinels.
  *
  * @param string $method HTTP method.
  * @param string $url    Request URL.
  * @param array  $body   Request body.
  *
- * @return string JSON response.
+ * @return string|int|null JSON response or a transport failure sentinel.
  */
-function vipgoci_unittests_github_request( string $method, string $url, array $body = array() ): string {
+function vipgoci_unittests_github_request( string $method, string $url, array $body = array() ): string|int|null {
 	global $vipgoci_test_http_requests, $vipgoci_test_http_responses;
 
 	$request = $method . ' ' . parse_url( $url, PHP_URL_PATH );
+	$query   = parse_url( $url, PHP_URL_QUERY );
+	$fixture = $request . ( null === $query ? '' : '?' . $query );
 
 	$vipgoci_test_http_requests[] = array(
 		'request' => $request,
+		'url'     => $url,
 		'body'    => $body,
 	);
 
-	return json_encode( $vipgoci_test_http_responses[ $request ] ?? array() );
+	if ( ! array_key_exists( $fixture, $vipgoci_test_http_responses ) ) {
+		$fixture = $request;
+	}
+
+	$response = array_key_exists( $fixture, $vipgoci_test_http_responses ) ?
+		$vipgoci_test_http_responses[ $fixture ] : array();
+
+	return ( null === $response || -1 === $response ) ? $response : json_encode( $response );
 }
 
 /**
@@ -40,32 +52,44 @@ function vipgoci_unittests_github_request( string $method, string $url, array $b
  * @param bool              $fatal_error_on_failure Failure policy, unused.
  * @param int               $curl_retries_max       Retry limit, unused.
  *
- * @return string JSON response.
+ * @return string|null JSON response or null on failure.
  */
 function vipgoci_http_api_fetch_url(
 	string $http_api_url,
 	null|string|array $http_api_token,
 	bool $fatal_error_on_failure = true,
 	int $curl_retries_max = 4
-): string {
+): string|null {
 	return vipgoci_unittests_github_request( 'GET', $http_api_url );
 }
 
 /**
- * Record review submissions without posting to GitHub.
+ * Record POST and DELETE requests without changing GitHub.
  *
  * @param string            $http_api_url        Request URL.
  * @param array             $http_api_postfields Request body.
  * @param null|string|array $http_api_token      Token, unused.
+ * @param bool              $http_delete         Whether to use DELETE instead of POST.
+ * @param bool              $json_encode         Encoding option, unused.
+ * @param int               $http_version        HTTP version, unused.
+ * @param string            $http_content_type   Content type, unused.
+ * @param int               $retry_max           Retry limit, unused.
+ * @param int               $timeout             Timeout, unused.
  *
- * @return string JSON response.
+ * @return string|int JSON response or -1 on failure.
  */
 function vipgoci_http_api_post_url(
 	string $http_api_url,
 	array $http_api_postfields,
-	null|string|array $http_api_token
-): string {
-	return vipgoci_unittests_github_request( 'POST', $http_api_url, $http_api_postfields );
+	null|string|array $http_api_token,
+	bool $http_delete = false,
+	bool $json_encode = true,
+	int $http_version = CURL_HTTP_VERSION_NONE,
+	string $http_content_type = VIPGOCI_HTTP_API_CONTENT_TYPE_APPLICATION_JSON,
+	int $retry_max = 4,
+	int $timeout = VIPGOCI_HTTP_API_LONG_TIMEOUT
+): string|int {
+	return vipgoci_unittests_github_request( $http_delete ? 'DELETE' : 'POST', $http_api_url, $http_api_postfields );
 }
 
 /**


### PR DESCRIPTION
## Summary

Avoid GitHub lookups when the calling operation has no work to do:

- Skip comment deduplication and comment-limit lookups for PRs with no new issues.
- Skip comment fetching for stale-review dismissal when there are no eligible reviews.
- Fetch previous reviews for skipped-file deduplication only when files were skipped.

Throttling, API endpoints, cache keys, and the deliberate fresh-comment lookup before dismissing eligible reviews are unchanged. Net request savings depend on the enabled features: another operation may still need the same review data later in the run.

## Testing

- Full unit suite on PHP 8.2: 241 tests, 524 assertions passed. Existing PHPUnit doc-comment metadata deprecation notices remain.
- 19 new regression tests pass on PHP 8.2 and PHP 8.5.
- Tests exercise production result processing, API filtering, and caching with a fake HTTP boundary. They cover empty and mixed-PR runs, comment limits, dismissed-comment reposting, skipped-file reporting, and review-dismissal safety, including a newly submitted active review.
- The test-only review follow-up adds query-specific pagination fixtures, full-URL recording, matching HTTP signatures, DELETE handling, and null/-1 failure fixtures. Four additional regressions cover pagination/cache results, explicit GET failure fixtures, comment deletion, and the failed-submission error-comment path.
- PHP 8.2+ compatibility checks pass for all five changed files.
- New test files pass the repository's configured WordPress coding-standard checks; the production changes add no diagnostics relative to the base revision.
- `git diff --check` passes.
- Live GitHub integration and E2E tests were not run locally.

## Scope

This is the first, bounded request-reduction pass. PR-scoped comment fetching, reuse of unfiltered comment snapshots, and narrower PR discovery remain separate follow-ups. No production timing improvement is claimed from mocked request-count tests.

## TODO

- [x] Add guards for empty GitHub-processing work.
- [x] Add regression tests for request counts and preserved results.
- [x] Keep PHPDoc comments current.
- [x] No new runtime requirements or configuration; no README, version, or scan-detail changes needed.
- [x] Assign normal priority and enhancement labels.
- [ ] Check remote automated test results.
- [ ] Include in the release changelog.
