### PR TITLE
Reduce Git diff memory usage during file discovery

### DIFF
--- a/git-repo.php
+++ b/git-repo.php
@@ -1062,8 +1062,203 @@ function vipgoci_gitrepo_submodule_get_url(
 }
 
 /**
+ * Execute Git with stdout on disk and stderr kept separate from diff records.
+ *
+ * @param string $cmd Escaped Git command.
+ * @return SplFileObject|null Open output file, or null on failure.
+ */
+function vipgoci_gitrepo_diff_output( string $cmd ): ?SplFileObject {
+	$output_file = vipgoci_save_temp_file( 'vipgoci-git-diff-' );
+	$stderr      = '';
+	$code        = -255;
+	try {
+		$result = vipgoci_runtime_measure_exec_with_retry(
+			// The outer command helper captures only stderr, never the patch.
+			'( ' . $cmd . ' >' . escapeshellarg( $output_file ) . ' )',
+			array( 0 ),
+			$stderr,
+			$code,
+			'git_cli',
+			true
+		);
+		if ( null === $result || str_starts_with( $result, 'fatal: ' ) ) {
+			vipgoci_log(
+				'Unable to run git due to error',
+				array(
+					'cmd'    => $cmd,
+					'output' => $stderr,
+				)
+			);
+			return null;
+		}
+		if ( '' !== $stderr ) {
+			vipgoci_log(
+				'Git returned diagnostic output',
+				array(
+					'cmd'    => $cmd,
+					'output' => $stderr,
+				)
+			);
+		}
+		return new SplFileObject( $output_file, 'r' );
+	} catch ( RuntimeException $exception ) {
+		vipgoci_log( 'Unable to read Git diff output', array( 'error' => $exception->getMessage() ) );
+		return null;
+	} finally {
+		// The open descriptor stays readable and closes when its owner releases it.
+		unlink( $output_file );
+	}
+}
+
+/**
+ * Fetch filenames, statuses and line counts without materializing patches.
+ *
+ * Raw records supply modes and rename identity; numstat supplies changed-line
+ * counts so renamed-and-edited files and permission-only changes retain the
+ * same filtering semantics as the patch reader. NUL delimiters preserve paths.
+ *
+ * @param string $local_git_repo Local repository path.
+ * @param string $commit_id_a    Baseline commit.
+ * @param string $commit_id_b    Comparison commit.
+ *
+ * @return array|null Metadata, or null if Git fails.
+ */
+function vipgoci_gitrepo_diffs_fetch_metadata(
+	string $local_git_repo,
+	string $commit_id_a,
+	string $commit_id_b
+): ?array {
+	$cached_id = array( __FUNCTION__, $local_git_repo, $commit_id_a, $commit_id_b );
+	$cached    = vipgoci_cache( $cached_id );
+	if ( false !== $cached ) {
+		return $cached;
+	}
+
+	// Numstat ignores textconv even when explicitly enabled. Preserve the old
+	// behavior using the local streaming reader for repositories with drivers.
+	$textconv_cache_id = array( __FUNCTION__, 'textconv', $local_git_repo );
+	$textconv          = vipgoci_cache( $textconv_cache_id );
+	if ( false === $textconv ) {
+		$output   = '';
+		$code     = -255;
+		$textconv = vipgoci_runtime_measure_exec_with_retry(
+			'git -C ' . escapeshellarg( $local_git_repo ) . ' config --get-regexp ' . escapeshellarg( '^diff\..*\.textconv$' ),
+			array( 0, 1 ), // No matching configuration is a successful empty result.
+			$output,
+			$code,
+			'git_cli',
+			true
+		);
+		if ( null !== $textconv ) {
+			vipgoci_cache( $textconv_cache_id, $textconv );
+		}
+	}
+	if ( '' !== $textconv ) {
+		return vipgoci_gitrepo_diffs_fetch_unfiltered( $local_git_repo, $commit_id_a, $commit_id_b );
+	}
+
+	$cmd    = sprintf(
+		'git --no-pager -C %s diff --no-color --raw --numstat -z %s',
+		escapeshellarg( $local_git_repo ),
+		escapeshellarg( $commit_id_a . '...' . $commit_id_b )
+	);
+	$stream = vipgoci_gitrepo_diff_output( $cmd );
+	if ( null === $stream ) {
+		return null;
+	}
+	$stream_stat = $stream->fstat();
+	if ( false === $stream_stat ) {
+		return null;
+	}
+	$data = 0 === $stream_stat['size'] ? '' : $stream->fread( $stream_stat['size'] );
+	if ( false === $data || strlen( $data ) !== $stream_stat['size'] ) {
+		return null;
+	}
+
+	$results      = array(
+		'files'      => array(),
+		'statistics' => array(
+			'additions' => 0,
+			'deletions' => 0,
+			'changes'   => 0,
+		),
+	);
+	$records      = explode( "\0", $data );
+	$record_count = count( $records ) - 1;
+	for ( $i = 0; $i < $record_count; $i++ ) {
+		$record = $records[ $i ];
+		if ( str_starts_with( $record, ':' ) ) {
+			$header = explode( ' ', substr( $record, 1 ) );
+			if ( 5 !== count( $header ) || ! isset( $records[ ++$i ] ) ) {
+				return null;
+			}
+			$filename          = $records[ $i ];
+			$status            = $header[4][0];
+			$previous_filename = null;
+			if ( 'R' === $status || 'C' === $status ) {
+				$previous_filename = $filename;
+				if ( ! isset( $records[ ++$i ] ) ) {
+					return null;
+				}
+				$filename = $records[ $i ];
+			}
+			$results['files'][ $filename ] = array(
+				'filename'  => $filename,
+				'status'    => match ( $status ) {
+					'A' => 'added',
+					'D' => 'removed',
+					'R', 'C' => $header[0] === $header[1] ? 'renamed' : 'modified',
+					default => 'modified',
+				},
+				'additions' => 0,
+				'deletions' => 0,
+				'changes'   => 0,
+			);
+			if ( null !== $previous_filename ) {
+				$results['files'][ $filename ]['previous_filename'] = $previous_filename;
+			}
+			continue;
+		}
+
+		$stat = explode( "\t", $record, 3 );
+		if ( 3 !== count( $stat ) ) {
+			return null;
+		}
+		$filename = $stat[2];
+		if ( '' === $filename ) {
+			// A rename has separate old and new NUL-delimited paths.
+			$i += 2;
+			if ( ! isset( $records[ $i ] ) ) {
+				return null;
+			}
+			$filename = $records[ $i ];
+		}
+		if ( ! isset( $results['files'][ $filename ] ) ) {
+			return null;
+		}
+		$file              = &$results['files'][ $filename ];
+		$file['additions'] = (int) $stat[0];
+		$file['deletions'] = (int) $stat[1];
+		$file['changes']   = $file['additions'] + $file['deletions'];
+		if ( 'renamed' === $file['status'] && 0 < $file['changes'] ) {
+			$file['status'] = 'modified';
+		} elseif ( 0 === $file['changes'] && in_array( $file['status'], array( 'added', 'removed' ), true ) ) {
+			// Match the existing patch reader for empty and binary-only changes.
+			$file['status'] = 'modified';
+		}
+		foreach ( array( 'additions', 'deletions', 'changes' ) as $stat_name ) {
+			$results['statistics'][ $stat_name ] += $file[ $stat_name ];
+		}
+		unset( $file );
+	}
+
+	vipgoci_cache( $cached_id, $results );
+	return $results;
+}
+
+/**
  * Fetch diff from git repository, unprocessed.
- * Results are not cached.
+ * Results are cached.
  *
  * @param string $local_git_repo  Path to local git repository.
  * @param string $commit_id_a     Baseline commit.
@@ -1145,49 +1340,9 @@ function vipgoci_gitrepo_diffs_fetch_unfiltered(
 		)
 	);
 
-	/*
-	 * Actually execute.
-	 */
-	$git_diff_results_output = '';
-	$git_diff_results_code   = -255;
-
-	$git_diff_results = vipgoci_runtime_measure_exec_with_retry(
-		$git_diff_cmd,
-		array( 0 ),
-		$git_diff_results_output,
-		$git_diff_results_code,
-		'git_cli',
-		true
-	);
-
-	if ( null === $git_diff_results ) {
-		vipgoci_log(
-			'Unable to run git due to error',
-			array(
-				'cmd'    => $git_diff_cmd,
-				'output' => $git_diff_results,
-			),
-		);
-
-		return null;
-	}
-
-	/*
-	 * Check if there are any problems,
-	 * return with error if there are any.
-	 */
-	if ( strpos(
-		$git_diff_results,
-		'fatal: '
-	) === 0 ) {
-		vipgoci_log(
-			'Unexpected problem while running git',
-			array(
-				'cmd'    => $git_diff_cmd,
-				'output' => $git_diff_results,
-			),
-		);
-
+	// Read one line at a time instead of retaining raw output and a line array.
+	$git_diff_lines = vipgoci_gitrepo_diff_output( $git_diff_cmd );
+	if ( null === $git_diff_lines ) {
 		return null;
 	}
 
@@ -1201,15 +1356,6 @@ function vipgoci_gitrepo_diffs_fetch_unfiltered(
 			VIPGOCI_GIT_DIFF_CALC_CHANGES['-'] => 0,
 			'changes'                          => 0,
 		),
-	);
-
-	/*
-	 * Split results into array
-	 */
-
-	$git_diff_results = explode(
-		PHP_EOL,
-		$git_diff_results
 	);
 
 	/*
@@ -1252,14 +1398,21 @@ function vipgoci_gitrepo_diffs_fetch_unfiltered(
 	 *  ...
 	 */
 
