### PR TITLE
Reduce GitHub requests for PR comments and team validation

### DIFF
--- a/github-api.php
+++ b/github-api.php
@@ -334,15 +334,17 @@ function vipgoci_github_fetch_commit_info(
  * repository and commit specified, will fetch only
  * comments made after certain timestamp and that are
  * associated with a pull request.
+ * Optionally limit the lookup to a single pull request.
  *
  * Will populate associative array of comments (the pointer
  * $pr_comments), with file-name and file-position as
  * keys.
  *
- * @param array  $options        Options array for the program.
- * @param string $commit_id      Will fetch comments associated with this commit-ID.
- * @param string $commit_made_at Will fetch comments made after this timestamp.
- * @param array  $prs_comments   Results array pointer; pull request comments.
+ * @param array    $options        Options array for the program.
+ * @param string   $commit_id      Will fetch comments associated with this commit-ID.
+ * @param string   $commit_made_at Will fetch comments made after this timestamp.
+ * @param array    $prs_comments   Results array pointer; pull request comments.
+ * @param int|null $pr_number      Pull request to query, or null for the whole repository.
  *
  * @return void
  */
@@ -350,7 +352,8 @@ function vipgoci_github_pr_reviews_comments_get(
 	array $options,
 	string $commit_id,
 	string $commit_made_at,
-	array &$prs_comments
+	array &$prs_comments,
+	?int $pr_number = null
 ) :void {
 	/*
 	 * Try to get comments from cache
@@ -361,6 +364,7 @@ function vipgoci_github_pr_reviews_comments_get(
 		$options['repo-name'],
 		$commit_made_at,
 		$options['token'],
+		$pr_number,
 	);
 
 	$cached_data = vipgoci_cache( $cached_id );
@@ -373,6 +377,7 @@ function vipgoci_github_pr_reviews_comments_get(
 			'repo_name'      => $options['repo-name'],
 			'commit_id'      => $commit_id,
 			'commit_made_at' => $commit_made_at,
+			'pr_number'      => $pr_number,
 		)
 	);
 
@@ -395,6 +400,7 @@ function vipgoci_github_pr_reviews_comments_get(
 				rawurlencode( $options['repo-owner'] ) . '/' .
 				rawurlencode( $options['repo-name'] ) . '/' .
 				'pulls/' .
+				( null === $pr_number ? '' : rawurlencode( (string) $pr_number ) . '/' ) .
 				'comments?' .
 				'sort=created&' .
 				'direction=asc&' .

--- a/github-api.php
+++ b/github-api.php
@@ -2279,6 +2279,64 @@ function vipgoci_github_team_members_many_get(
 
 
 /**
+ * Get one organization team by slug, without enumerating all teams.
+ *
+ * Cache both valid teams and missing/invalid responses for this run.
+ * Transport failures retain the HTTP helper's fatal-error policy.
+ *
+ * @param string $github_token GitHub token to use to make GitHub API requests.
+ * @param string $org_slug     Organization slug.
+ * @param string $team_slug    Team slug to look up.
+ *
+ * @return array Team information, or an empty array if no matching team is returned.
+ */
+function vipgoci_github_org_team_get(
+	string $github_token,
+	string $org_slug,
+	string $team_slug
+): array {
+	if ( '' === $team_slug ) {
+		return array();
+	}
+
+	$cached_id = array( __FUNCTION__, $github_token, $org_slug, $team_slug );
+	$team_info = vipgoci_cache( $cached_id );
+
+	vipgoci_log(
+		'Getting organization team from GitHub API' . vipgoci_cached_indication_str( $team_info ),
+		array(
+			'org_slug'  => $org_slug,
+			'team_slug' => $team_slug,
+		)
+	);
+
+	if ( false !== $team_info ) {
+		return $team_info;
+	}
+
+	$github_url = VIPGOCI_GITHUB_BASE_URL . '/orgs/' .
+		rawurlencode( $org_slug ) . '/teams/' . rawurlencode( $team_slug );
+
+	$team_info = json_decode(
+		vipgoci_http_api_fetch_url( $github_url, $github_token ),
+		true
+	);
+
+	// Error responses and renamed/nonmatching teams must not validate the option.
+	if (
+		( ! is_array( $team_info ) ) ||
+		( ! isset( $team_info['slug'] ) ) ||
+		( $team_slug !== $team_info['slug'] )
+	) {
+		$team_info = array();
+	}
+
+	vipgoci_cache( $cached_id, $team_info );
+
+	return $team_info;
+}
+
+/**
  * Get organization teams available to the calling
  * user from the GitHub API.
  *

--- a/options.php
+++ b/options.php
@@ -1009,26 +1009,18 @@ function vipgoci_option_teams_handle(
 		$options[ $option_name ]
 	);
 
-	$teams_info = vipgoci_github_org_teams_get(
-		$options['token'],
-		$options['repo-owner'],
-		null,
-		'slug'
-	);
-
 	foreach (
 		$options[ $option_name ] as $team_slug_key => $team_slug_value
 	) {
 		$team_slug_value_original = $team_slug_value;
 
-		/*
-		 * If the team slug provided by user is valid,
-		 * it should be in list of slugs returned by API.
-		 * Ensure this is the case.
-		 */
-		if ( ! empty( $teams_info[ $team_slug_value ] ) ) {
-			$team_slug_value = $teams_info[ $team_slug_value ][0]->slug;
-		} else {
+		$team_info = vipgoci_github_org_team_get(
+			$options['token'],
+			$options['repo-owner'],
+			$team_slug_value
+		);
+
+		if ( empty( $team_info ) ) {
 			/*
 			 * Something failed; slug may have been invalid so
 			 * remove it from the options array.
@@ -1063,7 +1055,7 @@ function vipgoci_option_teams_handle(
 		),
 	);
 
-	unset( $teams_info );
+	unset( $team_info );
 	unset( $team_slug_key );
 	unset( $team_slug_value );
 	unset( $team_slug_value_original );

--- a/results.php
+++ b/results.php
@@ -79,7 +79,8 @@ function vipgoci_results_remove_existing_github_comments(
 				$options,
 				$pr_item_commit_id,
 				$pr_item->created_at,
-				$prs_comments // Pointer used.
+				$prs_comments, // Pointer used.
+				$pr_item->number
 			);
 
 			unset( $pr_item_commit_id );

--- a/tests/config.ini.dist
+++ b/tests/config.ini.dist
@@ -165,5 +165,7 @@ commit-test-options-read-repo-file-with-file-3=1615b03f6997878feb1a25926631c4165
 commit-test-options-read-repo-file-with-file-5=9a13bbec0cc2c7557539076f0125cc396fab22c1
 
 [results]
+; These PRs share a commit, but the existing comments belong only to PR #56.
 pr-number-1=57
+pr-number-2=56
 commit-test-results-remove-existing-1=34ec039ca344336ad93abfbca2e9c313c11e28dd

--- a/tests/integration/ResultsRemoveExistingGithubCommentsTest.php
+++ b/tests/integration/ResultsRemoveExistingGithubCommentsTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Vipgoci\Tests\Integration;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Class that implements the testing.
@@ -37,6 +38,7 @@ final class ResultsRemoveExistingGithubCommentsTest extends TestCase {
 	 */
 	private array $options_results = array(
 		'pr-number-1'                           => null,
+		'pr-number-2'                           => null,
 		'commit-test-results-remove-existing-1' => null,
 	);
 
@@ -137,15 +139,44 @@ final class ResultsRemoveExistingGithubCommentsTest extends TestCase {
 	}
 
 	/**
-	 * Test if comments are removed from results when they have
-	 * already been posted on GitHub. Does not process dismissed
-	 * reviews.
+	 * Provide PRs sharing a commit, with comments present only on the second PR.
+	 *
+	 * @return array Test cases with expected remaining issues and error counts.
+	 */
+	public static function commentRemovalCases(): array {
+		return array(
+			'comments on another PR are preserved' => array(
+				'pr-number-1',
+				array(
+					self::COMMENTS_DATA['comment_removable'],
+					self::COMMENTS_DATA['comment_not_removable'],
+				),
+				2,
+			),
+			'comments on the same PR are removed'  => array(
+				'pr-number-2',
+				array( self::COMMENTS_DATA['comment_not_removable'] ),
+				1,
+			),
+		);
+	}
+
+	/**
+	 * Remove comments only when already posted on the PR being scanned.
+	 * Does not process dismissed reviews.
 	 *
 	 * @covers ::vipgoci_results_remove_existing_github_comments
 	 *
+	 * @param string $pr_option            Configuration key for the PR to scan.
+	 * @param array  $expected_issues      Issues that should remain after deduplication.
+	 * @param int    $expected_error_count Error count after deduplication.
+	 *
 	 * @return void
 	 */
-	public function testRemovingComments(): void {
+	#[DataProvider( 'commentRemovalCases' )]
+	public function testRemovingComments( string $pr_option, array $expected_issues, int $expected_error_count ): void {
+		$pr_number = (int) $this->options[ $pr_option ];
+
 		$this->options['commit'] =
 			$this->options['commit-test-results-remove-existing-1'];
 
@@ -168,8 +199,8 @@ final class ResultsRemoveExistingGithubCommentsTest extends TestCase {
 		vipgoci_unittests_output_unsuppress();
 
 		$prs_implicated = array(
-			$this->options['pr-number-1'] => (object) array(
-				'number'     => (int) $this->options['pr-number-1'],
+			$pr_number => (object) array(
+				'number'     => $pr_number,
 				'created_at' => '2020-01-01T00:00:01Z',
 			),
 		);
@@ -181,21 +212,19 @@ final class ResultsRemoveExistingGithubCommentsTest extends TestCase {
 
 		$results_expected = $results_actual;
 
-		$results_actual['issues'][ $this->options['pr-number-1'] ] = array(
+		$results_actual['issues'][ $pr_number ] = array(
 			self::COMMENTS_DATA['comment_removable'],
 			self::COMMENTS_DATA['comment_not_removable'],
 		);
 
-		$results_actual['stats'][ VIPGOCI_STATS_PHPCS ][ $this->options['pr-number-1'] ] = array(
+		$results_actual['stats'][ VIPGOCI_STATS_PHPCS ][ $pr_number ] = array(
 			'error' => 2,
 		);
 
-		$results_expected['issues'][ $this->options['pr-number-1'] ] = array(
-			self::COMMENTS_DATA['comment_not_removable'],
-		);
+		$results_expected['issues'][ $pr_number ] = $expected_issues;
 
-		$results_expected['stats'][ VIPGOCI_STATS_PHPCS ][ $this->options['pr-number-1'] ] = array(
-			'error' => 1,
+		$results_expected['stats'][ VIPGOCI_STATS_PHPCS ][ $pr_number ] = array(
+			'error' => $expected_error_count,
 		);
 
 		vipgoci_unittests_output_suppress();

--- a/tests/unit/GitHubRequestGuardsTest.php
+++ b/tests/unit/GitHubRequestGuardsTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 #[RunTestsInSeparateProcesses]
 #[PreserveGlobalState( false )]
 #[CoversFunction( 'vipgoci_results_remove_existing_github_comments' )]
+#[CoversFunction( 'vipgoci_github_pr_reviews_comments_get' )]
 #[CoversFunction( 'vipgoci_results_filter_comments_to_max' )]
 #[CoversFunction( 'vipgoci_github_pr_reviews_dismiss_with_non_active_comments' )]
 #[CoversFunction( 'vipgoci_report_submit_pr_review_from_results' )]
@@ -260,7 +261,7 @@ final class GitHubRequestGuardsTest extends TestCase {
 		$results['issues'][41]                  = array();
 		$results['issues'][42]                  = array( $this->issue() );
 		$results['stats']['phpcs'][42]['error'] = 1;
-		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/comments'] = array( $this->comment() );
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/comments'] = array( $this->comment() );
 
 		vipgoci_results_remove_existing_github_comments(
 			$this->options,
@@ -285,7 +286,129 @@ final class GitHubRequestGuardsTest extends TestCase {
 			$results['issues']
 		);
 		$this->assertSame( 0, $results['stats']['phpcs'][42]['error'] );
-		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/commits', 'GET /repos/owner/repo/pulls/comments' ) );
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/42/commits', 'GET /repos/owner/repo/pulls/42/comments' ) );
+	}
+
+	/**
+	 * Shared commits and creation timestamps must not leak comments between PRs.
+	 *
+	 * @return void
+	 */
+	public function testDeduplicationOnlyUsesCommentsOnTheCurrentPullRequest(): void {
+		$results                                = $this->emptyResults();
+		$results['issues'][42]                  = array( $this->issue() );
+		$results['issues'][99]                  = array( $this->issue() );
+		$results['stats']['phpcs'][42]['error'] = 1;
+		$results['stats']['phpcs'][99]          = $results['stats']['phpcs'][42];
+		$other_comment                          = $this->comment();
+		$other_comment['pull_request_url']      = 'https://api.github.com/repos/owner/repo/pulls/99';
+
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/comments']    = array( $other_comment );
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/comments'] = array();
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/99/comments'] = array( $other_comment );
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/99/commits']  = array( array( 'sha' => 'abc' ) );
+
+		vipgoci_results_remove_existing_github_comments(
+			$this->options,
+			array(
+				(object) array(
+					'number'     => 42,
+					'created_at' => '2026-01-01T00:00:00Z',
+				),
+				(object) array(
+					'number'     => 99,
+					'created_at' => '2026-01-01T00:00:00Z',
+				),
+			),
+			$results
+		);
+
+		$this->assertSame( array( $this->issue() ), $results['issues'][42] );
+		$this->assertSame( array(), $results['issues'][99] );
+		$this->assertSame( 1, $results['stats']['phpcs'][42]['error'] );
+		$this->assertSame( 0, $results['stats']['phpcs'][99]['error'] );
+		$this->assertRequests(
+			array(
+				'GET /repos/owner/repo/pulls/42/commits',
+				'GET /repos/owner/repo/pulls/42/comments',
+				'GET /repos/owner/repo/pulls/99/commits',
+				'GET /repos/owner/repo/pulls/99/comments',
+			)
+		);
+	}
+
+	/**
+	 * The legacy repository-wide lookup must remain separate from scoped caches.
+	 *
+	 * @return void
+	 */
+	public function testLegacyCommentLookupDoesNotPopulatePullRequestCache(): void {
+		$comment                     = $this->comment();
+		$comment['pull_request_url'] = 'https://api.github.com/repos/owner/repo/pulls/99';
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/comments']    = array( $comment );
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/comments'] = array();
+		$legacy_comments        = array();
+		$scoped_comments        = array();
+		$cached_legacy_comments = array();
+
+		vipgoci_github_pr_reviews_comments_get( $this->options, 'abc', '2026-01-01T00:00:00Z', $legacy_comments );
+		vipgoci_github_pr_reviews_comments_get( $this->options, 'abc', '2026-01-01T00:00:00Z', $scoped_comments, 42 );
+		vipgoci_github_pr_reviews_comments_get( $this->options, 'abc', '2026-01-01T00:00:00Z', $cached_legacy_comments );
+
+		$this->assertCount( 1, $legacy_comments['test.php:3'] );
+		$this->assertSame( 10, $legacy_comments['test.php:3'][0]->id );
+		$this->assertSame( array(), $scoped_comments );
+		$this->assertSame( $legacy_comments, $cached_legacy_comments );
+		$this->assertRequests( array( 'GET /repos/owner/repo/pulls/comments', 'GET /repos/owner/repo/pulls/42/comments' ) );
+	}
+
+	/**
+	 * Fetch every scoped page once, then filter cached comments for each commit.
+	 *
+	 * @return void
+	 */
+	public function testScopedCommentPagesAreReusedAcrossCommits(): void {
+		$first_page = array();
+		for ( $i = 1; $i <= 100; $i++ ) {
+			$comment       = $this->comment();
+			$comment['id'] = $i;
+			$first_page[]  = $comment;
+		}
+		$second_commit_comment                       = $this->comment( 8 );
+		$second_commit_comment['id']                 = 101;
+		$second_commit_comment['original_commit_id'] = 'def';
+		$unrelated_comment                           = $this->comment( 9 );
+		$unrelated_comment['original_commit_id']     = 'unrelated';
+
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/comments?sort=created&direction=asc&since=2026-01-01T00%3A00%3A00Z&page=1&per_page=100'] = $first_page;
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/comments?sort=created&direction=asc&since=2026-01-01T00%3A00%3A00Z&page=2&per_page=100'] = array(
+			$second_commit_comment,
+			$this->comment( null ),
+			$unrelated_comment,
+		);
+		$comments        = array();
+		$other_comments  = array();
+		$cached_comments = array();
+
+		vipgoci_github_pr_reviews_comments_get( $this->options, 'abc', '2026-01-01T00:00:00Z', $comments, 42 );
+		vipgoci_github_pr_reviews_comments_get( $this->options, 'def', '2026-01-01T00:00:00Z', $other_comments, 42 );
+		vipgoci_github_pr_reviews_comments_get( $this->options, 'abc', '2026-01-01T00:00:00Z', $cached_comments, 42 );
+
+		$this->assertSame( array( 'test.php:3' ), array_keys( $comments ) );
+		$this->assertCount( 100, $comments['test.php:3'] );
+		$this->assertSame( 1, $comments['test.php:3'][0]->id );
+		$this->assertSame( 100, $comments['test.php:3'][99]->id );
+		$this->assertSame( array( 'test.php:8' ), array_keys( $other_comments ) );
+		$this->assertCount( 1, $other_comments['test.php:8'] );
+		$this->assertSame( 101, $other_comments['test.php:8'][0]->id );
+		$this->assertSame( $comments, $cached_comments );
+		$this->assertSame(
+			array(
+				'https://api.github.com/repos/owner/repo/pulls/42/comments?sort=created&direction=asc&since=2026-01-01T00%3A00%3A00Z&page=1&per_page=100',
+				'https://api.github.com/repos/owner/repo/pulls/42/comments?sort=created&direction=asc&since=2026-01-01T00%3A00%3A00Z&page=2&per_page=100',
+			),
+			array_column( $GLOBALS['vipgoci_test_http_requests'], 'url' )
+		);
 	}
 
 	/**
@@ -315,8 +438,8 @@ final class GitHubRequestGuardsTest extends TestCase {
 		$results['issues'][42]                  = array( $this->issue() );
 		$results['stats']['phpcs'][42]['error'] = 1;
 		$expected                               = $results;
-		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/comments']   = array( $this->comment() );
-		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/reviews'] = array( $this->review( 'DISMISSED' ) );
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/comments'] = array( $this->comment() );
+		$GLOBALS['vipgoci_test_http_responses']['GET /repos/owner/repo/pulls/42/reviews']  = array( $this->review( 'DISMISSED' ) );
 
 		vipgoci_results_remove_existing_github_comments(
 			$this->options,
@@ -334,7 +457,7 @@ final class GitHubRequestGuardsTest extends TestCase {
 		$this->assertRequests(
 			array(
 				'GET /repos/owner/repo/pulls/42/commits',
-				'GET /repos/owner/repo/pulls/comments',
+				'GET /repos/owner/repo/pulls/42/comments',
 				'GET /repos/owner/repo/pulls/42/reviews',
 			)
 		);

--- a/tests/unit/GitHubRequestGuardsTest.php
+++ b/tests/unit/GitHubRequestGuardsTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Vipgoci\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
@@ -24,6 +25,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction( 'vipgoci_results_filter_comments_to_max' )]
 #[CoversFunction( 'vipgoci_github_pr_reviews_dismiss_with_non_active_comments' )]
 #[CoversFunction( 'vipgoci_report_submit_pr_review_from_results' )]
+#[CoversFunction( 'vipgoci_option_teams_handle' )]
+#[CoversFunction( 'vipgoci_github_org_team_get' )]
 final class GitHubRequestGuardsTest extends TestCase {
 	/**
 	 * Options for the fixture repository.
@@ -54,6 +57,8 @@ final class GitHubRequestGuardsTest extends TestCase {
 		require_once __DIR__ . '/../../output-security.php';
 		require_once __DIR__ . '/../../other-web-services.php';
 		require_once __DIR__ . '/../../log.php';
+		require_once __DIR__ . '/../../options.php';
+		require_once __DIR__ . '/../../misc.php';
 		require_once __DIR__ . '/helper/GitHubRequestGuards.php';
 
 		$GLOBALS['vipgoci_debug_level']         = -1;
@@ -164,6 +169,171 @@ final class GitHubRequestGuardsTest extends TestCase {
 	 */
 	private function assertRequests( array $expected ): void {
 		$this->assertSame( $expected, array_column( $GLOBALS['vipgoci_test_http_requests'], 'request' ) );
+	}
+
+	/**
+	 * Return a team response with the fields supplied by the list endpoint.
+	 *
+	 * @param string $slug Team slug.
+	 *
+	 * @return array Team fixture.
+	 */
+	private function team( string $slug = 'reviewers' ): array {
+		return array(
+			'id'                   => 1,
+			'node_id'              => 'MDQ6VGVhbTE=',
+			'url'                  => 'https://api.github.com/teams/1',
+			'html_url'             => 'https://github.com/orgs/owner/teams/' . $slug,
+			'name'                 => 'Reviewers',
+			'slug'                 => $slug,
+			'description'          => 'Review team.',
+			'privacy'              => 'closed',
+			'notification_setting' => 'notifications_enabled',
+			'permission'           => 'pull',
+			'members_url'          => 'https://api.github.com/teams/1/members{/member}',
+			'repositories_url'     => 'https://api.github.com/teams/1/repos',
+			'parent'               => null,
+		);
+	}
+
+	/**
+	 * Validation must request only unique configured slugs and reuse cached results.
+	 *
+	 * @return void
+	 */
+	public function testTeamValidationFetchesOnlyConfiguredTeams(): void {
+		$GLOBALS['vipgoci_test_http_responses']['GET /orgs/owner/teams']             = array( $this->team(), $this->team( 'maintainers' ) );
+		$GLOBALS['vipgoci_test_http_responses']['GET /orgs/owner/teams/reviewers']   = $this->team();
+		$GLOBALS['vipgoci_test_http_responses']['GET /orgs/owner/teams/maintainers'] = $this->team( 'maintainers' );
+		$GLOBALS['vipgoci_test_http_responses']['GET /orgs/owner/teams/missing']     = array(
+			'message' => 'Not Found',
+			'status'  => '404',
+		);
+		$this->options['teams'] = array( ' Reviewers ', 'missing', 'reviewers', 'maintainers', 'missing', '' );
+
+		vipgoci_option_teams_handle( $this->options, 'teams' );
+
+		$this->assertSame( array( 'reviewers', 'maintainers' ), $this->options['teams'] );
+		vipgoci_option_teams_handle( $this->options, 'teams' );
+		$this->assertSame( array( 'reviewers', 'maintainers' ), $this->options['teams'] );
+		$this->assertRequests(
+			array( 'GET /orgs/owner/teams/reviewers', 'GET /orgs/owner/teams/missing', 'GET /orgs/owner/teams/maintainers' )
+		);
+	}
+
+	/**
+	 * Empty, absent and non-array options must not enumerate teams.
+	 *
+	 * @return void
+	 */
+	public function testEmptyTeamOptionsMakeNoRequests(): void {
+		vipgoci_option_teams_handle( $this->options, 'teams' );
+		$this->assertSame( array(), $this->options['teams'] );
+		foreach ( array( array(), 'reviewers', array( ' ', '' ) ) as $input ) {
+			$this->options['teams'] = $input;
+			vipgoci_option_teams_handle( $this->options, 'teams' );
+			$this->assertSame( array(), $this->options['teams'] );
+		}
+		$this->assertRequests( array() );
+	}
+
+	/**
+	 * Cached team visibility must not leak across organizations or credentials.
+	 *
+	 * @return void
+	 */
+	public function testTeamValidationCacheSeparatesOrganizationsAndTokens(): void {
+		$GLOBALS['vipgoci_test_http_responses']['GET /orgs/owner/teams']           = array( $this->team() );
+		$GLOBALS['vipgoci_test_http_responses']['GET /orgs/owner/teams/reviewers'] = $this->team();
+		$this->options['teams'] = array( 'reviewers' );
+		vipgoci_option_teams_handle( $this->options, 'teams' );
+		$this->assertSame( array( 'reviewers' ), $this->options['teams'] );
+
+		$GLOBALS['vipgoci_test_http_responses']['GET /orgs/owner/teams/reviewers'] = array(
+			'message' => 'Not Found',
+			'status'  => '404',
+		);
+		$this->options['token'] = 'other-token';
+		vipgoci_option_teams_handle( $this->options, 'teams' );
+		$this->assertSame( array(), $this->options['teams'] );
+
+		$GLOBALS['vipgoci_test_http_responses']['GET /orgs/other/teams/reviewers'] = $this->team();
+		$this->options['repo-owner'] = 'other';
+		$this->options['teams']      = array( 'reviewers' );
+		vipgoci_option_teams_handle( $this->options, 'teams' );
+		$this->assertSame( array( 'reviewers' ), $this->options['teams'] );
+		$this->assertRequests(
+			array( 'GET /orgs/owner/teams/reviewers', 'GET /orgs/owner/teams/reviewers', 'GET /orgs/other/teams/reviewers' )
+		);
+	}
+
+	/**
+	 * Responses that must not validate a configured team.
+	 *
+	 * @return array Invalid response fixtures.
+	 */
+	public static function invalidTeamResponses(): array {
+		return array(
+			'not found'       => array(
+				array(
+					'message' => 'Not Found',
+					'status'  => '404',
+				),
+			),
+			'empty response'  => array( array() ),
+			'scalar response' => array( 'invalid' ),
+			'non-string slug' => array( array( 'slug' => 123 ) ),
+			'different slug'  => array( array( 'slug' => 'another-team' ) ),
+		);
+	}
+
+	/**
+	 * Missing or malformed teams must be removed and their results cached.
+	 *
+	 * @param mixed $response API response.
+	 *
+	 * @return void
+	 */
+	#[DataProvider( 'invalidTeamResponses' )]
+	public function testInvalidTeamResponsesAreRemovedAndCached( mixed $response ): void {
+		$GLOBALS['vipgoci_test_http_responses']['GET /orgs/owner/teams/reviewers'] = $response;
+		foreach ( array( 1, 2 ) as $attempt ) {
+			$this->options['teams'] = array( 'reviewers' );
+			vipgoci_option_teams_handle( $this->options, 'teams' );
+			$this->assertSame( array(), $this->options['teams'], 'Attempt ' . $attempt );
+		}
+		$this->assertRequests( array( 'GET /orgs/owner/teams/reviewers' ) );
+	}
+
+	/**
+	 * User-supplied names must remain inside their URL path segments.
+	 *
+	 * @return void
+	 */
+	public function testTeamLookupEncodesPathSegments(): void {
+		$this->options['repo-owner'] = 'owner/other';
+		$this->options['teams']      = array( 'reviewers?foo#bar' );
+		vipgoci_option_teams_handle( $this->options, 'teams' );
+		$this->assertSame( array(), $this->options['teams'] );
+		$this->assertRequests( array( 'GET /orgs/owner%2Fother/teams/reviewers%3Ffoo%23bar' ) );
+	}
+
+	/**
+	 * A per-team lookup must not populate the separate organization-list cache.
+	 *
+	 * @return void
+	 */
+	public function testTeamValidationDoesNotPoisonOrganizationListCache(): void {
+		$GLOBALS['vipgoci_test_http_responses']['GET /orgs/owner/teams/reviewers'] = $this->team();
+		$GLOBALS['vipgoci_test_http_responses']['GET /orgs/owner/teams']           = array( $this->team(), $this->team( 'maintainers' ) );
+		$this->options['teams'] = array( 'reviewers' );
+		vipgoci_option_teams_handle( $this->options, 'teams' );
+		$this->assertSame( array( 'reviewers' ), $this->options['teams'] );
+		$this->assertSame(
+			array( 'reviewers', 'maintainers' ),
+			array_keys( vipgoci_github_org_teams_get( 'test-token', 'owner', null, 'slug' ) )
+		);
+		$this->assertRequests( array( 'GET /orgs/owner/teams/reviewers', 'GET /orgs/owner/teams' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Follow-up to #403: reduce unnecessary GitHub lookups by scoping comment retrieval to the current PR and validating configured teams directly by slug.

### PR-scoped comment deduplication

The existing lookup fetches repository-wide review comments and filters by commit. If two PRs share a commit, a matching comment on one PR can incorrectly suppress an issue on the other. The broader lookup can also paginate through comments belonging to unrelated PRs.

- Pass the current PR number from result deduplication to the comment lookup.
- Use `/repos/{owner}/{repo}/pulls/{pull_number}/comments` when a PR is supplied, and include the PR in the cache key.
- Retain the optional argument's repository-wide default for existing callers, cached-page reuse across commits, commit/position filtering, dismissed-review behavior, and nonfatal transport policy.
- Cover shared commits and creation timestamps, legacy/scoped cache isolation, pagination, and cached filtering with regression tests.
- Update the live integration fixture: PR #57 retains its issues because its shared-commit comments belong to PR #56; PR #56 still suppresses its own matching comment.

### Direct team validation

Startup previously paginated through every visible organization team to validate the configured team slugs. Validation now uses `GET /orgs/{org}/teams/{team_slug}` for each distinct, nonempty configured slug instead.

- Add a per-team lookup with run-local caching isolated by token, organization, and team slug, including empty results for missing or invalid teams.
- Preserve trimming/lowercasing, invalid-team removal, order, and deduplication in the options handler.
- Reject malformed or nonmatching responses; empty team slugs make no requests.
- Leave the existing organization-wide team-list helper and its separate cache unchanged for other callers.
- Retain the GET helper's fatal transport-error policy, retries, and throttling.
- Add regression coverage for request counts, positive/negative caching, cache isolation, URL path encoding, empty options, and invalid responses.

### Performance and scope

The team change replaces organization-wide pagination with one lookup per distinct configured team, with cached reuse afterward. It is intended for the small configured team lists used during startup; requesting many teams individually is not guaranteed to be cheaper than listing them all.

PR-scoped comments can reduce fetched pages when unrelated PRs have many comments. Cache reuse across commits already existed, and PR isolation can increase requests where multiple PRs previously shared a repository-wide cache entry.

Neither change is a measured end-to-end build speedup. HTTP throttling, review-submission error/backoff handling, the separate raw-comment cache, and PHPCS behavior are outside this PR's scope.

## Validation

- PHP 8.2 full unit suite: 254 tests, 575 assertions passed; 1,389 existing PHPUnit annotation deprecations remain.
- PHP 8.2 and 8.5 focused request-boundary suite: 32 tests, 95 assertions passed on each.
- The 10 new team-validation regression cases failed against the old enumeration path before implementation and passed after the fix.
- Live PHP validation against GitHub retained a known valid team, removed a nonexistent team, and made two GETs across two validation runs, confirming positive and negative cache reuse.
- WordPress coding standards pass for the unit-test file with the repository's PHPUnit filename convention excluded. Production-file checks introduce no new diagnostics; the previously updated integration-test file retains its four existing formatting diagnostics.
- PHPCompatibility checks for PHP 8.2+ and `git diff --check` pass for the changed files.
- Independent review found no actionable regressions in the team-lookup change.
- The earlier comment-fixture correction passed both live integration cases on PHP 8.2 and 8.5. The full integration/E2E suites were not run locally.
- Remote CI for the expanded scope: pending. The [previous successful run](https://github.com/Automattic/vip-go-ci/actions/runs/33671981827) covers the earlier comment-only revision, not the new team lookup.

## TODO

- [x] Scope duplicate suppression to comments on the current PR.
- [x] Replace startup organization-wide team enumeration with cached direct lookups.
- [x] Add/update regression and request-count tests.
- [x] Update PHPDoc for the optional argument and team helper.
- [x] Assign priority and type labels.
- [x] Confirm no new software requirements, CLI options, or scan-run report fields are needed.
- [ ] Check remote automated test results for the expanded scope.
- [ ] Changelog entry (for VIP, during release preparation).
