### PR TITLE
Batch PHPCS scans and reduce routine logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,15 @@ Then run  `vip-go-ci.php`:
 
 -- where `repo-owner` is the GitHub repository-owner, `repo-name` is the name of the repository, `commit-ID` is the SHA-hash identifying the commit, `Local-Git-Repo` is a path to the git-repository used to scan, `GitHub-Access-Token` is a access-token created on GitHub that allows reading and commenting on the repository in question, `path-to-phpcs` is a full path to PHPCS, `File-Types` refers to a list of file-types to be approved (such as `css,txt,pdf`), and `Informational-Msg` is a message that explains the CI process.
 
-While running, `vip-go-ci` will output log of its actions. Here is an example -- note that output generated on your system can differ substantially:
+While running, `vip-go-ci` will output a log of its actions. The `--debug-level` option controls verbosity:
+
+* `0` (default): normal progress, failures, skipped-file notices, and a PHPCS scan summary.
+* `1`: additionally includes routine PHPCS per-file details, the scan file list, local file-fetch messages, and line-count validation details.
+* `2`: additionally includes PHPCS commands, successful raw PHPCS reports, and command-execution diagnostics. Failed scans remain visible at level `0`.
+
+The PHPCS completion summary counts files considered, successfully scanned, failed, and skipped; it includes SVG files when SVG checking is enabled. A successful scan can contain findings. Its `duration_seconds` measures the file-scanning loop, excluding subsequent Git attribution and report preparation. Changing verbosity does not change scan findings or GitHub reporting.
+
+Here is an example from an older version -- output generated on your system can differ substantially:
 
 ```
 [ 2018-04-16T14:10:04+00:00 -- 0 ]  Initializing...; []
@@ -354,6 +362,10 @@ For example:
 ### PHPCS configuration
 
 Support for checking for issues in PHP files by using [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer/) scanning is supported. The behaviour of PHPCS scanning can be configured using several options.
+
+Eligible files are scanned in groups of up to 25 per PHPCS process, sequentially within each process. Each process retains the existing 500 MB PHP memory limit and 300-second PHP execution-time setting. Large-file validation still happens before scanning, and SVG checks continue to use their separate scanner.
+
+If a batch fails or returns incomplete or inconsistent results, its partial findings are discarded and its files are retried individually. Findings and GitHub reporting remain per-file. Files containing inline `phpcs:set` or legacy `@codingStandardsChangeSetting` directives run individually so settings cannot leak into neighbouring files. Whole-file ignore directives in the first two lines also run individually; an omitted file is accepted only when PHPCS returns a valid empty report.
 
 An example of how PHPCS can be used:
 
@@ -717,4 +729,3 @@ Documentation on what steps to follow when releasing a new version of `vip-go-ci
 ## Updating tools-init.sh with new versions
 
 For information on how to update `tools-init.sh`, see the [TOOLS-UPDATE.md](TOOLS-UPDATE.md) file.
-

--- a/defines.php
+++ b/defines.php
@@ -235,6 +235,7 @@ define( 'VIPGOCI_LINT_ERROR_STR', 'PHP Syntax Errors Found' );
  * Defines relating to PHPCS scanning.
  */
 define( 'VIPGOCI_PHPCS_FILE_EXTENSIONS_DEFAULT', array( 'php', 'js', 'twig' ) );
+define( 'VIPGOCI_PHPCS_BATCH_SIZE', 25 );
 
 define(
 	'VIPGOCI_PHPCS_SCAN_REVIEW_START',

--- a/file-validation.php
+++ b/file-validation.php
@@ -83,7 +83,8 @@ function vipgoci_is_number_of_lines_valid(
 		array(
 			'file_name'     => $file_name,
 			'cached_result' => ( false === $is_number_of_lines_valid ) ? null : $is_number_of_lines_valid,
-		)
+		),
+		1
 	);
 
 	if ( false !== $is_number_of_lines_valid ) {
@@ -159,9 +160,9 @@ function vipgoci_is_number_of_lines_valid(
 		array(
 			'file_name' => $file_name,
 			'output'    => $output,
-		)
+		),
+		1
 	);
 
 	return $is_number_of_lines_valid;
 }
-