-	foreach ( $git_diff_results as $git_result_item ) {
+	foreach ( $git_diff_lines as $git_result_item ) {
+		if ( false === $git_result_item ) {
+			continue;
+		}
+		$git_result_item = rtrim( $git_result_item, "\n" );
+
 		/*
 		 * Split each line into array at spaces,
 		 * making it easy to process each line of results.
 		 */
 		$git_result_item_arr = explode(
 			' ',
-			$git_result_item
+			$git_result_item,
+			// Only header lines need tokenization; patch lines need the first byte.
+			str_starts_with( $git_result_item, 'diff --git ' ) || 'info' === $cur_mode ? PHP_INT_MAX : 1
 		);
 
 		/*
@@ -1660,6 +1813,7 @@ function vipgoci_gitrepo_diffs_clean_extra_whitespace(
  * @param bool       $removed_files_also      If to include removed files.
  * @param bool       $permission_changes_also If to include files whose permissions were changed.
  * @param null|array $filter                  Filter to apply to results.
+ * @param bool       $include_patches         Whether to load patches, rather than metadata only.
  *
  * @return array Array with results. For example:
  *  array(
@@ -1692,7 +1846,8 @@ function vipgoci_git_diffs_fetch(
 	bool $renamed_files_also = false,
 	bool $removed_files_also = true,
 	bool $permission_changes_also = false,
-	null|array $filter = null
+	null|array $filter = null,
+	bool $include_patches = true
 ): array {
 	/*
 	 * Check if we have a preference whether to
@@ -1728,7 +1883,8 @@ function vipgoci_git_diffs_fetch(
 	 * to fetch diff.
 	 */
 	if ( false === $github_api_preferred ) {
-		$diff_results = vipgoci_gitrepo_diffs_fetch_unfiltered(
+		$fetch_function = $include_patches ? 'vipgoci_gitrepo_diffs_fetch_unfiltered' : 'vipgoci_gitrepo_diffs_fetch_metadata';
+		$diff_results   = $fetch_function(
 			$local_git_repo,
 			$commit_id_a,
 			$commit_id_b
@@ -1854,7 +2010,7 @@ function vipgoci_git_diffs_fetch(
 		 * In case of no patch specified by
 		 * GitHub, we add it.
 		 */
-		if ( ! isset( $file_item['patch'] ) ) {
+		if ( false === $include_patches || ! isset( $file_item['patch'] ) ) {
 			$file_item['patch'] = null;
 		}
 
@@ -1882,4 +2038,3 @@ function vipgoci_git_diffs_fetch(
 
 	return $results;
 }
-

--- a/git-repo.php
+++ b/git-repo.php
@@ -1149,9 +1149,11 @@ function vipgoci_gitrepo_diffs_fetch_metadata(
 			'git_cli',
 			true
 		);
-		if ( null !== $textconv ) {
-			vipgoci_cache( $textconv_cache_id, $textconv );
+		if ( null === $textconv ) {
+			// Configuration is unknown: report failure instead of building patches.
+			return null;
 		}
+		vipgoci_cache( $textconv_cache_id, $textconv );
 	}
 	if ( '' !== $textconv ) {
 		return vipgoci_gitrepo_diffs_fetch_unfiltered( $local_git_repo, $commit_id_a, $commit_id_b );

--- a/github-misc.php
+++ b/github-misc.php
@@ -404,6 +404,7 @@ function vipgoci_github_files_affected_by_commit(
 			$removed_files_also,
 			$permission_changes_also,
 			$filter,
+			false // File discovery does not need patches.
 		);
 
 		foreach (
@@ -448,4 +449,3 @@ function vipgoci_github_files_affected_by_commit(
 
 	return $pr_item_files_changed;
 }
-

--- a/tests/unit/GitDiffMemoryTest.php
+++ b/tests/unit/GitDiffMemoryTest.php
@@ -303,6 +303,42 @@ final class GitDiffMemoryTest extends TestCase {
 		$this->assertSame( VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO, $filtered['data_source'] );
 	}
 
+	/** A failed textconv probe must not build patches or poison a later retry. */
+	public function testMetadataTextconvProbeFailureDoesNotFetchPatches(): void {
+		$base = $this->commit();
+		$this->write( 'file.php', "new\n" );
+		$head = $this->commit();
+
+		$real_git = trim( (string) shell_exec( 'command -v git' ) );
+		$this->assertNotSame( '', $real_git );
+		$shim = <<<'SH'
+#!/bin/sh
+if [ "$3" = config ] && [ "$4" = --get-regexp ]; then
+	exit 128
+fi
+SH;
+		$this->write( 'test-bin/git', $shim . "\nexec " . escapeshellarg( $real_git ) . ' "$@"' . "\n" );
+		chmod( $this->repo . '/test-bin/git', 0755 );
+		$original_path = getenv( 'PATH' );
+		try {
+			// Fail only the config probe; an accidental patch fetch still runs Git.
+			putenv( 'PATH=' . $this->repo . '/test-bin:' . $original_path );
+			$result = vipgoci_gitrepo_diffs_fetch_metadata( $this->repo, $base, $head );
+		} finally {
+			putenv( false === $original_path ? 'PATH' : 'PATH=' . $original_path );
+		}
+
+		$this->assertNull( $result );
+		$this->assertFalse( vipgoci_cache( array( 'vipgoci_gitrepo_diffs_fetch_unfiltered', $this->repo, $base, $head ) ) );
+		$this->assertFalse( vipgoci_cache( array( 'vipgoci_gitrepo_diffs_fetch_metadata', 'textconv', $this->repo ) ) );
+
+		// The same comparison can recover once the config probe succeeds.
+		$result = vipgoci_gitrepo_diffs_fetch_metadata( $this->repo, $base, $head );
+		$this->assertSame( array( 'file.php' ), array_keys( $result['files'] ) );
+		$this->assertSame( 1, $result['files']['file.php']['changes'] );
+		$this->assertFalse( vipgoci_cache( array( 'vipgoci_gitrepo_diffs_fetch_unfiltered', $this->repo, $base, $head ) ) );
+	}
+
 	/** Numstat ignores textconv; configured drivers must keep legacy scanning. */
 	public function testMetadataPreservesTextconvChangesUsingLocalFallback(): void {
 		$this->git( 'config diff.fixture.textconv cat' );

--- a/tests/unit/GitDiffMemoryTest.php
+++ b/tests/unit/GitDiffMemoryTest.php
@@ -1,0 +1,378 @@
+<?php
+/**
+ * Local Git regressions for diff memory usage and file-discovery semantics.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Use real temporary Git repositories, without network access or customer code.
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
+final class GitDiffMemoryTest extends TestCase {
+	/**
+	 * Temporary repository owned by this test.
+	 *
+	 * @var string
+	 */
+	private string $repo;
+
+	/** Load production code and initialize an isolated local fixture. */
+	protected function setUp(): void {
+		foreach ( array( 'defines', 'cache', 'log', 'misc', 'statistics', 'git-repo', 'github-api', 'github-misc' ) as $module ) {
+			require_once __DIR__ . '/../../' . $module . '.php';
+		}
+		$GLOBALS['vipgoci_debug_level'] = -1;
+		$this->repo                     = tempnam( sys_get_temp_dir(), 'vipgoci-diff-test-' );
+		unlink( $this->repo );
+		mkdir( $this->repo );
+		$this->git( 'init -q' );
+		$this->git( 'config core.fileMode true' );
+		$this->git( 'config diff.renames true' );
+	}
+
+	/** Remove only the repository created by this test. */
+	protected function tearDown(): void {
+		$entries = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $this->repo, \FilesystemIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $entries as $entry ) {
+			if ( $entry->isDir() && ! $entry->isLink() ) {
+				rmdir( $entry->getPathname() );
+			} else {
+				unlink( $entry->getPathname() );
+			}
+		}
+		rmdir( $this->repo );
+	}
+
+	/**
+	 * Run a fixture command without user hooks or commit signing.
+	 *
+	 * @param string $arguments Git arguments, constructed only by these tests.
+	 * @return string Command output.
+	 */
+	private function git( string $arguments ): string {
+		$output = array();
+		exec(
+			'git -c user.name=Fixture -c user.email=fixture@example.invalid -c commit.gpgsign=false -c core.hooksPath=/dev/null -C ' .
+				escapeshellarg( $this->repo ) . ' ' . $arguments . ' 2>&1',
+			$output,
+			$code
+		);
+		$this->assertSame( 0, $code, implode( "\n", $output ) );
+		return implode( "\n", $output );
+	}
+
+	/**
+	 * Write synthetic contents into the fixture repository.
+	 *
+	 * @param string $path     Relative path.
+	 * @param string $contents File contents.
+	 */
+	private function write( string $path, string $contents ): void {
+		$path = $this->repo . '/' . $path;
+		if ( ! is_dir( dirname( $path ) ) ) {
+			mkdir( dirname( $path ), 0700, true );
+		}
+		file_put_contents( $path, $contents );
+	}
+
+	/** Commit the fixture and return its object ID. */
+	private function commit(): string {
+		$this->git( 'add -A' );
+		$this->git( 'commit -qm fixture --allow-empty' );
+		return $this->git( 'rev-parse HEAD' );
+	}
+
+	/** File discovery must not retain patches or change rename/mode rules. */
+	public function testMetadataPreservesFilteringAndDoesNotPopulatePatchCache(): void {
+		$this->write( 'removed.php', "removed\n" );
+		$this->write( 'mode.php', "mode\n" );
+		$this->write( 'rename.php', "rename only\n" );
+		$this->write( 'edited.php', str_repeat( "original content\n", 20 ) );
+		$base = $this->commit();
+		unlink( $this->repo . '/removed.php' );
+		chmod( $this->repo . '/mode.php', 0755 );
+		rename( $this->repo . '/rename.php', $this->repo . '/renamed.php' );
+		rename( $this->repo . '/edited.php', $this->repo . '/renamed-edited.php' );
+		$this->write( 'renamed-edited.php', str_repeat( "original content\n", 20 ) . "added\n" );
+		$this->write( 'added.php', "new\n" );
+		$this->write( 'ignored/file.php', "ignore folder\n" );
+		$this->write( 'ignored.txt', "ignore extension\n" );
+		$head   = $this->commit();
+		$filter = array(
+			'file_extensions' => array( 'php' ),
+			'skip_folders'    => array( 'ignored' ),
+		);
+		$result = vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $base, $head, false, false, false, $filter, false );
+		$this->assertSame(
+			array(
+				'added.php'          => null,
+				'renamed-edited.php' => null,
+			),
+			$result['files']
+		);
+		$this->assertSame(
+			array(
+				'added.php'          => 'added',
+				'renamed-edited.php' => 'modified',
+			),
+			$result['files_status']
+		);
+		$this->assertSame(
+			array(
+				'additions' => 2,
+				'deletions' => 0,
+				'changes'   => 2,
+			),
+			$result['statistics']
+		);
+		$this->assertFalse( vipgoci_cache( array( 'vipgoci_gitrepo_diffs_fetch_unfiltered', $this->repo, $base, $head ) ) );
+		$included = vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $base, $head, true, true, true, $filter, false );
+		$this->assertSame( array( 'added.php', 'mode.php', 'removed.php', 'renamed-edited.php', 'renamed.php' ), array_keys( $included['files'] ) );
+		$patches = vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $base, $head, false, false, false, $filter );
+		$this->assertSame( "@@ -0,0 +1 @@\n+new", $patches['files']['added.php'] );
+		$this->assertSame( $result['files_status'], $patches['files_status'] );
+	}
+
+	/** A large dependency file must not exhaust PHP just to obtain its name. */
+	public function testLargeDiffDiscoveryWithin64MiB(): void {
+		$this->largeDiffProbe( 'discovery' );
+	}
+
+	/** Patch consumers must not allocate a whole-diff array of lines. */
+	public function testLargeDiffParsingWithin64MiB(): void {
+		$this->largeDiffProbe( 'patches' );
+	}
+
+	/** NUL-delimited metadata must preserve whitespace and special path bytes. */
+	public function testMetadataPreservesUnusualPathsAndCacheIsolation(): void {
+		$base  = $this->commit();
+		$paths = array( 'a/space name.php', 'quote".php', "tab\tname.php", "new\nline.php", 'unicode-é.php' );
+		foreach ( $paths as $path ) {
+			$this->write( $path, "content\n" );
+		}
+		$head   = $this->commit();
+		$result = vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $base, $head, false, false, false, null, false );
+		$this->assertEqualsCanonicalizing( $paths, array_keys( $result['files'] ) );
+		$this->assertSame( array_fill_keys( array_keys( $result['files'] ), null ), $result['files'] );
+		$empty = vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $head, $head, false, false, false, null, false );
+		$this->assertSame( array(), $empty['files'] );
+		$this->assertSame( $result, vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $base, $head, false, false, false, null, false ) );
+	}
+
+	/** Keep the existing treatment of binary, empty and mode-only changes. */
+	public function testMetadataPreservesZeroLineChangeAndRenamedModeRules(): void {
+		$this->write( 'deleted.bin', "binary\0data" );
+		$this->write( 'modified.bin', "binary\0data" );
+		$this->write( 'deleted-empty.php', '' );
+		$this->write( 'rename-mode.php', "rename and chmod\n" );
+		$base = $this->commit();
+		unlink( $this->repo . '/deleted.bin' );
+		unlink( $this->repo . '/deleted-empty.php' );
+		$this->write( 'added.bin', "new\0binary" );
+		$this->write( 'modified.bin', "changed\0binary" );
+		$this->write( 'added-empty.php', '' );
+		rename( $this->repo . '/rename-mode.php', $this->repo . '/renamed-mode.php' );
+		chmod( $this->repo . '/renamed-mode.php', 0755 );
+		$head = $this->commit();
+		foreach ( array( false, true ) as $include_patches ) {
+			$result = vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $base, $head, true, true, false, null, $include_patches );
+			// Git recognizes the identical empty files as a pure rename.
+			$this->assertSame( array( 'added-empty.php' => $include_patches ? '' : null ), $result['files'] );
+			$result = vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $base, $head, true, true, true, null, $include_patches );
+			$this->assertEquals(
+				array(
+					'added.bin'        => 'modified',
+					'added-empty.php'  => 'renamed',
+					'deleted.bin'      => 'modified',
+					'modified.bin'     => 'modified',
+					'renamed-mode.php' => 'modified',
+				),
+				$result['files_status']
+			);
+		}
+	}
+
+	/** Missing local commits must keep the established GitHub fallback. */
+	public function testMetadataFailureFallsBackWithoutReturningPatches(): void {
+		$base    = $this->commit();
+		$missing = str_repeat( '1', 40 );
+		vipgoci_cache(
+			array( 'vipgoci_github_diffs_fetch_unfiltered', 'fixture', 'fixture', $base, $missing ),
+			array(
+				'files' => array(
+					array(
+						'filename'  => 'fallback.php',
+						'status'    => 'added',
+						'patch'     => "@@ -0,0 +1 @@\n+new",
+						'additions' => 1,
+						'deletions' => 0,
+						'changes'   => 1,
+					),
+				),
+			)
+		);
+		$result = vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $base, $missing, false, false, false, null, false );
+		$this->assertSame( array( 'fallback.php' => null ), $result['files'] );
+		$this->assertSame( VIPGOCI_GIT_DIFF_DATA_SOURCE_GITHUB_API, $result['data_source'] );
+		$patches = vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $base, $missing );
+		$this->assertSame( "@@ -0,0 +1 @@\n+new", $patches['files']['fallback.php'] );
+	}
+
+	/** Distinct PR bases and previously skipped files must keep their mappings. */
+	public function testDiscoveryKeepsPrMappingsAndSkips(): void {
+		$base = $this->commit();
+		$this->write( 'first.php', "first\n" );
+		$second_base = $this->commit();
+		$this->write( 'second.php', "second\n" );
+		$head = $this->commit();
+		vipgoci_cache(
+			array( 'vipgoci_github_prs_implicated', 'fixture', 'fixture', $head, 'unused', array() ),
+			array(
+				(object) array(
+					'number' => 1,
+					'base'   => (object) array( 'sha' => $base ),
+				),
+				(object) array(
+					'number' => 2,
+					'base'   => (object) array( 'sha' => $second_base ),
+				),
+			)
+		);
+		$options = array(
+			'local-git-repo'  => $this->repo,
+			'repo-owner'      => 'fixture',
+			'repo-name'       => 'fixture',
+			'token'           => 'unused',
+			'commit'          => $head,
+			'branches-ignore' => array(),
+			'skip-draft-prs'  => false,
+		);
+		$skipped = array( 1 => array( 'issues' => array( VIPGOCI_VALIDATION_MAXIMUM_LINES => array( 'second.php' ) ) ) );
+		$this->assertSame(
+			array(
+				'all' => array( 'first.php', 'second.php' ),
+				1     => array( 'first.php' ),
+				2     => array( 'second.php' ),
+			),
+			vipgoci_github_files_affected_by_commit( $options, $head, $skipped )
+		);
+		$skipped[2] = $skipped[1];
+		$this->assertSame(
+			array(
+				'all' => array( 'first.php' ),
+				1     => array( 'first.php' ),
+				2     => array(),
+			),
+			vipgoci_github_files_affected_by_commit( $options, $head, $skipped )
+		);
+	}
+
+	/** Warnings from successful commands must not force a GitHub fallback. */
+	public function testMetadataKeepsSuccessfulDiffsWithMergeBaseWarningsLocal(): void {
+		$this->write( 'file.php', "base\n" );
+		$a  = $this->commit();
+		$ta = $this->git( 'rev-parse HEAD^{tree}' );
+		$this->write( 'file.php', "changed\n" );
+		$this->git( 'add -A' );
+		$tb = $this->git( 'write-tree' );
+		$b  = $this->git( "commit-tree $ta -p $a -m B" );
+		$c  = $this->git( "commit-tree $tb -p $a -m C" );
+		$d  = $this->git( "commit-tree $ta -p $b -p $c -m D" );
+		$this->write( 'file.php', "final\n" );
+		$this->git( 'add -A' );
+		$te     = $this->git( 'write-tree' );
+		$e      = $this->git( "commit-tree $te -p $c -p $b -m E" );
+		$result = vipgoci_gitrepo_diffs_fetch_metadata( $this->repo, $d, $e );
+		$this->assertNotNull( $result );
+		$this->assertSame( array( 'file.php' ), array_keys( $result['files'] ) );
+		$this->assertSame( 2, $result['files']['file.php']['changes'] );
+		$filtered = vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $d, $e, false, false, false, null, false );
+		$this->assertSame( VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO, $filtered['data_source'] );
+	}
+
+	/** Numstat ignores textconv; configured drivers must keep legacy scanning. */
+	public function testMetadataPreservesTextconvChangesUsingLocalFallback(): void {
+		$this->git( 'config diff.fixture.textconv cat' );
+		$this->write( '.gitattributes', "*.php diff=fixture\n" );
+		$this->write( 'file.php', "old\0binary\n" );
+		$base = $this->commit();
+		$this->write( 'file.php', "new\0binary\n" );
+		$head   = $this->commit();
+		$result = vipgoci_git_diffs_fetch( $this->repo, 'fixture', 'fixture', 'unused', $base, $head, false, false, false, null, false );
+		$this->assertSame( array( 'file.php' => null ), $result['files'] );
+		$this->assertSame(
+			array(
+				'additions' => 1,
+				'deletions' => 1,
+				'changes'   => 2,
+			),
+			$result['statistics']
+		);
+		$this->assertSame( VIPGOCI_GIT_DIFF_DATA_SOURCE_GIT_REPO, $result['data_source'] );
+	}
+
+	/** Streaming must preserve exact hunk contents, counts and missing newlines. */
+	public function testStreamingPreservesPatchBytes(): void {
+		$this->write( 'file.php', "one\r\ntwo\nthree" );
+		$base = $this->commit();
+		$this->write( 'file.php', "one\r\nnew two\nthree\n" );
+		$head   = $this->commit();
+		$result = vipgoci_gitrepo_diffs_fetch_unfiltered( $this->repo, $base, $head );
+		$this->assertSame( "@@ -1,3 +1,3 @@\n one\r\n-two\n-three\n\\ No newline at end of file\n+new two\n+three", $result['files']['file.php']['patch'] );
+		$this->assertSame(
+			array(
+				'additions' => 2,
+				'deletions' => 2,
+				'changes'   => 4,
+			),
+			$result['statistics']
+		);
+		$this->assertSame( $result, vipgoci_gitrepo_diffs_fetch_unfiltered( $this->repo, $base, $head ) );
+		$this->assertNull( vipgoci_gitrepo_diffs_fetch_unfiltered( $this->repo, $base, str_repeat( '1', 40 ) ) );
+	}
+
+	/**
+	 * Assert a million-line diff succeeds in a memory-limited process.
+	 *
+	 * @param string $mode Whether to discover files or collect patches.
+	 */
+	private function largeDiffProbe( string $mode ): void {
+		$base = $this->commit();
+		$this->write( 'vendor/dependency.php', '' );
+		$stream = fopen( $this->repo . '/vendor/dependency.php', 'wb' );
+		$chunk  = str_repeat( "// dependency line\n", 1000 );
+		for ( $i = 0; $i < 1000; $i++ ) {
+			fwrite( $stream, $chunk );
+		}
+		fclose( $stream );
+		$head   = $this->commit();
+		$output = array();
+		exec(
+			escapeshellarg( PHP_BINARY ) . ' -d memory_limit=64M ' .
+				escapeshellarg( __DIR__ . '/helper/GitDiffMemoryProbe.php' ) . ' ' .
+				escapeshellarg( $this->repo ) . ' ' . escapeshellarg( $base ) . ' ' . escapeshellarg( $head ) . ' ' . escapeshellarg( $mode ) . ' 2>&1',
+			$output,
+			$code
+		);
+		$this->assertSame( 0, $code, implode( "\n", $output ) );
+		$result = json_decode( implode( "\n", $output ), true, 512, JSON_THROW_ON_ERROR );
+		$this->assertSame( array( 'vendor/dependency.php' ), $result['files'] );
+		$this->assertLessThan( 64 * 1024 * 1024, $result['peak'] );
+		if ( 'patches' === $mode ) {
+			$this->assertSame( 1000000, $result['changes'] );
+		}
+	}
+}

--- a/tests/unit/helper/GitDiffMemoryProbe.php
+++ b/tests/unit/helper/GitDiffMemoryProbe.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Exercise diff discovery in a memory-limited subprocess using a local fixture.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+foreach ( array( 'defines', 'cache', 'log', 'misc', 'statistics', 'git-repo', 'github-api', 'github-misc' ) as $module ) {
+	require_once __DIR__ . '/../../../' . $module . '.php';
+}
+
+$GLOBALS['vipgoci_debug_level'] = -1;
+
+$options = array(
+	'local-git-repo'  => $argv[1],
+	'repo-owner'      => 'fixture',
+	'repo-name'       => 'fixture',
+	'token'           => 'unused',
+	'commit'          => $argv[3],
+	'branches-ignore' => array(),
+	'skip-draft-prs'  => false,
+);
+
+// The GitHub boundary is preloaded; all Git discovery and parsing remain real.
+vipgoci_cache(
+	array( 'vipgoci_github_prs_implicated', 'fixture', 'fixture', $argv[3], 'unused', array() ),
+	array(
+		(object) array(
+			'number' => 1,
+			'base'   => (object) array( 'sha' => $argv[2] ),
+		),
+	)
+);
+
+if ( 'discovery' === $argv[4] ) {
+	$skipped = array();
+	$result  = vipgoci_github_files_affected_by_commit(
+		$options,
+		$argv[3],
+		$skipped,
+		false,
+		false,
+		false,
+		array(
+			'file_extensions' => array( 'php' ),
+			'skip_folders'    => array(),
+		)
+	);
+	$files   = $result['all'];
+	$changes = null;
+} else {
+	$result  = vipgoci_gitrepo_diffs_fetch_unfiltered( $argv[1], $argv[2], $argv[3] );
+	$files   = array_keys( $result['files'] );
+	$changes = $result['statistics']['changes'];
+}
+
+echo json_encode(
+	array(
+		'files'   => $files,
+		'changes' => $changes,
+		'peak'    => memory_get_peak_usage( true ),
+	)
+);