--- a/git-repo.php
+++ b/git-repo.php
@@ -452,7 +452,8 @@ function vipgoci_gitrepo_fetch_committed_file(
 			'filename'       => $file_name,
 			'local_git_repo' => $local_git_repo,
 			'reject_symlink' => $reject_symlink,
-		)
+		),
+		1
 	);
 
 	/*

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -97,10 +97,10 @@ function vipgoci_phpcs_get_version(
 }
 
 /**
- * Run PHPCS for the file specified, using the
+ * Run PHPCS for the files specified, using the
  * appropriate standards. Return the results.
  *
- * @param string       $filename_tmp         Path to file to scan.
+ * @param string|array $filename_tmp         Path or paths to files to scan.
  * @param string       $phpcs_path           Path to PHPCS scanner.
  * @param string       $phpcs_php_path       Path to PHP to use to execute PHPCS scanner.
  * @param string|array $phpcs_standard       PHPCS standard to use.
@@ -111,7 +111,7 @@ function vipgoci_phpcs_get_version(
  * @return string|null Results of PHPCS scanning as string on success, null on failure.
  */
 function vipgoci_phpcs_do_scan(
-	string $filename_tmp,
+	string|array $filename_tmp,
 	string $phpcs_path,
 	string $phpcs_php_path,
 	array|string $phpcs_standard,
@@ -119,10 +119,13 @@ function vipgoci_phpcs_do_scan(
 	int $phpcs_severity,
 	array $phpcs_runtime_set
 ) :string|null {
+	if ( array() === $filename_tmp ) {
+		return null;
+	}
 	/*
 	 * Run PHPCS from the shell, making sure we escape everything.
 	 *
-	 * Feed PHPCS the temporary file specified by our caller.
+	 * Feed PHPCS the temporary files specified by our caller.
 	 */
 	$cmd = sprintf(
 		'%s -d memory_limit=500M -d max_execution_time=300 %s --severity=%s --report=%s -q',
@@ -193,17 +196,22 @@ function vipgoci_phpcs_do_scan(
 	 * Lastly, append the target filename
 	 * to the command-line string.
 	 */
-	$cmd .= sprintf(
-		' %s',
-		escapeshellarg( $filename_tmp )
-	);
+	if ( is_array( $filename_tmp ) ) {
+		// Batch execution must stay sequential within the existing memory limit.
+		$cmd .= ' --parallel=1';
+	} else {
+		$filename_tmp = array( $filename_tmp );
+	}
+	foreach ( $filename_tmp as $filename ) {
+		$cmd .= ' ' . escapeshellarg( $filename );
+	}
 
 	vipgoci_log(
 		'Running PHPCS now',
 		array(
 			'cmd' => $cmd,
 		),
-		0
+		2
 	);
 
 	/*
@@ -297,16 +305,43 @@ function vipgoci_phpcs_write_xml_standard_file(
 }
 
 /**
- * Scan a single file using the PHPCS scanner,
- * return JSON decoded results. Avoid scanning
- * a file if it is too large to scan.
+ * Track staged PHPCS files so exit-based failures also clean them up.
+ *
+ * @param string $filename Owned temporary path.
+ * @param bool   $remove   Delete and stop tracking this path.
+ * @return void
+ */
+function vipgoci_phpcs_temp_file( string $filename, bool $remove = false ): void {
+	static $files = null;
+	if ( null === $files ) {
+		$files = array();
+		register_shutdown_function(
+			static function () use ( &$files ) {
+				foreach ( array_keys( $files ) as $path ) {
+					if ( file_exists( $path ) ) {
+						unlink( $path );
+					}
+				}
+			}
+		);
+	}
+	if ( $remove ) {
+		unlink( $filename );
+		unset( $files[ $filename ] );
+	} else {
+		$files[ $filename ] = true;
+	}
+}
+
+/**
+ * Stage a file for PHPCS and apply the existing large-file validation.
  *
  * @param array  $options   Options needed.
  * @param string $file_name File path to scan.
  *
- * @return array Results of scanning and validation.
+ * @return array Temporary path and validation, or the completed skipped-file result.
  */
-function vipgoci_phpcs_scan_single_file(
+function vipgoci_phpcs_prepare_file(
 	array $options,
 	string $file_name
 ) {
@@ -342,6 +377,7 @@ function vipgoci_phpcs_scan_single_file(
 		$file_extension,
 		$file_contents
 	);
+	vipgoci_phpcs_temp_file( $temp_file_name );
 
 	/*
 	 * Skips the phpcs scan when the validation contains any issue
@@ -362,11 +398,22 @@ function vipgoci_phpcs_scan_single_file(
 				'validation'             => $validation,
 			);
 
-			unlink( $temp_file_name );
+			vipgoci_phpcs_temp_file( $temp_file_name, true );
 
 			return $skipped;
 		}
 	}
+
+	// Inspect the first two lines without copying/splitting the remaining source.
+	$first_line_end  = strpos( $file_contents, "\n" );
+	$second_line_end = false === $first_line_end ? false : strpos( $file_contents, "\n", $first_line_end + 1 );
+	$first_lines     = false === $second_line_end ? $file_contents : substr( $file_contents, 0, $second_line_end + 1 );
+	// PHPCS may omit files bearing these directives in their first two lines.
+	$may_be_ignored = false !== stripos( $first_lines, 'phpcs:ignorefile' ) ||
+		false !== strpos( $first_lines, '@codingStandardsIgnoreFile' );
+	// Settings mutate shared sniff instances. A conservative match only costs a process.
+	$requires_isolation = $may_be_ignored || false !== stripos( $file_contents, 'phpcs:set' ) ||
+		false !== stripos( $file_contents, '@codingStandardsChangeSetting' );
 
 	vipgoci_log(
 		'About to PHPCS-scan file',
@@ -377,14 +424,111 @@ function vipgoci_phpcs_scan_single_file(
 			'filename'       => $file_name,
 			'file_extension' => $file_extension,
 			'temp_file_name' => $temp_file_name,
-		)
+		),
+		1
 	);
 
-	$retry_cnt = 0;
+	return array(
+		'temp_file_name'     => $temp_file_name,
+		'validation'         => $validation ?? array(),
+		'requires_isolation' => $requires_isolation,
+		'may_be_ignored'     => $may_be_ignored,
+	);
+}
 
-	/*
-	 * Try to PHPCS scan.
-	 */
+/**
+ * Validate a complete PHPCS report and split it into independent per-file reports.
+ *
+ * Missing files, malformed messages and inconsistent counts must never look clean.
+ *
+ * @param string|null $output    Raw scanner output.
+ * @param array       $filenames Requested temporary paths.
+ * @return array|null Per-file reports keyed by temporary path, or null on failure.
+ */
+function vipgoci_phpcs_parse_report( ?string $output, array $filenames ): ?array {
+	$report = null === $output ? null : json_decode( $output, true );
+	if ( ! is_array( $report ) || ! isset( $report['files'], $report['totals'] ) ||
+		! is_array( $report['files'] ) || ! is_array( $report['totals'] ) ||
+		count( $report['files'] ) !== count( $filenames ) ) {
+		return null;
+	}
+	$reports = array();
+	$totals  = array(
+		'errors'   => 0,
+		'warnings' => 0,
+		'fixable'  => 0,
+	);
+	foreach ( $filenames as $filename ) {
+		$file = $report['files'][ $filename ] ?? $report['files'][ ltrim( $filename, '/' ) ] ?? null;
+		if ( ! is_array( $file ) || ! isset( $file['errors'], $file['warnings'], $file['messages'] ) ||
+			! is_int( $file['errors'] ) || ! is_int( $file['warnings'] ) ||
+			! is_array( $file['messages'] ) || ! array_is_list( $file['messages'] ) ) {
+			return null;
+		}
+		$file_totals = array(
+			'errors'   => 0,
+			'warnings' => 0,
+			'fixable'  => 0,
+		);
+		foreach ( $file['messages'] as $message ) {
+			if ( ! is_array( $message ) ||
+				! isset( $message['message'], $message['source'], $message['type'], $message['line'], $message['column'], $message['severity'], $message['fixable'] ) ||
+				! is_string( $message['message'] ) || ! is_string( $message['source'] ) ||
+				! in_array( $message['type'], array( 'ERROR', 'WARNING' ), true ) ||
+				! is_int( $message['line'] ) || ! is_int( $message['column'] ) || ! is_int( $message['severity'] ) || ! is_bool( $message['fixable'] ) ) {
+				return null;
+			}
+			++$file_totals[ 'ERROR' === $message['type'] ? 'errors' : 'warnings' ];
+			$file_totals['fixable'] += (int) $message['fixable'];
+		}
+		if ( $file['errors'] !== $file_totals['errors'] || $file['warnings'] !== $file_totals['warnings'] ) {
+			return null;
+		}
+		foreach ( $totals as $key => $value ) {
+			$totals[ $key ] += $file_totals[ $key ];
+		}
+		$reports[ $filename ] = array(
+			'totals' => $file_totals,
+			'files'  => array( $filename => $file ),
+		);
+	}
+	foreach ( $totals as $key => $value ) {
+		if ( ( $report['totals'][ $key ] ?? null ) !== $value ) {
+			return null;
+		}
+	}
+	return $reports;
+}
+
+/**
+ * Scan one file, also used to isolate failures after a rejected batch.
+ *
+ * @param array  $options   Scanner options.
+ * @param string $file_name Repository-relative file path.
+ * @return array Results of scanning and validation.
+ */
+function vipgoci_phpcs_scan_single_file( array $options, string $file_name ): array {
+	$prepared = vipgoci_phpcs_prepare_file( $options, $file_name );
+	if ( array_key_exists( 'file_issues_arr_master', $prepared ) ) {
+		return $prepared;
+	}
+	try {
+		return vipgoci_phpcs_scan_prepared_file( $options, $file_name, $prepared );
+	} finally {
+		vipgoci_phpcs_temp_file( $prepared['temp_file_name'], true );
+	}
+}
+
+/**
+ * Run one staged file in an isolated process; the caller owns cleanup.
+ *
+ * @param array  $options   Scanner options.
+ * @param string $file_name Repository-relative path.
+ * @param array  $prepared Staged file metadata.
+ * @return array Per-file scanning result.
+ */
+function vipgoci_phpcs_scan_prepared_file( array $options, string $file_name, array $prepared ): array {
+	$temp_file_name  = $prepared['temp_file_name'];
 	$file_issues_str = vipgoci_phpcs_do_scan(
 		$temp_file_name,
 		$options['phpcs-path'],
@@ -401,13 +545,26 @@ function vipgoci_phpcs_scan_single_file(
 			$file_issues_str,
 			"\n"
 		);
-
-		$file_issues_arr_master = json_decode(
-			$file_issues_str,
-			true
+	}
+	$reports                = vipgoci_phpcs_parse_report( $file_issues_str, array( $temp_file_name ) );
+	$file_issues_arr_master = $reports[ $temp_file_name ] ?? null;
+	if ( null === $file_issues_arr_master && $prepared['may_be_ignored'] &&
+		array() === vipgoci_phpcs_parse_report( $file_issues_str, array() ) ) {
+		// Accept an intentional omission only after PHPCS returned a valid zero-file report.
+		$file_issues_arr_master = array(
+			'totals' => array(
+				'errors'   => 0,
+				'warnings' => 0,
+				'fixable'  => 0,
+			),
+			'files'  => array(
+				$temp_file_name => array(
+					'errors'   => 0,
+					'warnings' => 0,
+					'messages' => array(),
+				),
+			),
 		);
-	} else {
-		$file_issues_arr_master = null;
 	}
 
 	/*
@@ -422,18 +579,125 @@ function vipgoci_phpcs_scan_single_file(
 			'file_issues_str' => $file_issues_str,
 			'issues_stats'    => isset( $file_issues_arr_master['totals'] ) ?
 				$file_issues_arr_master['totals'] : null,
-		)
+		),
+		( null !== $file_issues_arr_master ) ? 2 : 0
 	);
-
-	/* Get rid of temporary file */
-	unlink( $temp_file_name );
 
 	return array(
 		'file_issues_arr_master' => $file_issues_arr_master,
 		'file_issues_str'        => $file_issues_str,
 		'temp_file_name'         => $temp_file_name,
-		'validation'             => $validation ?? array(),
+		'validation'             => $prepared['validation'],
 	);
+}
+
+/**
+ * Scan a bounded group, retrying each eligible file if a batch is unusable.
+ *
+ * Only one group's staged files and reports are retained at a time.
+ *
+ * @param array $options    Scanner options.
+ * @param array $file_names Repository-relative paths, at most the batch size.
+ * @return array Per-file results keyed by repository-relative path.
+ */
+function vipgoci_phpcs_scan_batch( array $options, array $file_names ): array {
+	if ( 1 === count( $file_names ) ) {
+		return array( $file_names[0] => vipgoci_phpcs_scan_single_file( $options, $file_names[0] ) );
+	}
+	$prepared = array();
+	$results  = array();
+	$batch    = array();
+	try {
+		foreach ( $file_names as $file_name ) {
+			$file = vipgoci_phpcs_prepare_file( $options, $file_name );
+			if ( array_key_exists( 'file_issues_arr_master', $file ) ) {
+				$results[ $file_name ] = $file;
+			} else {
+				$prepared[ $file_name ] = $file;
+				if ( $file['requires_isolation'] ) {
+					$results[ $file_name ] = vipgoci_phpcs_scan_prepared_file( $options, $file_name, $file );
+				} else {
+					$batch[ $file_name ] = $file;
+				}
+			}
+		}
+		if ( empty( $batch ) ) {
+			return $results;
+		}
+		if ( 1 === count( $batch ) ) {
+			$file_name             = array_key_first( $batch );
+			$results[ $file_name ] = vipgoci_phpcs_scan_prepared_file( $options, $file_name, $batch[ $file_name ] );
+			return $results;
+		}
+		$filenames = array_column( $batch, 'temp_file_name' );
+		$output    = vipgoci_phpcs_do_scan(
+			$filenames,
+			$options['phpcs-path'],
+			$options['phpcs-php-path'],
+			$options['phpcs-standard'],
+			$options['phpcs-sniffs-exclude'],
+			$options['phpcs-severity'],
+			$options['phpcs-runtime-set']
+		);
+		$reports   = vipgoci_phpcs_parse_report( $output, $filenames );
+		if ( null !== $reports ) {
+			foreach ( $batch as $file_name => $file ) {
+				$report                = $reports[ $file['temp_file_name'] ];
+				$results[ $file_name ] = array(
+					'file_issues_arr_master' => $report,
+					'file_issues_str'        => json_encode( $report ),
+					'temp_file_name'         => $file['temp_file_name'],
+					'validation'             => $file['validation'],
+				);
+			}
+			vipgoci_log(
+				'PHPCS returned results',
+				array(
+					'filenames'       => array_keys( $batch ),
+					'file_issues_str' => $output,
+				),
+				2
+			);
+			return $results;
+		}
+		vipgoci_log(
+			'Retrying PHPCS batch files individually',
+			array( 'filenames' => array_keys( $batch ) )
+		);
+		// Discard all partial results; individual retries are the only source of findings.
+		foreach ( $batch as $file_name => $file ) {
+			$results[ $file_name ] = vipgoci_phpcs_scan_prepared_file( $options, $file_name, $file );
+		}
+		return $results;
+	} finally {
+		foreach ( $prepared as $file ) {
+			vipgoci_phpcs_temp_file( $file['temp_file_name'], true );
+		}
+	}
+}
+
+/**
+ * Yield results in input order while batching PHPCS and keeping SVG scans separate.
+ *
+ * @param array $options    Scanner options.
+ * @param array $file_names Repository-relative paths to scan.
+ * @return Generator Per-file results.
+ */
+function vipgoci_phpcs_scan_files( array $options, array $file_names ): Generator {
+	foreach ( array_chunk( $file_names, VIPGOCI_PHPCS_BATCH_SIZE ) as $chunk ) {
+		$phpcs_files = array();
+		foreach ( $chunk as $file_name ) {
+			if ( ! $options['svg-checks'] || ! in_array( vipgoci_file_extension_get( $file_name ), $options['svg-file-extensions'], true ) ) {
+				$phpcs_files[] = $file_name;
+			}
+		}
+		$results = vipgoci_phpcs_scan_batch( $options, $phpcs_files );
+		foreach ( $chunk as $file_name ) {
+			yield $file_name => in_array( $file_name, $phpcs_files, true ) ?
+				$results[ $file_name ] : vipgoci_svg_scan_single_file( $options, $file_name );
+			unset( $results[ $file_name ] );
+		}
+	}
 }
 
 /**
@@ -530,6 +794,12 @@ function vipgoci_phpcs_scan_commit(
 	);
 
 	$files_issues_arr = array();
+	$scan_summary     = array(
+		'files_considered' => count( $pr_item_files_changed['all'] ),
+		'files_scanned'    => 0,
+		'files_failed'     => 0,
+		'files_skipped'    => 0,
+	);
 
 	/*
 	 * Loop through each altered file in all the pull requests,
@@ -545,7 +815,8 @@ function vipgoci_phpcs_scan_commit(
 			'repo_name'                => $repo_name,
 			'commit_id'                => $commit_id,
 			'all_files_changed_by_prs' => $pr_item_files_changed['all'],
-		)
+		),
+		1
 	);
 
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_START, 'phpcs_scan_single_file' );
@@ -564,6 +835,7 @@ function vipgoci_phpcs_scan_commit(
 		break;
 	}
 
+	$files_to_scan = array();
 	foreach ( $pr_item_files_changed['all'] as $file_name ) {
 		if (
 			isset( $commit_skipped_files[ $pr_item->number ]['issues'][ VIPGOCI_VALIDATION_MAXIMUM_LINES ] )
@@ -574,44 +846,12 @@ function vipgoci_phpcs_scan_commit(
 			)
 		) {
 			$files_issues_arr[ $file_name ] = array();
+			++$scan_summary['files_skipped'];
 			continue;
 		}
-
-		/*
-		 * Loop through each file affected by
-		 * the commit.
-		 */
-
-		$file_extension = vipgoci_file_extension_get(
-			$file_name
-		);
-
-		/*
-		 * If a SVG file, scan using a
-		 * custom internal function, otherwise
-		 * use PHPCS.
-		 *
-		 * However, only do this if SVG-checks
-		 * is enabled.
-		 */
-		$scanning_func =
-			(
-				( true === in_array(
-					$file_extension,
-					$options['svg-file-extensions'],
-					true
-				) )
-				&&
-				( $options['svg-checks'] )
-			) ?
-				'vipgoci_svg_scan_single_file' :
-				'vipgoci_phpcs_scan_single_file';
-
-		$tmp_scanning_results = $scanning_func(
-			$options,
-			$file_name
-		);
-
+		$files_to_scan[] = $file_name;
+	}
+	foreach ( vipgoci_phpcs_scan_files( $options, $files_to_scan ) as $file_name => $tmp_scanning_results ) {
 		if (
 			( true === $options['skip-large-files'] ) &&
 			( 0 !== $tmp_scanning_results['validation']['total'] )
@@ -641,6 +881,7 @@ function vipgoci_phpcs_scan_commit(
 			);
 
 			$files_issues_arr[ $file_name ] = array();
+			++$scan_summary['files_skipped'];
 
 			continue;
 		}
@@ -702,6 +943,7 @@ function vipgoci_phpcs_scan_commit(
 				$files_failed_phpcs_scanning,
 				$file_name,
 			);
+			++$scan_summary['files_failed'];
 
 			continue;
 		}
@@ -740,9 +982,12 @@ function vipgoci_phpcs_scan_commit(
 			vipgoci_log(
 				'Unable to read results of PHPCS scanning, missing index',
 				array(
-					'temp_file_name' => $temp_file_name,
+					'filename'        => $file_name,
+					'temp_file_name'  => $temp_file_name,
+					'file_issues_str' => $tmp_scanning_results['file_issues_str'],
 				)
 			);
+			++$scan_summary['files_failed'];
 
 			continue;
 		}
@@ -775,6 +1020,7 @@ function vipgoci_phpcs_scan_commit(
 		);
 
 		$files_issues_arr[ $file_name ] = $file_issues_arr_master;
+		++$scan_summary['files_scanned'];
 
 		/*
 		 * Get rid of data, and
@@ -782,11 +1028,10 @@ function vipgoci_phpcs_scan_commit(
 		 */
 		vipgoci_log(
 			'Cleaning up after scanning of file...',
-			array()
+			array(),
+			1
 		);
 
-		unset( $file_contents );
-		unset( $file_extension );
 		unset( $temp_file_name );
 		unset( $file_issues_arr_master );
 		unset( $file_issues_str );
@@ -794,7 +1039,7 @@ function vipgoci_phpcs_scan_commit(
 		gc_collect_cycles();
 	}
 
-	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'phpcs_scan_single_file' );
+	$scan_summary['duration_seconds'] = vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'phpcs_scan_single_file' );
 
 	/*
 	 * Send generic message to each pull request
@@ -841,7 +1086,8 @@ function vipgoci_phpcs_scan_commit(
 				'commit_id'     => $commit_id,
 				'pr_number'     => $pr_item->number,
 				'files_changed' => $pr_item_files_changed[ $pr_item->number ],
-			)
+			),
+			1
 		);
 
 		/*
@@ -1028,7 +1274,7 @@ function vipgoci_phpcs_scan_commit(
 
 	vipgoci_log(
 		'PHPCS-scanning complete',
-		array()
+		$scan_summary
 	);
 
 	vipgoci_runtime_measure( VIPGOCI_RUNTIME_STOP, 'phpcs_scan_commit' );

--- a/phpcs-scan.php
+++ b/phpcs-scan.php
@@ -326,7 +326,9 @@ function vipgoci_phpcs_temp_file( string $filename, bool $remove = false ): void
 		);
 	}
 	if ( $remove ) {
-		unlink( $filename );
+		if ( file_exists( $filename ) ) {
+			unlink( $filename );
+		}
 		unset( $files[ $filename ] );
 	} else {
 		$files[ $filename ] = true;

--- a/tests/integration/PhpcsScanBatchIsolationTest.php
+++ b/tests/integration/PhpcsScanBatchIsolationTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Compare batch and singleton findings using real PHPCS on synthetic source.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+namespace Vipgoci\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
+final class PhpcsScanBatchIsolationTest extends TestCase {
+	/** @var string|null Owned synthetic repository and ruleset directory. */
+	private ?string $directory = null;
+
+	/** @var array Scanner options. */
+	private array $options;
+
+	/** Use the integration suite's configured scanner; never access GitHub. */
+	protected function setUp(): void {
+		require_once __DIR__ . '/IncludesForTests.php';
+		$path = vipgoci_unittests_get_config_value( 'phpcs-scan', 'phpcs-path' );
+		$php  = vipgoci_unittests_get_config_value( 'phpcs-scan', 'phpcs-php-path' );
+		if ( empty( $path ) || empty( $php ) || ! is_file( $path ) || ! is_file( $php ) ) {
+			$this->markTestSkipped( 'Configure phpcs-path and phpcs-php-path in tests/config.ini.' );
+		}
+		$GLOBALS['vipgoci_debug_level'] = -1;
+		$this->directory                = tempnam( sys_get_temp_dir(), 'vipgoci-batch-parity-' );
+		unlink( $this->directory );
+		mkdir( $this->directory );
+		$this->git( 'init -q' );
+		$standard = $this->directory . '/standard.xml';
+		vipgoci_phpcs_write_xml_standard_file( $standard, array(), array( 'Generic.Files.LineLength' ) );
+		$this->options = array(
+			'repo-owner'           => 'fixture',
+			'repo-name'            => 'fixture',
+			'token'                => 'unused',
+			'local-git-repo'       => $this->directory,
+			'phpcs-path'           => $path,
+			'phpcs-php-path'       => $php,
+			'phpcs-standard'       => array( $standard ),
+			'phpcs-sniffs-exclude' => array(),
+			'phpcs-severity'       => 1,
+			'phpcs-runtime-set'    => array(),
+			'skip-large-files'     => false,
+			'svg-checks'           => false,
+			'svg-file-extensions'  => array( 'svg' ),
+		);
+	}
+
+	/** Remove only files inside this test's temporary directory. */
+	protected function tearDown(): void {
+		if ( null === $this->directory ) {
+			return;
+		}
+		$entries = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $this->directory, \FilesystemIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $entries as $entry ) {
+			if ( $entry->isDir() && ! $entry->isLink() ) {
+				rmdir( $entry->getPathname() );
+			} else {
+				unlink( $entry->getPathname() );
+			}
+		}
+		rmdir( $this->directory );
+	}
+
+	/**
+	 * @param string $arguments Trusted fixture setup arguments.
+	 * @return string Git output.
+	 */
+	private function git( string $arguments ): string {
+		exec(
+			'git -c user.name=Fixture -c user.email=fixture@example.invalid -c commit.gpgsign=false -c core.hooksPath=/dev/null -C ' .
+				escapeshellarg( $this->directory ) . ' ' . $arguments . ' 2>&1',
+			$output,
+			$code
+		);
+		$this->assertSame( 0, $code, implode( "\n", $output ) );
+		return implode( "\n", $output );
+	}
+
+	/** @return array Modern/legacy settings, ignores and per-file suppression. */
+	public static function annotations(): array {
+		$long_line = '// ' . str_repeat( 'long ', 33 ) . "\n";
+		return array(
+			'settings'           => array( "// phpcs:set Generic.Files.LineLength lineLimit 1000\n// phpcs:set Generic.Files.LineLength absoluteLineLimit 1000\n" . $long_line, 1 ),
+			'legacy settings'    => array( "// @codingStandardsChangeSetting Generic.Files.LineLength lineLimit 1000\n// @codingStandardsChangeSetting Generic.Files.LineLength absoluteLineLimit 1000\n" . $long_line, 1 ),
+			'ignore first line'  => array( "<?php // phpcs:ignoreFile\n" . $long_line, 0 ),
+			'ignore second line' => array( "// PHPCS:IGNOREFILE\n" . $long_line, 0 ),
+			'legacy ignore'      => array( "// @codingStandardsIgnoreFile\n" . $long_line, 0 ),
+			'disable'            => array( "// phpcs:disable Generic.Files.LineLength\n" . $long_line, 0 ),
+			'ignore line'        => array( "// phpcs:ignore Generic.Files.LineLength\n" . $long_line, 0 ),
+		);
+	}
+
+	/**
+	 * Every ordinary neighbour must retain its error regardless of prior annotations.
+	 *
+	 * @param string $annotated Annotated source, with or without an opening tag.
+	 * @param int    $errors    Expected errors in the annotated file itself.
+	 */
+	#[DataProvider( 'annotations' )]
+	public function testBatchFindingsMatchSingletons( string $annotated, int $errors ): void {
+		file_put_contents( $this->directory . '/a.php', str_starts_with( $annotated, '<?php' ) ? $annotated : "<?php\n" . $annotated );
+		file_put_contents( $this->directory . '/b.php', "<?php\n// " . str_repeat( 'long ', 33 ) . "\n" );
+		file_put_contents( $this->directory . '/c.php', "<?php\n// clean\n" );
+		$this->git( 'add -A' );
+		$this->git( 'commit -qm fixture' );
+		$this->options['commit'] = $this->git( 'rev-parse HEAD' );
+		$expected                = array();
+		foreach ( array( 'a.php', 'b.php', 'c.php' ) as $name ) {
+			$result = vipgoci_phpcs_scan_single_file( $this->options, $name );
+			$this->assertNotNull( $result['file_issues_arr_master'] );
+			$expected[ $name ] = $result['file_issues_arr_master']['files'][ $result['temp_file_name'] ];
+			$this->assertFileDoesNotExist( $result['temp_file_name'] );
+		}
+		// LineLength scans the file at its opening tag, before setting directives apply.
+		$this->assertSame( $errors, $expected['a.php']['errors'] );
+		$this->assertSame( 1, $expected['b.php']['errors'] );
+		$actual = array();
+		foreach ( vipgoci_phpcs_scan_files( $this->options, array_keys( $expected ) ) as $name => $result ) {
+			$this->assertNotNull( $result['file_issues_arr_master'] );
+			$actual[ $name ] = $result['file_issues_arr_master']['files'][ $result['temp_file_name'] ];
+			$this->assertFileDoesNotExist( $result['temp_file_name'] );
+		}
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/tests/integration/PhpcsScanBatchIsolationTest.php
+++ b/tests/integration/PhpcsScanBatchIsolationTest.php
@@ -98,6 +98,7 @@ final class PhpcsScanBatchIsolationTest extends TestCase {
 			'ignore first line'  => array( "<?php // phpcs:ignoreFile\n" . $long_line, 0 ),
 			'ignore second line' => array( "// PHPCS:IGNOREFILE\n" . $long_line, 0 ),
 			'legacy ignore'      => array( "// @codingStandardsIgnoreFile\n" . $long_line, 0 ),
+			'legacy wrong case'  => array( "// @CODINGSTANDARDSIGNOREFILE\n" . $long_line, 1 ),
 			'disable'            => array( "// phpcs:disable Generic.Files.LineLength\n" . $long_line, 0 ),
 			'ignore line'        => array( "// phpcs:ignore Generic.Files.LineLength\n" . $long_line, 0 ),
 		);

--- a/tests/unit/PhpcsScanGitGuardsTest.php
+++ b/tests/unit/PhpcsScanGitGuardsTest.php
@@ -435,23 +435,64 @@ final class PhpcsScanGitGuardsTest extends TestCase {
 		$this->base              = $this->commit( array() );
 		$this->head              = $this->commit(
 			array(
-				'ignored.php' => "<?php\n// phpcs:ignoreFile\n// fixture-empty-report\n",
-				'legacy.php'  => "<?php\n// @codingStandardsIgnoreFile\n// fixture-empty-report\n",
-				'missing.php' => "<?php\n// fixture-empty-report\n",
-				'broken.php'  => "<?php\n// phpcs:ignoreFile\n// fixture-invalid-json\n",
+				'ignored.php'    => "<?php\n// phpcs:ignoreFile\n// fixture-empty-report\n",
+				'legacy.php'     => "<?php\n// @codingStandardsIgnoreFile\n// fixture-empty-report\n",
+				'missing.php'    => "<?php\n// fixture-empty-report\n",
+				'broken.php'     => "<?php\n// phpcs:ignoreFile\n// fixture-invalid-json\n",
+				'wrong-case.php' => "<?php\n// @CODINGSTANDARDSIGNOREFILE\n// fixture-empty-report\n",
 			)
 		);
 		list( $result, $output ) = $this->scanWithLogs( 0 );
 		$this->assertSame( array( 42 => array() ), $result['issues'] );
 		$this->assertStringContainsString( '"files_scanned": 2', $output );
-		$this->assertStringContainsString( '"files_failed": 2', $output );
+		$this->assertStringContainsString( '"files_failed": 3', $output );
 		$posts = array_values( array_filter( $GLOBALS['vipgoci_test_http_requests'], static fn( $request ) => str_starts_with( $request['request'], 'POST ' ) ) );
 		$this->assertCount( 1, $posts );
 		$this->assertStringContainsString( '* missing.php', $posts[0]['body']['body'] );
 		$this->assertStringContainsString( '* broken.php', $posts[0]['body']['body'] );
+		$this->assertStringContainsString( '* wrong-case.php', $posts[0]['body']['body'] );
 		$this->assertStringNotContainsString( '* ignored.php', $posts[0]['body']['body'] );
 		$this->assertStringNotContainsString( '* legacy.php', $posts[0]['body']['body'] );
 		$this->phpcsInvocations();
+	}
+
+	/** @return array Ways a tracked temporary file can already have been removed. */
+	public static function missingTempFiles(): array {
+		return array(
+			'external removal' => array( true ),
+			'repeated cleanup' => array( false ),
+		);
+	}
+
+	/**
+	 * Cleanup must silently forget files that are no longer present.
+	 *
+	 * @param bool $removed_externally Whether another operation removed the file.
+	 */
+	#[DataProvider( 'missingTempFiles' )]
+	public function testTempFileCleanupToleratesMissingFiles( bool $removed_externally ): void {
+		$path = $this->directory . '/staged.php';
+		file_put_contents( $path, "<?php\n// synthetic source\n" );
+		vipgoci_phpcs_temp_file( $path );
+		if ( $removed_externally ) {
+			unlink( $path );
+		} else {
+			vipgoci_phpcs_temp_file( $path, true );
+		}
+		$this->assertFileDoesNotExist( $path );
+		$warnings = array();
+		set_error_handler(
+			static function ( $severity, $message ) use ( &$warnings ) {
+				$warnings[] = $message;
+				return true;
+			}
+		);
+		try {
+			vipgoci_phpcs_temp_file( $path, true );
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertSame( array(), $warnings );
 	}
 
 	/** exit() bypasses finally; a later staging failure must still remove earlier files. */

--- a/tests/unit/PhpcsScanGitGuardsTest.php
+++ b/tests/unit/PhpcsScanGitGuardsTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Vipgoci\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
@@ -41,6 +42,13 @@ final class PhpcsScanGitGuardsTest extends TestCase {
 	private string|false $original_path;
 
 	/**
+	 * Restore any caller-provided fixture log destination after the test.
+	 *
+	 * @var string|false
+	 */
+	private string|false $original_phpcs_log;
+
+	/**
 	 * Base commit used for the pull request fixture.
 	 *
 	 * @var string
@@ -56,7 +64,7 @@ final class PhpcsScanGitGuardsTest extends TestCase {
 
 	/** Load production code and create a local repository without user hooks. */
 	protected function setUp(): void {
-		foreach ( array( 'defines', 'cache', 'log', 'misc', 'statistics', 'git-repo', 'github-api', 'github-misc', 'phpcs-scan', 'results', 'reports', 'skip-file', 'file-validation', 'output-security', 'other-web-services' ) as $module ) {
+		foreach ( array( 'defines', 'cache', 'log', 'misc', 'statistics', 'git-repo', 'github-api', 'github-misc', 'phpcs-scan', 'svg-scan', 'results', 'reports', 'skip-file', 'file-validation', 'output-security', 'other-web-services' ) as $module ) {
 			require_once __DIR__ . '/../../' . $module . '.php';
 		}
 		require_once __DIR__ . '/helper/GitHubRequestGuards.php';
@@ -64,9 +72,11 @@ final class PhpcsScanGitGuardsTest extends TestCase {
 		$GLOBALS['vipgoci_test_http_requests']  = array();
 		$GLOBALS['vipgoci_test_http_responses'] = array();
 		$this->original_path                    = getenv( 'PATH' );
+		$this->original_phpcs_log               = getenv( 'VIPGOCI_TEST_PHPCS_INVOCATIONS' );
 		$this->directory                        = tempnam( sys_get_temp_dir(), 'vipgoci-phpcs-git-' );
 		unlink( $this->directory );
 		mkdir( $this->directory );
+		putenv( 'VIPGOCI_TEST_PHPCS_INVOCATIONS=' . $this->directory . '/phpcs.jsonl' );
 		$this->repo = $this->directory . '/repo';
 		mkdir( $this->repo );
 		$this->git( 'init -q' );
@@ -78,6 +88,7 @@ final class PhpcsScanGitGuardsTest extends TestCase {
 	/** Restore the environment and remove only this test's fixture. */
 	protected function tearDown(): void {
 		putenv( false === $this->original_path ? 'PATH' : 'PATH=' . $this->original_path );
+		putenv( false === $this->original_phpcs_log ? 'VIPGOCI_TEST_PHPCS_INVOCATIONS' : 'VIPGOCI_TEST_PHPCS_INVOCATIONS=' . $this->original_phpcs_log );
 		$entries = new \RecursiveIteratorIterator(
 			new \RecursiveDirectoryIterator( $this->directory, \FilesystemIterator::SKIP_DOTS ),
 			\RecursiveIteratorIterator::CHILD_FIRST
@@ -216,6 +227,387 @@ final class PhpcsScanGitGuardsTest extends TestCase {
 				static fn( $line ) => str_contains( $line, $fragment )
 			)
 		);
+	}
+
+	/**
+	 * Inspect real scanner invocations and ensure all their staged files were removed.
+	 *
+	 * @return array Recorded invocation arguments.
+	 */
+	private function phpcsInvocations(): array {
+		$calls = array_map(
+			static fn( $line ) => json_decode( $line, true, 512, JSON_THROW_ON_ERROR ),
+			file( $this->directory . '/phpcs.jsonl', FILE_IGNORE_NEW_LINES )
+		);
+		foreach ( $calls as $call ) {
+			foreach ( $call['files'] as $filename ) {
+				$this->assertFileDoesNotExist( $filename );
+			}
+		}
+		return $calls;
+	}
+
+	/** @return array Inline annotations requiring process isolation. */
+	public static function inlineSettings(): array {
+		return array(
+			array( 'phpcs:set Generic.Files.LineLength lineLimit 1000' ),
+			array( '@PHPCS:SET Generic.Files.LineLength lineLimit 1000' ),
+			array( '@codingStandardsChangeSetting Generic.Files.LineLength lineLimit 1000' ),
+			array( 'phpcs:ignoreFile' ),
+			array( '@codingStandardsIgnoreFile' ),
+		);
+	}
+
+	/** Inline settings and potentially omitted files must not affect batch neighbours. */
+	#[DataProvider( 'inlineSettings' )]
+	public function testInlineSettingsUseIsolatedProcesses( string $directive ): void {
+		$this->base = $this->commit( array() );
+		$this->head = $this->commit(
+			array(
+				'a.php' => "<?php\n// $directive\n// fixture-error\n",
+				'b.php' => "<?php\n// fixture-error\n",
+				'c.php' => "<?php\n// fixture-error\n",
+			)
+		);
+		$result     = $this->scan();
+		$calls      = $this->phpcsInvocations();
+		$this->assertSame( array( 1, 2 ), array_map( static fn( $call ) => count( $call['files'] ), $calls ) );
+		$this->assertSame( array( 'a.php', 'b.php', 'c.php' ), array_column( $result['issues'][42], 'file_name' ) );
+	}
+
+	/** The production commit scanner must group files, not just expose an unused batch helper. */
+	public function testCommitScanUsesBoundedBatches(): void {
+		$this->base = $this->commit( array() );
+		$files      = array();
+		for ( $index = 0; $index < 51; $index++ ) {
+			$files[ sprintf( 'file-%02d.php', $index ) ] = "<?php\n// clean\n";
+		}
+		$this->head = $this->commit( $files );
+		$result     = $this->scan();
+		$calls      = $this->phpcsInvocations();
+		$this->assertSame( array( 25, 25, 1 ), array_map( static fn( $call ) => count( $call['files'] ), $calls ) );
+		$this->assertContains( '--parallel=1', $calls[0]['argv'] );
+		$this->assertSame( array( 42 => array() ), $result['issues'] );
+		$this->assertSame( 51, vipgoci_counter_report( VIPGOCI_COUNTERS_DUMP )['github_pr_files_phpcs_scanned'] );
+	}
+
+	/**
+	 * Faults that must invalidate an entire batch before individual recovery.
+	 *
+	 * @return array Scanner failure markers.
+	 */
+	public static function batchFailures(): array {
+		return array(
+			'fatal exit'      => array( 'fixture-batch-fatal' ),
+			'missing file'    => array( 'fixture-batch-missing' ),
+			'invalid entry'   => array( 'fixture-batch-invalid-entry' ),
+			'wrong totals'    => array( 'fixture-batch-count-mismatch' ),
+			'unexpected file' => array( 'fixture-batch-unknown-file' ),
+		);
+	}
+
+	/**
+	 * Failed/partial batches must retry every file and preserve each finding once.
+	 *
+	 * @param string $marker Fixture fault to inject only for multi-file execution.
+	 */
+	#[DataProvider( 'batchFailures' )]
+	public function testBatchFailureRetriesFilesIndividually( string $marker ): void {
+		$this->base = $this->commit( array() );
+		$this->head = $this->commit(
+			array(
+				'a.php' => "<?php\n// $marker\n// fixture-error\n",
+				'b.php' => "<?php\n// fixture-error\n",
+			)
+		);
+
+		list( $result, $output ) = $this->scanWithLogs( 0 );
+		$calls                   = $this->phpcsInvocations();
+		$this->assertSame( array( 2, 1, 1 ), array_map( static fn( $call ) => count( $call['files'] ), $calls ) );
+		$this->assertSame( array( 'a.php', 'b.php' ), array_column( $result['issues'][42], 'file_name' ) );
+		$this->assertSame( 2, $result['stats'][42]['error'] );
+		$this->assertStringContainsString( 'Retrying PHPCS batch files individually', $output );
+		$this->assertStringContainsString( '"files_failed": 0', $output );
+		$this->assertSame( 2, vipgoci_counter_report( VIPGOCI_COUNTERS_DUMP )['github_pr_files_phpcs_scanned'] );
+	}
+
+	/** A persistent failure must not discard its healthy batch neighbour's finding. */
+	public function testBatchRecoveryReportsOnlyPersistentlyFailedFiles(): void {
+		$this->base = $this->commit( array() );
+		$this->head = $this->commit(
+			array(
+				'a.php' => "<?php\n// fixture-invalid-json\n",
+				'b.php' => "<?php\n// fixture-error\n",
+			)
+		);
+		$result     = $this->scan();
+		$calls      = $this->phpcsInvocations();
+		$this->assertSame( array( 2, 1, 1 ), array_map( static fn( $call ) => count( $call['files'] ), $calls ) );
+		$this->assertSame( array( 'b.php' ), array_column( $result['issues'][42], 'file_name' ) );
+		$posts = array_values( array_filter( $GLOBALS['vipgoci_test_http_requests'], static fn( $request ) => str_starts_with( $request['request'], 'POST ' ) ) );
+		$this->assertCount( 1, $posts );
+		$this->assertStringContainsString( '* a.php', $posts[0]['body']['body'] );
+		$this->assertStringNotContainsString( '* b.php', $posts[0]['body']['body'] );
+	}
+
+	/** Validation must exclude large files before invoking PHPCS. */
+	public function testBatchesExcludeLargeFiles(): void {
+		$this->base = $this->commit( array() );
+		$this->head = $this->commit(
+			array(
+				'a.php' => "<?php\n// clean\n",
+				'b.php' => "<?php\n// clean\n",
+				'c.php' => "<?php\n// long\n// long\n// long\n",
+			)
+		);
+		$result     = $this->scan( array( 42 ), array(
+'skip-large-files'       => true,
+'skip-large-files-limit' => 4
+) );
+		$calls      = $this->phpcsInvocations();
+		$this->assertSame( array( 2 ), array_map( static fn( $call ) => count( $call['files'] ), $calls ) );
+		$this->assertSame( array( 'c.php' ), $result['skipped'][42]['issues'][ VIPGOCI_VALIDATION_MAXIMUM_LINES ] );
+		$this->assertSame( 2, vipgoci_counter_report( VIPGOCI_COUNTERS_DUMP )['github_pr_files_phpcs_scanned'] );
+	}
+
+	/** SVG files retain their separate scanner and internal forbidden-tag checks. */
+	public function testBatchingKeepsSvgScanningSeparate(): void {
+		$this->base = $this->commit( array() );
+		$this->head = $this->commit(
+			array(
+				'a.php'    => "<?php\n// fixture-error\n",
+				'icon.svg' => "<svg>\n<?php\n</svg>\n",
+				'z.php'    => "<?php\n// fixture-error\n",
+			)
+		);
+		$result     = $this->scan(
+			array( 42 ),
+			array(
+				'svg-checks'       => true,
+				'svg-scanner-path' => __DIR__ . '/helper/PhpcsScanFixture.php',
+				'svg-php-path'     => PHP_BINARY,
+			)
+		);
+		$calls      = $this->phpcsInvocations();
+		$this->assertSame( array( 2, 1 ), array_map( static fn( $call ) => count( $call['files'] ), $calls ) );
+		$this->assertStringEndsWith( '.php', $calls[0]['files'][0] );
+		$this->assertStringEndsWith( '.php', $calls[0]['files'][1] );
+		$this->assertStringEndsWith( '.svg', $calls[1]['files'][0] );
+		$this->assertSame( array( 'a.php', 'icon.svg', 'z.php' ), array_column( $result['issues'][42], 'file_name' ) );
+		$this->assertSame( 'VipgociInternal.SVG.DisallowedTags', $result['issues'][42][1]['issue']['source'] );
+	}
+
+	/** Both absolute and slash-trimmed PHPCS report keys must map back to the right file. */
+	public function testBatchAcceptsSlashTrimmedReportPaths(): void {
+		$this->base = $this->commit( array() );
+		$this->head = $this->commit(
+			array(
+				'a.php' => "<?php\n// fixture-leading-slash\n// fixture-error\n",
+				'b.php' => "<?php\n// fixture-error\n",
+			)
+		);
+		$result     = $this->scan();
+		$this->assertCount( 1, $this->phpcsInvocations() );
+		$this->assertSame( array( 'a.php', 'b.php' ), array_column( $result['issues'][42], 'file_name' ) );
+	}
+
+	/** Every batch path is a separate escaped shell argument. */
+	public function testBatchCommandQuotesEachPath(): void {
+		$paths = array( $this->directory . "/one ' quoted.php", $this->directory . '/two spaced.php' );
+		foreach ( $paths as $path ) {
+			file_put_contents( $path, "<?php\n// fixture-error\n" );
+		}
+		$output = vipgoci_phpcs_do_scan( $paths, __DIR__ . '/helper/PhpcsScanFixture.php', PHP_BINARY, array(), array(), 1, array() );
+		$report = json_decode( $output, true, 512, JSON_THROW_ON_ERROR );
+		$this->assertSame( $paths, array_keys( $report['files'] ) );
+		$this->assertSame( 2, $report['totals']['errors'] );
+	}
+
+	/** An empty filename array must not accidentally scan the working directory. */
+	public function testEmptyBatchCommandDoesNotRunPhpcs(): void {
+		$output = vipgoci_phpcs_do_scan( array(), __DIR__ . '/helper/PhpcsScanFixture.php', PHP_BINARY, array(), array(), 1, array() );
+		$this->assertNull( $output );
+		$this->assertFileDoesNotExist( $this->directory . '/phpcs.jsonl' );
+	}
+
+	/** An omitted file is only clean when both its directive and zero report agree. */
+	public function testIntentionalOmissionDoesNotMaskMissingReports(): void {
+		$this->base              = $this->commit( array() );
+		$this->head              = $this->commit(
+			array(
+				'ignored.php' => "<?php\n// phpcs:ignoreFile\n// fixture-empty-report\n",
+				'legacy.php'  => "<?php\n// @codingStandardsIgnoreFile\n// fixture-empty-report\n",
+				'missing.php' => "<?php\n// fixture-empty-report\n",
+				'broken.php'  => "<?php\n// phpcs:ignoreFile\n// fixture-invalid-json\n",
+			)
+		);
+		list( $result, $output ) = $this->scanWithLogs( 0 );
+		$this->assertSame( array( 42 => array() ), $result['issues'] );
+		$this->assertStringContainsString( '"files_scanned": 2', $output );
+		$this->assertStringContainsString( '"files_failed": 2', $output );
+		$posts = array_values( array_filter( $GLOBALS['vipgoci_test_http_requests'], static fn( $request ) => str_starts_with( $request['request'], 'POST ' ) ) );
+		$this->assertCount( 1, $posts );
+		$this->assertStringContainsString( '* missing.php', $posts[0]['body']['body'] );
+		$this->assertStringContainsString( '* broken.php', $posts[0]['body']['body'] );
+		$this->assertStringNotContainsString( '* ignored.php', $posts[0]['body']['body'] );
+		$this->assertStringNotContainsString( '* legacy.php', $posts[0]['body']['body'] );
+		$this->phpcsInvocations();
+	}
+
+	/** exit() bypasses finally; a later staging failure must still remove earlier files. */
+	public function testStagingFailureCleansEarlierFilesAtShutdown(): void {
+		$this->head = $this->commit( array( 'a.php' => "<?php\n// staged source\n" ) );
+		$staging    = $this->directory . '/staging';
+		mkdir( $staging );
+		exec(
+			escapeshellarg( PHP_BINARY ) . ' -d ' . escapeshellarg( 'sys_temp_dir=' . $staging ) . ' ' .
+			escapeshellarg( __DIR__ . '/helper/PhpcsBatchStagingFailure.php' ) . ' ' .
+			escapeshellarg( $this->repo ) . ' ' . escapeshellarg( $this->head ) . ' 2>&1',
+			$output,
+			$code
+		);
+		$this->assertSame( VIPGOCI_EXIT_SYSTEM_PROBLEM, $code, implode( "\n", $output ) );
+		$this->assertStringContainsString( 'About to PHPCS-scan file', implode( "\n", $output ) );
+		$this->assertStringContainsString( 'Unable to fetch file from repository', implode( "\n", $output ) );
+		$this->assertSame( array( '.', '..' ), scandir( $staging ) );
+	}
+
+	/**
+	 * Capture the real logger without changing scanner or report behavior.
+	 *
+	 * @param int   $level     Console verbosity.
+	 * @param array $overrides Scanner option overrides.
+	 * @return array Scanner results and captured output.
+	 */
+	private function scanWithLogs( int $level, array $overrides = array() ): array {
+		$GLOBALS['vipgoci_debug_level'] = $level;
+		ob_start();
+		try {
+			$result = $this->scan( array( 42 ), $overrides );
+			return array( $result, ob_get_contents() );
+		} finally {
+			ob_end_clean();
+			$GLOBALS['vipgoci_debug_level'] = -1;
+		}
+	}
+
+	/**
+	 * Supported verbosity levels must retain diagnostics only when requested.
+	 *
+	 * @return array Levels with expected per-file and raw output visibility.
+	 */
+	public static function verbosityLevels(): array {
+		return array(
+			'default' => array( 0, false, false ),
+			'verbose' => array( 1, true, false ),
+			'debug'   => array( 2, true, true ),
+		);
+	}
+
+	/**
+	 * Routine details must not leak at level zero or disappear at higher levels.
+	 *
+	 * @param int  $level   Console verbosity.
+	 * @param bool $details Whether per-file details should be visible.
+	 * @param bool $raw     Whether commands and raw reports should be visible.
+	 */
+	#[DataProvider( 'verbosityLevels' )]
+	public function testRoutineScanLogsRespectVerbosity( int $level, bool $details, bool $raw ): void {
+		$this->base = $this->commit( array() );
+		$this->head = $this->commit( array( 'clean.php' => "<?php\n// clean\n" ) );
+
+		list( $result, $output ) = $this->scanWithLogs( $level, array( 'skip-large-files' => true ) );
+		$this->assertSame( array( 42 => array() ), $result['issues'] );
+		foreach ( array( 'About to PHPCS-scan file', 'Fetching file-contents from local Git repository', 'Validating number of lines', 'Validated number of lines', 'Cleaning up after scanning of file...', '"all_files_changed_by_prs"', '"files_changed"' ) as $message ) {
+			$this->assertSame( $details, str_contains( $output, $message ), $message );
+		}
+		foreach ( array( 'Running PHPCS now', 'PHPCS returned results', 'file_issues_str' ) as $message ) {
+			$this->assertSame( $raw, str_contains( $output, $message ), $message );
+		}
+		$this->assertStringContainsString( 'PHPCS-scanning complete', $output );
+	}
+
+	/**
+	 * Summary counts describe outcomes, not just attempted scanner invocations.
+	 */
+	public function testDefaultLogsSummarizeSuccessfulFailedAndSkippedFiles(): void {
+		$this->base = $this->commit( array() );
+		$this->head = $this->commit(
+			array(
+				'clean.php'   => "<?php\n// clean\n",
+				'finding.php' => "<?php\n// fixture-error\n",
+				'failed.php'  => "<?php\n// fixture-invalid-json\n",
+				'large.php'   => "<?php\n// too long\n// too long\n// too long\n",
+			)
+		);
+
+		list( $result, $output ) = $this->scanWithLogs(
+			0,
+			array(
+				'skip-large-files'       => true,
+				'skip-large-files-limit' => 4,
+			)
+		);
+		$this->assertCount( 1, $result['issues'][42] );
+		$this->assertSame( 'finding.php', $result['issues'][42][0]['file_name'] );
+		$this->assertStringContainsString( 'Error when running PHPCS', $output );
+		$this->assertStringContainsString( 'Invalid scanner output', $output );
+		$this->assertStringContainsString( 'Failed parsing output from PHPCS', $output );
+		$this->assertStringContainsString( VIPGOCI_SKIPPED_FILES, $output );
+		$this->assertSame( 1, preg_match( '/"PHPCS-scanning complete"; (\{.*?\n\})/s', $output, $matches ) );
+		$summary = json_decode( $matches[1], true, 512, JSON_THROW_ON_ERROR );
+		$this->assertSame( 4, $summary['files_considered'] );
+		$this->assertSame( 2, $summary['files_scanned'] );
+		$this->assertSame( 1, $summary['files_failed'] );
+		$this->assertSame( 1, $summary['files_skipped'] );
+		$this->assertGreaterThanOrEqual( 0, $summary['duration_seconds'] );
+	}
+
+	/** No changed files must yield a zero summary without a scanner invocation. */
+	public function testEmptyScanSummary(): void {
+		$this->base = $this->commit( array() );
+		$this->head = $this->commit( array() );
+
+		list( $result, $output ) = $this->scanWithLogs( 0 );
+		$this->assertSame( array( 42 => array() ), $result['issues'] );
+		$this->assertSame( 1, preg_match( '/"PHPCS-scanning complete"; (\{.*?\n\})/s', $output, $matches ) );
+		$summary = json_decode( $matches[1], true, 512, JSON_THROW_ON_ERROR );
+		foreach ( array( 'files_considered', 'files_scanned', 'files_failed', 'files_skipped' ) as $key ) {
+			$this->assertSame( 0, $summary[ $key ] );
+		}
+		$this->assertGreaterThanOrEqual( 0, $summary['duration_seconds'] );
+		$this->assertStringNotContainsString( 'Running PHPCS now', $output );
+	}
+
+	/** A subprocess failure remains visible even when routine logs are hidden. */
+	public function testFailedCommandRemainsVisibleAtDefaultLevel(): void {
+		$this->base = $this->commit( array() );
+		$this->head = $this->commit( array( 'failed.php' => "<?php\n// clean\n" ) );
+
+		list( $result, $output ) = $this->scanWithLogs( 0, array( 'phpcs-path' => $this->directory . '/missing-scanner.php' ) );
+		$this->assertSame( array( 42 => array() ), $result['issues'] );
+		$this->assertStringContainsString( 'Error when running PHPCS', $output );
+		$this->assertStringContainsString( 'Failed parsing output from PHPCS', $output );
+		$this->assertStringContainsString( 'failed.php', $output );
+		$this->assertStringContainsString( '"files_failed": 1', $output );
+	}
+
+	/** Valid JSON for a different file is a failure and must retain its diagnostics. */
+	public function testMissingReportFileKeepsFailureDiagnostics(): void {
+		$this->base = $this->commit( array() );
+		$this->head = $this->commit( array( 'wrong-path.php' => "<?php\n// fixture-missing-file\n// fixture-error\n" ) );
+
+		list( $result, $output ) = $this->scanWithLogs( 0 );
+		$this->assertSame( array( 42 => array() ), $result['issues'] );
+		$this->assertStringContainsString( '"files_failed": 1', $output );
+		$this->assertSame( 1, preg_match( '/"Error when running PHPCS"; (\{.*?\n\})/s', $output, $matches ) );
+		$failure = json_decode( $matches[1], true, 512, JSON_THROW_ON_ERROR );
+		$this->assertArrayHasKey( 'filename', $failure );
+		$this->assertSame( 'wrong-path.php', $failure['filename'] );
+		$this->assertArrayHasKey( 'file_issues_str', $failure );
+		$report = json_decode( $failure['file_issues_str'], true, 512, JSON_THROW_ON_ERROR );
+		$this->assertArrayHasKey( '/unexpected.php', $report['files'] );
+		$this->assertSame( 'Fixture finding.', $report['files']['/unexpected.php']['messages'][0]['message'] );
 	}
 
 	/** Clean scans must not run blame or populate the full-patch cache. */

--- a/tests/unit/helper/PhpcsBatchStagingFailure.php
+++ b/tests/unit/helper/PhpcsBatchStagingFailure.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Exercise production exit-based failure after staging one file.
+ *
+ * @package Automattic/vip-go-ci
+ */
+
+declare(strict_types=1);
+
+foreach ( array( 'defines', 'cache', 'log', 'misc', 'statistics', 'git-repo', 'phpcs-scan' ) as $module ) {
+	require __DIR__ . '/../../../' . $module . '.php';
+}
+$GLOBALS['vipgoci_debug_level'] = 1;
+vipgoci_phpcs_scan_batch(
+	array(
+		'repo-owner'       => 'owner',
+		'repo-name'        => 'repo',
+		'token'            => 'unused',
+		'local-git-repo'   => $argv[1],
+		'commit'           => $argv[2],
+		'skip-large-files' => false,
+	),
+	array( 'a.php', 'missing.php' )
+);

--- a/tests/unit/helper/PhpcsScanFixture.php
+++ b/tests/unit/helper/PhpcsScanFixture.php
@@ -7,51 +7,84 @@
 
 declare(strict_types=1);
 
-$filename = end( $argv );
-$contents = file_get_contents( $filename );
+$filenames = array_values( array_filter( array_slice( $argv, 1 ), 'is_file' ) );
+$contents  = implode( "\n", array_map( 'file_get_contents', $filenames ) );
+$log_path  = getenv( 'VIPGOCI_TEST_PHPCS_INVOCATIONS' );
+if ( false !== $log_path ) {
+	file_put_contents( $log_path, json_encode( array(
+		'files' => $filenames,
+		'argv'  => $argv,
+	) ) . "\n", FILE_APPEND );
+}
+
+if ( count( $filenames ) > 1 && str_contains( $contents, 'fixture-batch-fatal' ) ) {
+	fwrite( STDERR, 'Simulated PHPCS fatal error' );
+	exit( 255 );
+}
 
 if ( str_contains( $contents, 'fixture-invalid-json' ) ) {
 	echo 'Invalid scanner output';
 	exit( 0 );
 }
 
-$messages    = array();
-$error_count = 0;
-$warnings    = 0;
-foreach ( explode( "\n", $contents ) as $index => $line ) {
-	if ( ! preg_match( '/fixture-(error|warning)/', $line, $matches ) ) {
+$report = array(
+	'totals' => array(
+		'errors'   => 0,
+		'warnings' => 0,
+		'fixable'  => 0,
+	),
+	'files'  => array(),
+);
+foreach ( $filenames as $filename ) {
+	$file_contents = file_get_contents( $filename );
+	if ( str_contains( $file_contents, 'fixture-empty-report' ) ) {
 		continue;
 	}
-	$issue_type = strtoupper( $matches[1] );
-	$messages[] = array(
-		'message'  => 'Fixture finding.',
-		'source'   => 'Fixture.Test.Finding',
-		'severity' => 5,
-		'fixable'  => false,
-		'type'     => $issue_type,
-		'line'     => $index + 1,
-		'column'   => 1,
+	$messages    = array();
+	$error_count = 0;
+	$warnings    = 0;
+	foreach ( explode( "\n", $file_contents ) as $index => $line ) {
+		if ( ! preg_match( '/fixture-(error|warning)/', $line, $matches ) ) {
+			continue;
+		}
+		$issue_type = strtoupper( $matches[1] );
+		$messages[] = array(
+			'message'  => 'Fixture finding.',
+			'source'   => 'Fixture.Test.Finding',
+			'severity' => 5,
+			'fixable'  => false,
+			'type'     => $issue_type,
+			'line'     => $index + 1,
+			'column'   => 1,
+		);
+		if ( 'ERROR' === $issue_type ) {
+			++$error_count;
+		} else {
+			++$warnings;
+		}
+	}
+	if ( str_contains( $file_contents, 'fixture-missing-file' ) ) {
+		$filename = '/unexpected.php';
+	} elseif ( str_contains( $file_contents, 'fixture-leading-slash' ) ) {
+		$filename = ltrim( $filename, '/' );
+	}
+	$report['files'][ $filename ]  = array(
+		'errors'   => $error_count,
+		'warnings' => $warnings,
+		'messages' => $messages,
 	);
-	if ( 'ERROR' === $issue_type ) {
-		++$error_count;
-	} else {
-		++$warnings;
+	$report['totals']['errors']   += $error_count;
+	$report['totals']['warnings'] += $warnings;
+}
+if ( count( $filenames ) > 1 ) {
+	if ( str_contains( $contents, 'fixture-batch-missing' ) ) {
+		array_pop( $report['files'] );
+	} elseif ( str_contains( $contents, 'fixture-batch-invalid-entry' ) ) {
+		$report['files'][ $filenames[0] ]['messages'] = null;
+	} elseif ( str_contains( $contents, 'fixture-batch-count-mismatch' ) ) {
+		++$report['totals']['errors'];
+	} elseif ( str_contains( $contents, 'fixture-batch-unknown-file' ) ) {
+		$report['files']['/unknown.php'] = $report['files'][ $filenames[0] ];
 	}
 }
-
-echo json_encode(
-	array(
-		'totals' => array(
-			'errors'   => $error_count,
-			'warnings' => $warnings,
-			'fixable'  => 0,
-		),
-		'files'  => array(
-			$filename => array(
-				'errors'   => $error_count,
-				'warnings' => $warnings,
-				'messages' => $messages,
-			),
-		),
-	)
-);
+echo json_encode( $report );


### PR DESCRIPTION
## Summary

Combine PHPCS batching and quieter routine logging in one change.

- Scan up to 25 eligible files per PHPCS process, with `--parallel=1` and the existing `memory_limit=500M` / `max_execution_time=300` settings. Large-file validation and the separate SVG scanner remain in place.
- Validate batch file membership, message schemas, and totals before using any findings. Discard unusable batches and retry their files individually using the same staged bytes. Persistent failures remain visible and reported per file.
- Isolate files with inline `phpcs:set` or legacy setting directives. PHPCS 3.13.5 shares sniff instances between files, so these directives can otherwise silently suppress a later file's findings. Handle whole-file ignore annotations only when the isolated process returns a valid empty report.
- Clean up staged source on normal completion, failed batches, and exit-based staging failures.
- Move routine per-file logging to level 1 and commands/successful raw reports to level 2. Keep errors at level 0 and add a completion summary with considered/scanned/failed/skipped counts and scan-loop duration.

## Local benchmark

Offline comparison using a fixed 93-file cohort (50 PHP, 43 JavaScript), PHP 8.2.30, PHPCS 3.13.5, WordPress-VIP-Go and PHPCompatibilityWP. Four runs per strategy in balanced order, with fresh worker processes and quiet logging for both strategies. The measured path includes source preparation, line validation, scanning, parsing, and cleanup; it excludes checkout/setup, Git attribution, and GitHub reporting.

| Strategy | PHPCS processes | Median elapsed |
| --- | ---: | ---: |
| One file per process | 93 | 8.62s |
| Batches of 25 | 4 | 3.40s |

Approximately 2.53x faster for this scan path. All 51 findings matched the fixed baseline in every run. This is not an end-to-end build-speed claim, and the benchmark does not quantify CI log-sink I/O savings. The input corpus and detailed outputs remain local.

## Verification

- Full unit suite on PHP 8.2: 295 tests, 1,287 assertions; 1,389 existing PHPUnit deprecations.
- Focused production scan tests on PHP 8.5: 30 tests, 561 assertions.
- Real-PHPCS integration regressions: seven modern/legacy setting, whole-file ignore, and per-file suppression cases; 133 assertions. Disabling setting isolation reproduces the lost-neighbour-finding regression.
- Failure coverage includes fatal exit, missing/extra files, malformed entries, inconsistent counts, persistent invalid output, and exit during staging. Also covers batch boundaries, SVG routing, large-file skips, quoted paths, empty input, counters, and per-PR finding attribution.
- PHP compatibility checks for 8.2+ and `git diff --check` pass.
- Full integration/E2E suites were not run locally; the focused integration test uses synthetic source and the configured real scanner without GitHub access.

## TODO

- [x] Implement batching and logging changes together.
- [x] Add unit and real-scanner regression coverage.
- [x] Update README and PHPDoc for the changed behavior.
- [x] Keep existing scanner limits and dependency requirements.
- [ ] Check automated CI results.