### PR DESCRIPTION
## Summary

File discovery currently builds and caches complete patches only to take their filenames. Large comparisons can exhaust the bot's memory at the whole-diff `explode()` before any files are scanned.

This change:

- Uses NUL-delimited Git raw/numstat metadata for filename-only discovery, preserving three-dot comparisons, filtering, rename/content-change distinctions, PR mappings, and skipped-file handling.
- Reads full patches line by line from a temporary file instead of retaining both raw output and an array of every diff line. Standard error is kept separate so successful Git warnings cannot corrupt metadata or trigger unnecessary GitHub fallback.
- Keeps the existing GitHub fallback for local failures. Repositories with textconv drivers use the local streaming parser because numstat does not reflect converted content.
- Adds local, synthetic regression tests, including memory-limited subprocesses that failed at the original `explode()` and now pass under 64 MiB.

No PHPCS batching, scanner-policy changes, new runtime requirements, or memory-limit increases.

## Measurements

Local PHP 8.2 benchmark: 1,000 synthetic files, one million added lines; three runs per case, median elapsed time. These are not production-build measurements.

| Operation | Peak PHP memory before | Peak PHP memory after | Time before | Time after |
| --- | ---: | ---: | ---: | ---: |
| Filename discovery | 103.25 MiB | 2 MiB | 0.540 s | 0.094 s |
| Full-patch parsing | 103.25 MiB | 22 MiB | 0.546 s | 0.596 s |

Discovery is approximately six times faster in this fixture. Full-patch parsing trades roughly 10% more time for much lower peak memory. This does not impose a hard memory bound: full-patch consumers still retain returned patches and caches, and textconv compatibility uses that path.

## Verification

- PHP 8.2 full unit suite: 264 tests, 710 assertions passed. Existing PHPUnit deprecation notices remain.
- PHP 8.5 focused regressions: 10 tests, 135 assertions passed.
- Six existing historical Git diff fixtures checked for exact patch bytes, statuses, and counts; metadata matches their expected results without patches.
- Regression coverage includes pure/edited renames, mode-only changes, binary/empty files, unusual paths, cache isolation, per-PR skips, missing-commit fallback, multiple-merge-base warnings, textconv, and missing final newlines.
- Independent review completed; both compatibility findings were reproduced, fixed, and re-reviewed.
- Full network-backed integration and E2E suites were not run locally; CI remains pending.

## TODO

- [x] Implement the memory fix and update function documentation.
- [x] Add regression coverage and verify locally.
- [x] Confirm no requirements or scan-run-detail changes are needed.
- [ ] Check automated CI results.
- [ ] Changelog entry during release preparation.
